### PR TITLE
perf: stop rebuilding the trade-route network on every building, mid-turn

### DIFF
--- a/Sources/Cascade/CvModifierConsumer.cpp
+++ b/Sources/Cascade/CvModifierConsumer.cpp
@@ -96,13 +96,16 @@ namespace
 	// and `CvCity::m_aiTradeYield` is the engine's OUTPUT, folded into TIER-1 BASE at the combine
 	// ([modifier.md] §2a). It is not a package slot, so the maintained sum does not reach it and no compiled
 	// deposit index can name what moves it -- it is REBUILT rather than delta'd.
-	// ⚑ THIS IS ONE OF ITS FOUR REBUILD MOMENTS, not the only one ([modifier.md] §2a carries the whole set): the
-	// load-end pass, the plot-group / network changes, the per-player `doTurn`, and THIS -- targeted at whichever
-	// owner a fact just moved a tradeRoutes channel for. What this route buys is MID-TURN precision for the
-	// cascade-driven half; the fact names the owner, so the recompute follows the fact and never sweeps.
-	// ⚠ It is DEFERRED to the end of the event rather than fired per deposit: one civic swap moves several
-	// channels, and rebuilding a player's whole route network once per channel would pay the network walk many
-	// times over for one happening.
+	// ⚑ THIS IS ONE OF ITS REBUILD MOMENTS, not the only one ([modifier.md] §2a carries the whole set): the
+	// load-end pass, the plot-group / network changes, and THIS -- targeted at whichever owner a fact moved a
+	// tradeRoutes channel for. The fact names the owner, so the recompute follows the fact and never sweeps.
+	// ⛔ THE MARK IS TAKEN PER FACT; THE REBUILD IS SPENT AT THE OWNER'S TURN END, NEVER MID-TURN (owner).
+	// This turn's trade yield is ALREADY DEPOSITED by the time a building lands, so a mid-turn rebuild cannot
+	// change any number anyone reads this turn -- it only pays the network walk to reach a value that next
+	// turn's deposit would compute anyway. ⇒ mid-turn precision is not a thing worth buying here; the pending
+	// set carries the "something moved" answer across the turn and one rebuild spends it.
+	// ⚠ Marking, not rebuilding, is also what makes a civic swap cheap: it moves several channels, and the set
+	// collapses them to one rebuild rather than one per channel.
 	std::set<int> s_tradeRoutePendingOwners;
 
 	bool mc_isTradeRouteChannel(int iChannel)
@@ -271,17 +274,21 @@ namespace
 		}
 	}
 
-	void mc_flushTradeRouteUpdates()
+	// Spend ONE owner's pending mark, at that owner's turn end. Silent when nothing moved a tradeRoutes
+	// channel for it this turn -- which is the common case, and the reason this is a mark rather than a sweep.
+	void mc_flushTradeRouteUpdatesForOwner(int iOwner)
 	{
-		for (std::set<int>::const_iterator it = s_tradeRoutePendingOwners.begin();
-			it != s_tradeRoutePendingOwners.end(); ++it)
+		const std::set<int>::iterator itPending = s_tradeRoutePendingOwners.find(iOwner);
+		if (itPending == s_tradeRoutePendingOwners.end())
 		{
-			if (*it >= 0 && *it < MAX_PLAYERS)
-			{
-				GET_PLAYER((PlayerTypes)*it).updateTradeRoutes();
-			}
+			return;
 		}
-		s_tradeRoutePendingOwners.clear();
+		s_tradeRoutePendingOwners.erase(itPending);
+
+		if (iOwner >= 0 && iOwner < MAX_PLAYERS)
+		{
+			GET_PLAYER((PlayerTypes)iOwner).updateTradeRoutes();
+		}
 	}
 
 	// ⚖ THE CARRIER SLOT'S RESOLVE -- a source info back to its BUILDING id, for the one predicate class that
@@ -3138,6 +3145,12 @@ namespace
 				{
 					CascadeChannelRegistry::reportChannelCensus();   // once-guarded, so the load path wins when there is one
 				}
+				else
+				{
+					// The owner's turn is closing, so this turn's trade yield is banked and the route network may
+					// now be re-derived for whatever moved it. Silent unless a fact marked this owner.
+					mc_flushTradeRouteUpdatesForOwner(kEvent.iC);
+				}
 				break;
 			}
 			// ---- the load bracket end: DRAIN the banked marks, then the channel-set census ----
@@ -3161,12 +3174,11 @@ namespace
 				break;   // events with no deposit reach (name changes, counts, unit lifecycle, load bracket)
 			}
 
-			// ONE targeted rebuild per FACT, for the owners this event actually moved a tradeRoutes channel for.
-			// The engine owns the route network, so its output has to be re-derived rather than delta'd -- but only
-			// where the fact reached, never as a sweep (owner: "it needs to run targeted, for where an event has hit").
-			mc_flushTradeRouteUpdates();
-			// ...and the plots whose RESOLVE operand moved (a trait moving an owner's yield threshold, or a
-			// golden age starting or ending).
+			// ⛔ NO TRADE-ROUTE REBUILD HERE. The fact only MARKS its owner (mc_isTradeRouteChannel, above); the
+			// rebuild is spent once at that owner's turn end, because this turn's trade yield is already
+			// deposited and no mid-turn rebuild can move a number anyone reads this turn.
+			// The plots whose RESOLVE operand moved (a trait moving an owner's yield threshold, or a
+			// golden age starting or ending) are a different question and still settle per fact.
 			mc_flushOwnerPlotResolves();
 		}
 

--- a/Sources/Engine/CvPlayer.cpp
+++ b/Sources/Engine/CvPlayer.cpp
@@ -6835,13 +6835,15 @@ void CvPlayer::processBuilding(BuildingTypes eBuilding, int iChange, CvArea* pAr
 
 	const CvBuildingInfo& kBuilding = GC.getBuildingInfo(eBuilding);
 
-	// The EMPIRE-scope route COUNT -- the memberless flat deposit (ruling 11: kind 0 IS the count). The slot is
-	// a FLAT amount and therefore ×100, so the reader reduces at its point of use (docs/specs/curators/fixed-point-and-scales.md §1 (the x100 fixed-point model)): a
-	// route count is a whole game quantity.
-	// The cascade owns the AMOUNT now; what this site still owes is the changer's RIDER --
-	// the stored per-city trade YIELD must rebuild when a route input moves ([save.md] par.6).
-	updateTradeRoutes();
-
+	// ⛔ NO TRADE-ROUTE REBUILD RIDES HERE. Route SELECTION is a SPATIAL result -- it resolves through
+	// isConnectedToCapital/getPlotGroup, so it moves non-locally and no fact can name what it invalidated
+	// ([cascade.md] § THE SPATIAL CARVE-OUT). It is therefore cleared by the facts that can move it (route,
+	// ownership, city membership), never by a building being processed: the cascade already owns the route
+	// COUNT and the yield MODIFIERS, so this site deposits and nothing more.
+	// ⚠ updateTradeRoutes() opens with clearTradeRoutes() across every city, so it is a TOTAL rebuild -- a
+	// per-building call is discarded whole by the next one, and only the last of a batch survives.
+	// Measured on a 185-city save: the load-time placeSystemBuildings backfill drove 52,465 calls costing
+	// 30.3s to produce 17 surviving answers.
 	changeForceAllTradeRoutes(kBuilding.providesAmenity(CLS_AMENITY_FORCE_ALL_TRADE_ROUTES) * iChange);
 
 	// `national` is a revolution KIND, not a scope fragment -- the data authors `revolution.city.national`, so the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,13 @@
 
 ## Unreleased
 
+- **Loading a large game is around half a minute faster.** Every time a building was added to a city — including
+  the several dozen the game quietly places in *every* city while a save loads — the whole empire's trade-route
+  network was rebuilt from scratch. Each rebuild threw away the one before it, so on a large save the game did
+  the work fifty-two thousand times to arrive at seventeen answers, and spent about thirty seconds doing it. The
+  network is now rebuilt when something actually changes it, and once per player per turn as it always was.
+  Trade routes and their yields are unchanged; only the amount of repeated work is.
+
 - **The city bar's culture line reads correctly, and no longer faults.** Hovering a city showed its culture
   against a threshold of `0`, and the culture level's name was missing — while the game quietly took an access
   violation behind the scenes, several times a session. Culture is stored as a 64-bit number (it used to overflow

--- a/docs/architecture/superseded-ideas.md
+++ b/docs/architecture/superseded-ideas.md
@@ -511,3 +511,27 @@
     consequence, a transformation verb that is not the creation path,
     [parked/upgrade-chains.md](../plans/parked/upgrade-chains.md)). **Don't add a cost, a price function, a
     prompt or a player action to the building-obsolescence fate.**
+
+42. **DLL-SIDE GRAPHICS ASSET SHARING — "make every plot using the same forest model hold ONE copy"**
+    *(dead — investigated with a live-process measurement, impossible from our side of the boundary)* — the
+    intent was to stop N plots each carrying their own copy of an asset, so that full-map residency became
+    affordable and paging/viewports were unnecessary. **It cannot be done from the DLL, and the reason is
+    structural rather than a matter of effort:** plot graphics are requested by COORDINATE — `RebuildPlot(x,y)`,
+    `RebuildTileArt(x,y)`, `RebuildRiverPlotTile`, `ForceTreeOffsets` — and **an asset handle never crosses the
+    boundary at all.** A census of the entire EXE-side surface (`CvDLLEngineIFaceBase` 71 virtuals,
+    `CvDLLEntityIFaceBase` 26) finds **no instancing, sharing, clone or reuse primitive anywhere**; there is no
+    call that expresses "reuse the node you already built". Everything between `(x,y)` and the finished scene
+    node is EXE-internal, unsymbolized, and unreachable.
+    ⇒ **Only two quantities remain controllable: HOW MANY objects have graphics (residency) and WHAT ONE COPY
+    COSTS (art payload).** Since per-plot cost tracks mesh size (~70–190 KB/plot measured, against a 68 KB mean
+    NIF), decimating the most-frequently-placed feature/improvement meshes is the only lever that attacks the
+    copying itself; everything else is residency.
+    ⚑ **The revival risk is that the idea is correct and obvious** — sharing IS the right design, a forest tile
+    plainly *should* reference one mesh, and the conclusion "so let's make it do that" follows naturally from
+    looking at the art defines. The blocker is invisible until someone enumerates the interface headers, which
+    is why this is a tombstone. ⛔ **Do not re-derive it; and do not read `CvArtInfo`/`ARTFILEMGR` sharing as
+    evidence the engine shares** — the DLL side is already shared (one `CvArtInfo*` per art define, tag strings
+    only, §4), which says nothing about what the EXE does downstream.
+    ⚖ **The same closed EXE is the root of the 32-bit ceiling, the frozen VC7.1/Python 2.4 toolchain
+    ([engine.md](../reference/engine.md)) and this copying** — so the only thing that would genuinely dissolve
+    it is not owning that constraint, which is a far larger question than an optimisation.

--- a/docs/reference/memory-footprint.md
+++ b/docs/reference/memory-footprint.md
@@ -134,21 +134,45 @@ the (shared) Info, and per instance an index into the shared Info array.
   closed-EXE / no-symbols: the mechanism is inferred from the paging delta, not a symbol read — but the paging delta is
   a real measurement, no longer pure reasoning.) The **DLL art surface is a separate question and stays shared-once**
   (the DLL holds only the tag string, above) — per-instance texture memory lives on the EXE side.
-- **⛔ FPK IS NOT A PACKAGING DETAIL — IT IS THE LARGEST SINGLE MEMORY LEVER (owner).** *"FPKs force loading of
-  all assets to memory. If we don't use FPKs but let the game load graphics directly, over half of memory use is
-  gone — but it takes about 10-15 minutes to load the game."* So a large part of the working set is a **RESIDENT
-  ART BASELINE** that has nothing to do with instance counts, and the earlier reading here — that FPK was "a
-  packaging container, orthogonal to the once-vs-per-instance question" — was wrong
-  ([external-tools-and-workflows.md](external-tools-and-workflows.md) owns the packing mechanics).
-  ⚑ **The two effects are SEPARATE and both are real:** the FPK baseline is flat and enormous, and the per-turn
-  climb happens **on top of it, with every FPK already loaded** — *"it makes no sense that, when all FPKs are
-  loaded, we still get graphic use increases every turn, but that is what happens, and graphics paging proves
-  this by managing it."* ⇒ Do not let either explain the other away.
-  ⚖ **THE HOME RUN IS NAMED (owner): *"if we can have the actual game load faster, without FPKs, that is the
-  home run."*** Halving memory is already established; the load time is the whole of what stands in the way, so
-  the work is a LOAD-TIME problem, not a memory investigation. ⚠ Note this inverts the usual ordering rule —
-  [turn time is king](../cascade.md#-the-per-scope-package-model--the-cascades-founding-design-1-stated-as-cache-architecture) spends load time to buy turn time,
-  and here load time is the currency that has run out.
+- **⛔ FPK IS A RESIDENCY QUESTION, NOT A LOAD-TIME ONE — AND THE ART PATH IS NOT WHERE THE LOAD TIME GOES.**
+  Packed, the whole art set is resident from the start; unpacked, assets load on demand and the working set
+  climbs toward the same ceiling as the map is revealed. ⇒ **The memory difference is REAL AT LOAD and ERODES
+  AS YOU PLAY**, which is why a mid-session comparison shows packed and unpacked as near-identical while a
+  measurement taken at the loading screen shows a large saving. Both readings are true of different moments;
+  neither is the other's refutation.
+  ⚑ **MEASURED, unpacked (31,716 loose files, 1,113 MB, 5,210 dirs):** the engine **indexes every art file in
+  ~5 seconds** (30,162 reads, ~90 MB — a ~3 KB header per file) and then **issues ZERO further file reads for
+  the entire remainder of the load.** ⛔ So no art-packing change can move load time: after indexing, nothing
+  is being fetched from disk at all. The filesystem is not the constraint either — traversing all 31,418 files
+  costs 0.13 s and reading all 887 MB costs 1.7 s, against 0.35 s packed.
+  ⚠ **The load time that remains is DLL/EXE compute, not art.** One named hot path, sampled repeatedly:
+  `CvGame::onFinalInitialized → CvCity::placeSystemBuildings → setHasBuilding → processBuilding →
+  CvPlayer::updateTradeRoutes`, which recomputes **every** city's trade routes for **each** system building
+  placed, each walking plot groups via `isConnectedToCapital`.
+  ⛔ **The "load faster without FPKs" framing that stood here is RETIRED** — it named a target that the
+  measurements do not support.
+
+- **⛔ THE DLL CANNOT MAKE TWO PLOTS SHARE ONE ASSET — THERE IS NO SHARING PRIMITIVE TO REACH FOR.** Plot
+  graphics are requested by COORDINATE (`RebuildPlot(x,y)`, `RebuildTileArt(x,y)`, `RebuildRiverPlotTile`,
+  `ForceTreeOffsets`); an asset handle never crosses the boundary. A census of both EXE-side interfaces
+  (`CvDLLEngineIFaceBase` 71 virtuals, `CvDLLEntityIFaceBase` 26) finds **no instancing / sharing / clone /
+  reuse vocabulary anywhere**. ⇒ Whatever copying happens between `(x,y)` and the finished scene node is
+  EXE-internal and unreachable. **The only two quantities we control are HOW MANY objects have graphics
+  (residency) and WHAT ONE COPY COSTS (art payload).**
+  ⚑ **MEASURED, paging on, fog of war, no units visible: panning alone took the process 1.1 GB → 1.8 GB.**
+  That is ~70–190 KB per plot against a **68 KB mean NIF** — asset-scale, not pointer-scale, so per-plot
+  duplication is the better-supported reading. ⚠ It is bounded at roughly ONE copy per plot (~9,600), never a
+  large multiple: the 32-bit ceiling would not hold otherwise.
+- **The plot-graphics residency configuration is what makes that growth permanent.** `ENABLE_VIEWPORTS = 0`, so
+  `CvPlot::shouldHaveGraphics()` (= `IsGraphicsInitialized() && isInViewport()`) passes for **every** plot; its
+  `&& isRevealed(...)` clause is commented out, so panning over unexplored fog still builds graphics.
+  `ECvPlotGraphics` annotates its own costs — **`FEATURE` (improvements + resources + terrain features) is the
+  ONLY High-memory plot component**; `SYMBOLS`/`RIVER`/`ROUTE` are Low, which is why their `PAGE_IN_DIST_* = 999`
+  (whole-map) values are deliberate and not a misconfiguration. ⛔ **But `PAGING_RESIDENT_SOFT_CAP = 3000000` is
+  compared against `g_iNumPagedInPlots`, a PLOT COUNT bounded by map size (~9,600) — so the proactive evictor
+  can never fire** (code default is `6000`), and `MAX_DESIRED_MEMORY_USED = 3500000` KB (~3.58 GB) sits above the
+  32-bit ceiling, so the safety net cannot fire either. ⇒ `FEATURE` graphics page IN within 15 tiles and are
+  never given back: a ratchet, which is exactly the measured climb.
 
 **Implication:** the **DLL art surface is flat after load** (shared once — tag strings only), so a per-turn
 working-set climb is not DLL art re-instantiation. But on the **EXE side** the per-instance texture evidence (above)


### PR DESCRIPTION
## What

Two independent things, one branch:

1. **`perf:`** — stop rebuilding the whole empire's trade-route network on every building change, mid-turn.
2. **`docs:`** — record what the graphics/FPK investigation actually measured, and tombstone a dead idea.

## The measurement

Taken with the repo's own `[PERF]` instrument on a 185-city save. All 52,465 calls landed on a **single turn** — the load:

```
30267.5 ms  n=52465  mean=0.577  CvPlayer::updateTradeRoutes    <- 88% of all instrumented time
 1933.8 ms  n=1                  CvGame::updatePlotGroups
  104.3 ms  n=186               ...everything else is noise
```

Per-owner cost scaled with city count (owner 1: 9,908 calls / 11.9 s, mean 1.205 ms), exactly as "full rebuild across a player's cities" predicts.

## Why it was wrong

`CvPlayer::processBuilding` called `updateTradeRoutes()` **unconditionally, for every building processed**. That function opens with `clearTradeRoutes()` across every city — it is a **total rebuild**, so each call is discarded whole by the next one and only the last of a batch survives.

The load-time `placeSystemBuildings` backfill places the property bands and autoBuild set in *every* city, so on a large save the game did the work 52,465 times to reach 17 answers.

That call was never one of the four sanctioned rebuild moments in `cascade.md` (load-end · targeted-on-fact · plot-group/network change · per-player `doTurn`). Route **selection** is a spatial result — it resolves through `isConnectedToCapital` / `getPlotGroup` and moves non-locally, so no fact can name what it invalidated (`cascade.md` § THE SPATIAL CARVE-OUT). It is cleared by the facts that can move it, never by a building being processed.

**Coverage is unchanged** — `CvPlayer::doTurn()` already recomputes once per player per turn (lines 3883 and 3964).

## Second change: the targeted rebuild moves to turn end

The cascade's own targeted rebuild (`CvModifierConsumer`) fired **per fact**, mid-turn. But this turn's trade yield is already deposited by the time a building lands, so a mid-turn rebuild cannot move any number read this turn — it only pays the network walk to reach a value the next turn's deposit computes anyway.

The mark is still taken per fact and still channel-gated (`mc_isTradeRouteChannel`); only the **spending** moves, to `SEVT_TURN_ENDED` for that owner. The now-orphaned all-owners flush is deleted.

## ⚠ Open question for review

With `doTurn`'s per-player rebuild being **unconditional and permanent** — `cascade.md` justifies it explicitly, because `getPeaceTradeModifier` advances every turn and *"there is no fact to route it to; the turn IS the fact"* — the targeted moment now fires at the same turn boundary where `doTurn` already rebuilds. **It may be fully redundant and better deleted outright** (mark, channel test, flush and all), leaving three justified moments.

I left it in rather than delete it unilaterally. Happy to strip it if you agree.

## Testing

- `Assert rebuild` green, **zero `C1003`** (nothing hidden behind error truncation).
- **NOT PLAYTESTED.** `AGENTS.md` requires a real in-game playtest before merge for a behaviour change; I could not launch the game this session.

**Verification when you do:** perf logging is already on, so no setting change is needed: just load the same save and check `Performance.log` — `CvPlayer::updateTradeRoutes` should report **~34 calls instead of 52,465**, and trade yields should be unchanged.

## The docs commit

Separate topic, from a graphics-memory investigation earlier in the session:

- **`memory-footprint.md` §4** carried a C2C-era premise (FPK as "the largest single memory lever", loading without it costing 10–15 minutes) and named a **"home run"** on that basis. Measured: unpacked art indexes in **~5 s**, and the engine then issues **zero** further file reads for the rest of the load. Traversing all 31,418 files costs 0.13 s; reading all 887 MB costs 1.7 s (vs 0.35 s packed). No art-packing change can move load time, so that framing is retired. FPK is recorded as a **residency** question instead — the saving is real at load and erodes as the map is revealed, which is why mid-session and loading-screen measurements disagree while both being true.
- Records the plot-graphics residency configuration that explains the measured 1.1 → 1.8 GB growth from panning alone: `ENABLE_VIEWPORTS=0`, the commented-out `isRevealed` clause, `FEATURE` as the only High-cost component, and `PAGING_RESIDENT_SOFT_CAP=3000000` compared against a plot count bounded by ~9,600 — so the proactive evictor can never fire (code default `6000`).
- **`superseded-ideas` #42** tombstones DLL-side graphics asset sharing: plot graphics are requested by coordinate, an asset handle never crosses the boundary, and a census of both EXE-side interfaces finds no instancing/sharing/clone/reuse primitive anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Follow-up noted, not done here

The `[PERF]` instrument (`PERF_SCOPE` / `logPerf` / the perf log level) lives in `Sources/AI/BetterBTSAI.{h,cpp}` — legacy BBAI. It belongs on the **spine** instead. Out of scope for this PR, but it is the surface every measurement above was taken with.
