### PR TITLE
fix(#465): a specialist is a specialist -- free or assigned, it provides

### DIFF
--- a/Sources/Engine/CvCity.cpp
+++ b/Sources/Engine/CvCity.cpp
@@ -2360,7 +2360,8 @@ bool CvCity::canContinueProduction(const OrderData& order) const
 // ⛔ Never a walk of a keyed container the info no longer holds (the own-data inversion,
 // pedia-read-map finding 2), and never a package read: a keyed entry deliberately does NOT fold into a scope
 // package outside plot scope, because folding it would hand EVERY unit the melee-only experience.
-int CvCity::keyedExperience(int iTargetSegment, int iTargetFk) const
+int CvCity::keyedExperience(int iTargetSegment, int iTargetFk,
+	const std::vector<int64_t>* pFreeSpecialists) const
 {
 	if (iTargetSegment < 0 || iTargetFk < 0)
 	{
@@ -2375,9 +2376,25 @@ int CvCity::keyedExperience(int iTargetSegment, int iTargetFk) const
 			GC.getBuildingInfo((BuildingTypes)*it).getModifiers(), MODFAM_EXPERIENCE, -1, iTargetSegment, iTargetFk);
 	}
 
+	// ⛔ A SETTLED GREAT PERSON IS A **FREE** SPECIALIST, NOT AN ASSIGNED ONE -- the join path calls
+	// changeFreeSpecialistCount, and the two planes are separate members. Reading only the assigned plane made
+	// every settled specialist contribute nothing to this leg (#465: hunters got no experience from a settled
+	// great hunter, whose experience.city.unitCombats deposit is the whole point of settling one).
+	// ⚠ getFreeSpecialists walks an eval ctx + the operating set + the whole empire, so a caller that fans this
+	// over a unit's combat classes takes the GROUP read once and hands it down; only a lone caller reads here.
+	std::vector<int64_t> aiFreeSpecialistsLocal;
+	if (pFreeSpecialists == NULL)
+	{
+		getFreeSpecialists(aiFreeSpecialistsLocal);
+		pFreeSpecialists = &aiFreeSpecialistsLocal;
+	}
+
 	for (int iSpecialist = 0; iSpecialist < GC.getNumSpecialistInfos(); ++iSpecialist)
 	{
-		const int iCount = getSpecialistCount((SpecialistTypes)iSpecialist);
+		const int iFreeCount = (iSpecialist < (int)pFreeSpecialists->size())
+			? (int)((*pFreeSpecialists)[iSpecialist] / 100)
+			: 0;
+		const int iCount = getSpecialistCount((SpecialistTypes)iSpecialist) + iFreeCount;
 		if (iCount > 0)
 		{
 			iExperience += iCount * InfoValuation::keyedTarget(
@@ -2416,9 +2433,16 @@ void CvCity::collectUnitCombatExperience(std::vector<std::pair<int, int> >& rows
 			GC.getBuildingInfo((BuildingTypes)*it).getModifiers(), MODFAM_EXPERIENCE, -1, iSegment, sourceRows);
 		mergeKeyedRows(rows, sourceRows, 1);
 	}
+	// Assigned + free, exactly as the VALUE leg counts them (keyedExperience) -- a decomposition that counted a
+	// different population than the number it explains is the drift the census exists to catch.
+	std::vector<int64_t> aiFreeSpecialists;
+	getFreeSpecialists(aiFreeSpecialists);
 	for (int iSpecialist = 0; iSpecialist < GC.getNumSpecialistInfos(); ++iSpecialist)
 	{
-		const int iCount = getSpecialistCount((SpecialistTypes)iSpecialist);
+		const int iFreeCount = (iSpecialist < (int)aiFreeSpecialists.size())
+			? (int)(aiFreeSpecialists[iSpecialist] / 100)
+			: 0;
+		const int iCount = getSpecialistCount((SpecialistTypes)iSpecialist) + iFreeCount;
 		if (iCount > 0)
 		{
 			InfoValuation::collectKeyedTarget(
@@ -2474,15 +2498,21 @@ int CvCity::getProductionExperience(UnitTypes eUnit, ProductionExperienceLegs* p
 			const int iUnitCombatsSegment = InfoValuation::keyedTargetSegment("unitCombats");
 			const int iDomainsSegment = InfoValuation::keyedTargetSegment("domains");
 
+			// The GROUP read, ONCE for the whole fan below: a unit carries a primary combat class plus a
+			// dozen secondaries, and each keyedExperience would otherwise re-walk the eval ctx, the operating
+			// set and the whole empire to answer the same question.
+			std::vector<int64_t> aiFreeSpecialists;
+			getFreeSpecialists(aiFreeSpecialists);
+
 			// The ROOT combat-class FKs (json §8: `combatClass` + `combatClasses`, never identity). An absent
 			// primary is -1, which keyedExperience already answers 0 for, so it needs no test of its own.
-			lKeyedCombat += keyedExperience(iUnitCombatsSegment, kUnit.getCombatClass());
+			lKeyedCombat += keyedExperience(iUnitCombatsSegment, kUnit.getCombatClass(), &aiFreeSpecialists);
 			const std::vector<int>& kSubCombats = kUnit.getCombatClasses();
 			for (size_t iSub = 0; iSub < kSubCombats.size(); ++iSub)
 			{
-				lKeyedCombat += keyedExperience(iUnitCombatsSegment, kSubCombats[iSub]);
+				lKeyedCombat += keyedExperience(iUnitCombatsSegment, kSubCombats[iSub], &aiFreeSpecialists);
 			}
-			lKeyedDomain += keyedExperience(iDomainsSegment, (int)kUnit.getDomain());
+			lKeyedDomain += keyedExperience(iDomainsSegment, (int)kUnit.getDomain(), &aiFreeSpecialists);
 			lExperience += lKeyedCombat + lKeyedDomain;
 		}
 	}

--- a/Sources/Engine/CvCity.h
+++ b/Sources/Engine/CvCity.h
@@ -874,7 +874,10 @@ public:
 
 	bool isBombardable(const CvUnit* pUnit) const;
 	int cascadeValue(ModifierFamily eFamily, int eKind) const;   // ANY (family,kind) slot; unit per infoKindUnit
-	int keyedExperience(int iTargetSegment, int iTargetFk) const;   // the keyed experience.<scope>.{unitCombats|domains} legs
+	// The keyed experience.<scope>.{unitCombats|domains} legs. pFreeSpecialists is the caller's ONE
+	// getFreeSpecialists read, passed in where a caller fans this over a unit's combat classes; NULL takes it here.
+	int keyedExperience(int iTargetSegment, int iTargetFk,
+		const std::vector<int64_t>* pFreeSpecialists = NULL) const;
 	int getDomainExperience(DomainTypes eDomain) const;             // experience.<scope>.domains.{DOMAIN}, every live source
 	// Every (unitCombat, experience) this city's live sources deposit, collected ONCE. ⛔ A consumer wanting the
 	// military subset filters THESE rows -- it never asks per id over the unitcombat registry, which is the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,13 @@
 
 ## Unreleased
 
+- **A settled Great Hunter trains better hunters again.** Settling a great person makes it a *free* specialist,
+  which the game tracks separately from the citizens you assign to specialist jobs — and the experience a
+  specialist grants to units trained in its city was counting only the assigned ones. A settled Great Hunter
+  therefore sat in the city contributing nothing to the thing it exists for. Every settled specialist that grants
+  experience was affected, not just hunters. ⚑ A specialist is a specialist: free or assigned makes no difference
+  to what it provides.
+
 - **Starting units can no longer be units nobody can build.** A player could begin a Prehistoric game holding a
   Gladiator — an arena-placed unit — and it was not the worst case available: a strength-17 Master Big Game
   Hunter and a strength-15 Crusader were both reachable. Starting unit identities are not authored anywhere;

--- a/docs/cascade.md
+++ b/docs/cascade.md
@@ -2774,7 +2774,19 @@ A deposit lands in one of three ways ([json](specs/json.md) §6.1):
 > PLOT scope a keyed entry deliberately does **not** fold into the scope's Σflat/Σpercent slots (only the plot's own
 > substrate keys resolve there, §2 plot-as-base; the `empires` fan is the one target whose fold IS the deposit). So
 > a consumer answering *"how much does this source give THIS target"* asks each live source what IT deposits onto
-> that key — the city's OPERATING buildings, its assigned specialists × count, the empire's held traits — and sums.
+> that key — the city's OPERATING buildings, its specialists × count, the empire's held traits — and sums.
+>
+> ⛔ **A SPECIALIST IS A SPECIALIST — FREE OR OTHERWISE DOES NOT MATTER (owner).** The count is the city's WHOLE
+> specialist population: the assigned citizens **plus** the free ones (the derivable `freeSpecialists.{X}` grants
+> of its operating buildings and empire sources, plus the unattributed ledger a settled Great Person lands in).
+> They are one provider kind (§ THE FOUR-PROVIDER LAW), so the origin of a specialist has no standing in what it
+> provides. ⚠ Reading only the assigned plane is the shape to recognise, because the two live in SEPARATE members
+> (`m_paiSpecialistCount` vs the `getFreeSpecialists` group read) and the assigned one is the obvious getter:
+> it makes a settled Great Person contribute NOTHING while the city visibly holds it, which is silent and
+> plausible in exactly the way this rule exists to prevent. *(Worked: a settled Great Hunter granted no
+> `experience.city.unitCombats` to the hunters trained beside it — the whole point of settling one.)*
+> ⚑ **Take the GROUP read once** (`getFreeSpecialists`): it builds an eval ctx and walks the city's operating set
+> AND the empire's sources, so a per-specialist call inside a loop pays all of that per specialist.
 >
 > **⚖ A KEYED ROW'S REACH IS ITS AUTHORED SCOPE, AND BOTH SCOPES ARE REAL ON A BUILDING (owner).** A building is
 > a per-city source, so a CITY-scope keyed row means faster HERE — *"units are scoped on the city the building is


### PR DESCRIPTION
Closes #465.

## What was wrong

A settled Great Hunter gave hunters trained beside it no experience.

Two things it was **not**, both of which looked likely:

- **Not the data.** `SPECIALIST_GREAT_HUNTER` correctly authors `experience.city.unitCombats.UNITCOMBAT_EXPLORER = 2`.
- **Not combat-class matching.** `UNIT_HUNTER` carries `UNITCOMBAT_EXPLORER` only as a *secondary* class (its primary is `UNITCOMBAT_HUNTER`) — but `getProductionExperience` already sums the primary `combatClass` **and** every entry of `combatClasses`, so it was matched fine.

**The break:** a *settled* great person is a **free** specialist. `CvUnit`'s join path calls `changeFreeSpecialistCount`, which lands in a different member from assigned citizens:

| | member |
|---|---|
| assigned citizens | `m_paiSpecialistCount` |
| free / settled | the `getFreeSpecialists` group read — derivable `freeSpecialists.{X}` grants of operating buildings + empire sources, plus the unattributed ledger |

`CvCity::keyedExperience` counted only `getSpecialistCount`. So a settled specialist contributed **nothing** — while the city visibly held it.

## The shape is correct; the population was not

Per `cascade.md` §5, a keyed deposit is an **entry-list read over the live sources**, never a package fold — folding `experience.city.unitCombats.{MELEE}` scope-wide would hand *every* unit the melee-only experience. So the registry walk is the sanctioned shape here. What was wrong is the population it walked.

Both the **value** leg and the **`[XP/production]` decomposition** now count assigned + free, so the census cannot report a different population from the number it explains.

**The group read is taken once.** `getFreeSpecialists` builds an eval ctx and walks the city's operating set *and* the whole empire. A hunter fans `keyedExperience` over a primary class + 11 secondaries + a domain, so a per-call read would pay all of that 13× per unit trained. `getProductionExperience` reads it once and hands it down.

## Spec fix in the same change

`cascade.md` §5 said the consumer asks *"its **assigned** specialists × count"*. That word is where the defect came from. It now states the whole population, records your ruling that a specialist is a specialist regardless of origin, and names why reading the assigned plane alone is silently plausible — the two live in separate members and the assigned one is the obvious getter.

## Scope

Every settled specialist that grants experience was affected, not only hunters.

## Conformance

`cascade.md` §6 (THE TWO-PART SEAM) names the sanctioned consumer read outright: the realized per-type counts
**`getSpecialistCount + getFreeSpecialistCount`** are *"a sanctioned output-seam read, never a self-containment
ride-in."* That is exactly what this change does — the cascade owns the AMOUNT of free specialists, the engine
owns PLACEMENT, and consumers read the realized combined count.

## ⚠ Related item, NOT in this PR

Specialist **yields** reach consumers through a different path — the maintained `m_specialistYields` package,
fed by `SEVT_CITY_SPECIALIST_ADDED/REMOVED`, which only the assigned path emits (`setSpecialistCountInternal`);
`changeFreeSpecialistCount` emits nothing. `CvInfoValuation`'s census documents the symptom already: *"a type the
city holds ONLY as free-typed contributes nothing today"*, emitting a deliberate zero row to keep it visible.

Whether that is a real gap is a **conformance check against §6**, not an open design question — §6 already says
what a consumer reads and how the seam splits. It wants its own issue and its own trace against that section
rather than riding in on this fix.

## Testing

- `Assert rebuild` green, zero `C1003`. `verify-docs` passes.
- **NOT PLAYTESTED.** Verify by settling a Great Hunter and training a hunter in that city — it should gain the specialist's experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

