### PR TITLE
fix: a calculated starting unit must be one the player could ever be offered

### DIFF
--- a/Sources/Engine/CvPlayer.cpp
+++ b/Sources/Engine/CvPlayer.cpp
@@ -1991,6 +1991,19 @@ bool CvPlayer::addStartUnitAI(const UnitAITypes eUnitAI, const int iCount)
 		}
 		const CvUnitInfo& kUnit = GC.getUnitInfo((UnitTypes) iI);
 
+		// ⛔ A CALCULATED START UNIT MUST BE ONE THIS PLAYER COULD EVER BE OFFERED, and `requiresMetForPlayer`
+		// below cannot answer that: it is the SYSTEM-PLACEMENT gate, which deliberately admits statically-
+		// excluded entities because trigger spawns and WB placements legitimately place them
+		// (CvEnablerKernel.h). The city-scoped tri-state is not reachable here either -- the trainable domain
+		// lives on CvCity (enabler.md par.8) and no city exists yet at game start, which is the whole reason
+		// this identity is CALCULATED rather than authored (triggers.md, START PACKAGES).
+		// So ask the ONE offerability verdict the enabler's own static exclusion folds (CvUnitEnabler seeds
+		// setStaticExcluded from this same getter) -- never the underlying flag, which would be a second
+		// implementation of one verdict.
+		if (!kUnit.isOfferable())
+		{
+			continue;
+		}
 		if (!GET_TEAM(getTeam()).isUnitBonusEnabledByTech(kUnit, true))
 		{
 			continue;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,14 @@
 
 ## Unreleased
 
+- **Starting units can no longer be units nobody can build.** A player could begin a Prehistoric game holding a
+  Gladiator — an arena-placed unit — and it was not the worst case available: a strength-17 Master Big Game
+  Hunter and a strength-15 Crusader were both reachable. Starting unit identities are not authored anywhere;
+  they are chosen at game start by scanning every unit and keeping whichever scores highest for the role. That
+  scan checked whether a unit's requirements were met but never whether it may be built at all, so the 46
+  never-buildable units that advertise a starting role were all candidates — and being strong is exactly what
+  made them win. The scan now asks the same offerability verdict the rest of the game uses.
+
 - **The city bar's culture line reads correctly, and no longer faults.** Hovering a city showed its culture
   against a threshold of `0`, and the culture level's name was missing — while the game quietly took an access
   violation behind the scenes, several times a session. Culture is stored as a 64-bit number (it used to overflow


### PR DESCRIPTION
## The bug

An AI began a **Prehistoric** game holding a **Gladiator**.

`Assets/Data/units/unit_gladiator.json`:

```json
"identity": {
  "spawnOnly": true,
  "unitAIs": ["UNITAI_ATTACK", "UNITAI_RESERVE", "UNITAI_COUNTER", "UNITAI_CITY_DEFENSE"]
},
"strength": { "unit": { "flat": 9 } },
"combat":   { "unit": { "unitCombat": { "UNITCOMBAT_MELEE": { "percent": 25 } } } },
"requires": { "build": { "dormant": { "all": ["UNIT_MACEMAN"] } } }
```

Every link: it is `spawnOnly` (arena-placed, never trainable), it advertises **`UNITAI_CITY_DEFENSE`** so it is a candidate for `addStartUnitAI(UNITAI_CITY_DEFENSE, …)`, it has **no `enabled` gate** and its only `requires.build` clause is `dormant` — so the gate passes it — and then strength 9 + 25% melee wins `AI_unitValue` against anything prehistoric.

## Why it happened

Starting unit **identity is not authored anywhere**. `docs/specs/triggers.md` (START PACKAGES) states the problem exactly:

> *the COUNTS are curated, but the **unit identity is not authored anywhere** — it is picked at runtime by scanning the whole unit database, filtering on trainability and scoring with an AI valuation*

`CvPlayer::addStartUnitAI` does that scan, gated only on `isUnitBonusEnabledByTech` and `EnablerKernel::requiresMetForPlayer` — the `requires` half. **It never asked whether the unit may be built at all.**

And `requiresMetForPlayer` cannot answer that. Its own contract says so — it is the **system-placement gate**, and it admits statically-excluded entities *on purpose*, because trigger spawns and WorldBuilder placements legitimately place them:

> *"a system-placed entity is statically excluded and therefore permanently HIDDEN (`identity.spawnOnly` / `identity.notConstructible`) — which is exactly why this exists."*

Per `enabler.md`, `available(X) = generated ∧ requires met ∧ under allowed cap`. The scan checked **only the middle term**, and the spec is explicit that there is *"no implicit no-edge ⇒ always available engine rule."*

## Scope — Gladiator was not the ceiling

Of **2,073** units, **525 are `spawnOnly`**, and **46 of those advertise a start-relevant UnitAI** — all 46 were candidates. Selection is by `AI_unitValue`, so the scan was biased *toward* them: being strong is what made them win.

| strength | unit | roles offered |
|--:|---|---|
| **17** | `UNIT_MASTER_BIG_GAME_HUNTER` | EXPLORE, ATTACK |
| **15** | `UNIT_CRUSADER` | ATTACK, EXPLORE, CITY_DEFENSE |
| **12** | `UNIT_MASTER_GAME_HUNTER` | EXPLORE, ATTACK |
| 9 | `UNIT_GLADIATOR` | ATTACK, CITY_DEFENSE |
| 9 | `UNIT_SPARTACUS` | ATTACK, CITY_DEFENSE |

## The fix

One filter, asking the **one** offerability verdict:

```cpp
if (!kUnit.isOfferable()) { continue; }
```

`CvUnitInfo::isOfferable()` is not a new rule — `CvUnitEnabler` seeds its domain's `setStaticExcluded` from **that same getter**, so the enabler's `isStaticExcluded` is simply its cached form. Asking it here is the same verdict, not a second implementation of one (which the enabler header explicitly warns against: *"a CAN-I-EVER consumer asks HERE rather than re-reading the authoring off the infos"*).

**Why not the city-scoped tri-state:** unit availability is a `CvCity` read (`getUnitAvailability`), and per `enabler.md` par.8 the trainable domain lives on `CvCity::m_enabler`. At game start **no city exists** — `addStartUnitAI` is creating the settler that founds the first one — so there is no domain to ask. That absence is precisely why this identity is calculated rather than authored.

## Note on the real fix

This is a **guard on a mechanism the spec already marks for replacement**. `triggers.md` specifies JSON-authored **START PACKAGES** that author unit identity outright, replacing the scan-and-score entirely; no `STARTPACKAGE` data or code exists in the tree yet. This PR makes the interim mechanism stop picking never-buildable units; it does not make start composition authorable.

## Testing

- `Assert rebuild` green, **zero `C1003`**.
- **NOT PLAYTESTED.** `AGENTS.md` requires a real in-game playtest before merge for a behaviour change; I could not launch the game this session.

**Verification:** start a Prehistoric game and confirm every starting unit — yours and the AI's — is one that could actually be trained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
