### PR TITLE
Fix #440: Size Matters merged units can never be split

### DIFF
--- a/Sources/CvUnit.cpp
+++ b/Sources/CvUnit.cpp
@@ -27137,6 +27137,14 @@ CvUnit* CvUnit::mergeUnits(CvUnit* pUnit1, CvUnit* pUnit2, CvUnit* pUnit3, CvSel
 
 	CvUnit* pkMergedUnit = GET_PLAYER(eOwner).initUnit(eUnitType, pPlot->getX(), pPlot->getY(), NO_UNITAI, NO_DIRECTION, GC.getGame().getSorenRandNum(10000, "AI Unit Birthmark"));
 
+	// Oscillation guard (scoped to THIS merge operation): forbid splitting while the merge is in
+	// progress, so a split fired re-entrantly mid-merge can't tear the half-formed unit apart. It is
+	// RELEASED the moment the merge completes (below) -- it is NOT a permanent lock. Leaving it set was
+	// the #440 bug: group-merged units could never split, which also broke the SM city-defense fallback
+	// that splits a merged defender. The merge<->split CYCLE stays guarded the other way by inhibitMerge
+	// (set on split units, checked in canMerge), so releasing this does not enable thrash.
+	pkMergedUnit->setInhibitSplit(true);
+
 	pUnit1->setFortifyTurns(0);
 	pUnit2->setFortifyTurns(0);
 	pUnit3->setFortifyTurns(0);
@@ -27229,7 +27237,6 @@ CvUnit* CvUnit::mergeUnits(CvUnit* pUnit1, CvUnit* pUnit2, CvUnit* pUnit3, CvSel
 	{
 		pkMergedUnit->setLeaderUnitType(pUnit3->getLeaderUnitType());
 	}
-	pkMergedUnit->setInhibitSplit(true);
 	if (pJoinGroup != NULL)
 	{
 		pkMergedUnit->joinGroup(pJoinGroup);
@@ -27253,6 +27260,12 @@ CvUnit* CvUnit::mergeUnits(CvUnit* pUnit1, CvUnit* pUnit2, CvUnit* pUnit3, CvSel
 	pUnit2->kill(true, NO_PLAYER, true);
 	pUnit3->getGroup()->AI_setMissionAI(MISSIONAI_DELIBERATE_KILL, NULL, NULL);
 	pUnit3->kill(true, NO_PLAYER, true);
+
+	// Merge complete -- release the operation-scoped guard. The merged unit is now freely splittable
+	// (the human Split button and the SM city-defense fallback both depend on this). Strategic
+	// merge<->split oscillation is NOT prevented here; that belongs in the AI decision tree (a
+	// per-turn, per-unit merge/split cap), not in a permanent flag on the unit.
+	pkMergedUnit->setInhibitSplit(false);
 
 	return pkMergedUnit;
 }

--- a/docs/indexes/DESPAIR_INDEX.html
+++ b/docs/indexes/DESPAIR_INDEX.html
@@ -386,7 +386,29 @@
 </article>
 
 <article class="entry">
-  <h2>14. The .vcxproj of Lies</h2>
+  <h2>14. The Merger With No Undo (Bring a Boat)</h2>
+  <div class="score-row"><span class="score">54 cp</span><span class="meter"><i style="width:54%"></i></span></div>
+  <p>Size Matters lets you fuse three units into one bigger one. The merge stamped the new
+  unit with an <em>inhibit-split</em> flag — and the only line in the entire codebase that
+  ever cleared it was the one that loads a unit onto a <strong>transport ship</strong>. So a
+  merged army could never be split apart again <em>unless you first put it on a boat</em>.</p>
+  <p>It gets better. The individual-unit merge path — a second, inline copy of the merge
+  logic — quietly never set the flag, so <em>that</em> path worked fine. The "merge everyone
+  in this group" path went through the shared merge core and inherited the permanent lock:
+  same feature, two implementations, opposite behaviour. And the AI's own Size-Matters
+  city-defense fallback <em>splits a merged defender back into pieces</em> — so the lock
+  silently disabled a defensive move the AI still believed it had.</p>
+  <p>The flag was an anti-oscillation band-aid, almost certainly from the pre-git era, back
+  when the AI's decision tree would thrash a single stack merge→split→merge forever on
+  contradictory logic. The AI has improved measurably since; the band-aid outlived the wound
+  and stayed on, quietly confiscating everyone's Split button.</p>
+  <p class="status">Status: fixed (#440) — the guard now scopes to the merge itself and
+  releases the instant the merge completes, so merged units split again. A proper per-turn AI
+  guard is on file for if the oscillation ever returns. Boats are once more optional.</p>
+</article>
+
+<article class="entry">
+  <h2>15. The .vcxproj of Lies</h2>
   <div class="score-row"><span class="score">47 cp</span><span class="meter"><i style="width:47%"></i></span></div>
   <p>The Visual Studio project file confidently states <code>PlatformToolset: v142</code>.
   The actual compiler is the <strong>Microsoft Visual C++ Toolkit 2003</strong> (MSVC 7.1).

--- a/docs/indexes/DESPAIR_INDEX.md
+++ b/docs/indexes/DESPAIR_INDEX.md
@@ -298,7 +298,32 @@ fortified. The uranium has been returned.*
 
 ---
 
-## 14. The .vcxproj of Lies — 47 cp
+## 14. The Merger With No Undo (Bring a Boat) — 54 cp
+
+Size Matters lets you fuse three units into one bigger one. The merge stamped the new unit
+with an *inhibit-split* flag — and the only line in the entire codebase that ever cleared it
+was the one that loads a unit onto a **transport ship**. So a merged army could never be
+split apart again *unless you first put it on a boat*.
+
+It gets better. The individual-unit merge path — a second, inline copy of the merge logic —
+quietly never set the flag, so *that* path worked fine. The "merge everyone in this group"
+path went through the shared merge core and inherited the permanent lock: same feature, two
+implementations, opposite behaviour. And the AI's own Size-Matters city-defense fallback
+*splits a merged defender back into pieces* — so the lock silently disabled a defensive move
+the AI still believed it had.
+
+The flag was an anti-oscillation band-aid, almost certainly from the pre-git era, back when
+the AI's decision tree would thrash a single stack merge→split→merge forever on contradictory
+logic. The AI has improved measurably since; the band-aid outlived the wound and stayed on,
+quietly confiscating everyone's Split button.
+
+*Status: fixed (#440) — the guard now scopes to the merge itself and releases the instant the
+merge completes, so merged units split again. A proper per-turn AI guard is on file for if the
+oscillation ever returns. Boats are once more optional.*
+
+---
+
+## 15. The .vcxproj of Lies — 47 cp
 
 The Visual Studio project file confidently states `PlatformToolset: v142`. The actual
 compiler is the **Microsoft Visual C++ Toolkit 2003** (MSVC 7.1). The project file drives

--- a/docs/indexes/index.html
+++ b/docs/indexes/index.html
@@ -52,14 +52,17 @@
 
   <div class="preamble">
     Stones2Stars keeps several ranked catalogs. This page ranks <strong>the catalogs themselves</strong>, by their
-    <strong>Load-Bearing Authority™</strong> — a rigorously unscientific blend of how often each is the correct answer
-    to "wait… that's <em>intentional?</em>", and how reliably it consumes a developer's afternoon. Click one to descend.
+    <strong>Load-Bearing Authority™</strong>, measured in <strong>kilopains (kp)</strong> — because the pain these
+    catalogs induce runs so high that the Despair Index's own <em>centi</em>phants couldn't contain it, and the unit
+    had to climb clear across the SI prefixes to <em>kilo</em>. A rigorously unscientific blend of how often each is
+    the correct answer to "wait… that's <em>intentional?</em>", and how reliably it consumes a developer's afternoon.
+    Click one to descend.
   </div>
 
   <a class="entry gold" href="DESPAIR_INDEX.html">
     <h2><span class="medal">🥇</span> The Despair Index <span class="arrow">→</span></h2>
     <div class="score-row">
-      <span class="score">Authority 97 / 100</span>
+      <span class="score">97 kp</span>
       <span class="meter"><span style="width:97%"></span></span>
     </div>
     <p>The flagship. Bugs ranked by the developer despair they induce, in centiphants. Opened mid-<code>git&nbsp;blame</code>,
@@ -69,7 +72,7 @@
   <a class="entry silver" href="REALISM_INDEX.html">
     <h2><span class="medal">🥈</span> The Realism Index <span class="arrow">→</span></h2>
     <div class="score-row">
-      <span class="score">Authority 84 / 100</span>
+      <span class="score">84 kp</span>
       <span class="meter"><span style="width:84%"></span></span>
     </div>
     <p>The balm. Absurdities working <em>exactly as designed</em> — "it's not a bug, it's gloriously realistic." Where
@@ -79,7 +82,7 @@
   <a class="entry bronze" href="COMPLEXITY_INDEX.html">
     <h2><span class="medal">🥉</span> The Complexity Index <span class="arrow">→</span></h2>
     <div class="score-row">
-      <span class="score">Authority 71 / 100</span>
+      <span class="score">71 kp</span>
       <span class="meter"><span style="width:71%"></span></span>
     </div>
     <p>The vast one. Catalogs how much there is to hold in one's head at once. Deeply respected, rarely read for


### PR DESCRIPTION
Fixes #440.

## The bug
`CvUnit::mergeUnits` set `inhibitSplit=true` on the merged unit and nothing ever cleared it (except the unrelated transport-load path), so `canSplit()` vetoed the Split command **forever**. The **individual-unit** merge path (`CvNetChooseMergeUnit::Execute`) is a separate inline copy of the merge that never sets the flag, so it stayed splittable — which is why the bug only showed on the **group "merge all in group"** path (the human `CvSelectionGroup` hack), which routes through the shared `mergeUnits`.

The permanent lock also silently disabled the Size-Matters **city-defense fallback**, which splits a merged defender back into pieces.

## The fix
Make `inhibitSplit` an **operation-scoped guard**: set at the start of the merge (re-entrant safety, so a split can't fire mid-merge), released the instant the merge completes. Merged units are splittable again — fixing both the human Split button and the AI city-defense fallback.

The merge↔split **cycle** stays guarded on the merge-after-split leg by `inhibitMerge` (set on split units, checked in `canMerge`), so removing the permanent split-lock does **not** reintroduce runaway oscillation.

## Oscillation / follow-up
The permanent lock was an anti-oscillation band-aid — almost certainly pre-git — for a contradictory AI merge/split decision tree that used to thrash a stack merge→split→merge. The AI has improved measurably since. A **proper per-turn, AI-only merge/split guard** belongs in the AI decision tree (not a permanent unit flag) and is tracked as a separate follow-up, to be added only if the oscillation is re-observed.

## Validation
- Compiles clean (Assert build, isolated worktree).
- Behaviour change — needs an in-game playtest (Size Matters on: group-merge a stack, confirm the Split button appears on the merged unit and works).

## Docs
- Despair Index entry #14 — "The Merger With No Undo (Bring a Boat)" (`.md` + `.html`).
- Index of Indexes ranking unit restated as **kilopains (kp)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)