### PR TITLE
fix(#469): the empty options menu, the dead clicks, and the founding crash

### DIFF
--- a/Assets/Python/Screens/Advisors/CvCivicsScreen.py
+++ b/Assets/Python/Screens/Advisors/CvCivicsScreen.py
@@ -472,7 +472,9 @@ class CvCivicsScreen:
 
 		elif iCode == NotifyCode.NOTIFY_CLICKED:
 
-			if NAME.startswith("Civic_Tab"):
+			# Only the NUMBERED tabs carry an index. startswith alone also matches the bare "Civic_Tab",
+			# whose last character is "b", so int(NAME[-1]) raised and killed the whole click handler.
+			if NAME.startswith("Civic_Tab") and NAME[len("Civic_Tab"):].isdigit():
 				if "|" not in NAME:
 					screen.hide("Civic_Tab|Col" + str(self.iTab))
 					screen.show("Civic_Tab" + str(self.iTab))

--- a/Assets/Python/Screens/CvOptionsScreen.py
+++ b/Assets/Python/Screens/CvOptionsScreen.py
@@ -285,8 +285,8 @@ class CvOptionsScreen:
 
 			if (bContinue):
 
-				szOptionDesc = gc.getPlayerOptionsInfo(iOptionLoop).getDescription()
-				szHelp = gc.getPlayerOptionsInfo(iOptionLoop).getHelp()
+				szOptionDesc = gc.getPlayerOptionDescription(iOptionLoop)
+				szHelp = gc.getPlayerOptionHelp(iOptionLoop)
 				szCallbackFunction = "handleGameOptionsClicked"
 				szWidgetName = "GameOptionCheckBox_" + str(iOptionLoop)
 				bOptionOn = UserProfile.getPlayerOption(iOptionLoop)
@@ -489,8 +489,8 @@ class CvOptionsScreen:
 
 		# Checkboxes
 		for iOptionLoop in range(GraphicOptionTypes.NUM_GRAPHICOPTION_TYPES):
-			szOptionDesc = gc.getGraphicOptionsInfo(iOptionLoop).getDescription()
-			szHelp = gc.getGraphicOptionsInfo(iOptionLoop).getHelp()
+			szOptionDesc = gc.getGraphicOptionDescription(iOptionLoop)
+			szHelp = gc.getGraphicOptionHelp(iOptionLoop)
 			szCallbackFunction = "handleGraphicOptionsClicked"
 			szWidgetName = "GraphicOptionCheckbox_" + str(iOptionLoop)
 			bOptionOn = UserProfile.getGraphicOption(iOptionLoop)

--- a/Sources/Engine/CvCity.cpp
+++ b/Sources/Engine/CvCity.cpp
@@ -2159,9 +2159,25 @@ bool CvCity::couldConstructWith(BuildingTypes eCandidate, BuildingTypes eExtraBu
 }
 
 
+CultureLevelTypes CvCity::cultureLevelForRead() const
+{
+	const CultureLevelTypes eLevel = getCultureLevel();
+	if (eLevel != NO_CULTURELEVEL)
+	{
+		return eLevel;
+	}
+	static int s_iNoneLevel = -1;
+	if (s_iNoneLevel < 0)
+	{
+		s_iNoneLevel = GC.getInfoTypeForString("CULTURELEVEL_NONE", /*bHideAssert*/true);
+	}
+	return (CultureLevelTypes)std::max(0, s_iNoneLevel);
+}
+
+
 int CvCity::getMaxNumWorldWonders() const
 {
-	return GC.getCultureLevelInfo(getCultureLevel()).getMaxWorldWonders();
+	return GC.getCultureLevelInfo(cultureLevelForRead()).getMaxWorldWonders();
 }
 
 bool CvCity::isWorldWondersMaxed() const
@@ -2184,13 +2200,13 @@ bool CvCity::isWorldWondersMaxed() const
 
 int CvCity::getMaxNumTeamWonders() const
 {
-	return GC.getCultureLevelInfo(getCultureLevel()).getMaxTeamWonders();
+	return GC.getCultureLevelInfo(cultureLevelForRead()).getMaxTeamWonders();
 }
 
 
 int CvCity::getMaxNumNationalWonders() const
 {
-	return GC.getCultureLevelInfo(getCultureLevel()).getMaxNationalWonders();
+	return GC.getCultureLevelInfo(cultureLevelForRead()).getMaxNationalWonders();
 }
 
 void CvCity::clearUpgradeCache(UnitTypes eUnit) const
@@ -11679,7 +11695,7 @@ void CvCity::doPlotCulture(PlayerTypes ePlayer, int iCultureRate)
 	PROFILE_FUNC();
 	FASSERT_BOUNDS(0, MAX_PLAYERS, ePlayer);
 
-	int iCultureLevel = GC.getCultureLevelInfo(getCultureLevel()).getLevel();
+	int iCultureLevel = GC.getCultureLevelInfo(cultureLevelForRead()).getLevel();
 
 	clearCultureDistanceCache();
 

--- a/Sources/Engine/CvCity.h
+++ b/Sources/Engine/CvCity.h
@@ -219,6 +219,14 @@ public:
 	// ⚠ It EVALUATES (unlike every read above), so it is a per-decision call and never an inner-loop one.
 	bool couldConstructWith(BuildingTypes eCandidate, BuildingTypes eExtraBuilding) const;
 	bool isWorldWondersMaxed() const;
+	///<summary>
+	/// The culture level to READ an info by. A city with no culture yet answers NO_CULTURELEVEL, and the info
+	/// plane holds no entry at -1 -- an unloaded read ABORTS in every config, so founding a city died here.
+	/// CULTURELEVEL_NONE is the entry that authors what "no culture yet" means, which is what getCityRadius
+	/// already answers with.
+	///</summary>
+	CultureLevelTypes cultureLevelForRead() const;
+
 	int getMaxNumWorldWonders() const;
 	int getMaxNumTeamWonders() const;
 	int getMaxNumNationalWonders() const;

--- a/Sources/Infrastructure/CvPythonGlobalContextLoader.cpp
+++ b/Sources/Infrastructure/CvPythonGlobalContextLoader.cpp
@@ -25,6 +25,11 @@ void CvPythonGlobalContextLoader::CyGlobalContextPythonInterface1(boost::python:
 {
 	OutputDebugString("Python Extension Module - CyGlobalContextPythonInterface1\n");
 	inst
+		.def("getPlayerOptionDescription", &CyGlobalContext::getPlayerOptionDescription, "wstring (int iOption) - the option's label")
+		.def("getPlayerOptionHelp", &CyGlobalContext::getPlayerOptionHelp, "wstring (int iOption) - the option's hover text")
+		.def("getGraphicOptionDescription", &CyGlobalContext::getGraphicOptionDescription, "wstring (int iOption) - the option's label")
+		.def("getGraphicOptionHelp", &CyGlobalContext::getGraphicOptionHelp, "wstring (int iOption) - the option's hover text")
+
 		.def("getGame", &CyGlobalContext::getCyGame, boost::python::return_value_policy<boost::python::reference_existing_object>(), "() - CyGame()")
 		.def("getMap", &CyGlobalContext::getCyMap, boost::python::return_value_policy<boost::python::reference_existing_object>(), "() - CyMap()")
 		.def("getPlayer", &CyGlobalContext::getCyPlayer, boost::python::return_value_policy<boost::python::reference_existing_object>(), "(iPlayer) - iPlayer instance")

--- a/Sources/Python/CyGlobalContext.cpp
+++ b/Sources/Python/CyGlobalContext.cpp
@@ -59,6 +59,27 @@ int CyGlobalContext::getInfoTypeForString(const char* szInfoType, bool bHideAsse
 // data rather than a new method.
 
 
+std::wstring CyGlobalContext::getPlayerOptionDescription(int iOption) const
+{
+	return GC.getPlayerOptionInfo((PlayerOptionTypes)iOption).getDescription();
+}
+
+std::wstring CyGlobalContext::getPlayerOptionHelp(int iOption) const
+{
+	return GC.getPlayerOptionInfo((PlayerOptionTypes)iOption).getHelp();
+}
+
+std::wstring CyGlobalContext::getGraphicOptionDescription(int iOption) const
+{
+	return GC.getGraphicOptionInfo((GraphicOptionTypes)iOption).getDescription();
+}
+
+std::wstring CyGlobalContext::getGraphicOptionHelp(int iOption) const
+{
+	return GC.getGraphicOptionInfo((GraphicOptionTypes)iOption).getHelp();
+}
+
+
 CyGame* CyGlobalContext::getCyGame() const
 {
 	static CyGame cyGame(GC.getGame());

--- a/Sources/Python/CyGlobalContext.h
+++ b/Sources/Python/CyGlobalContext.h
@@ -45,6 +45,16 @@ public:
 
 	int getNumCivilizationInfos() const { return GC.getNumCivilizationInfos(); }   // the correctly-spelled twin
 
+	// PLAYER + GRAPHIC OPTIONS are SETTINGS, so they are served here rather than by CyInfo, which answers
+	// ENTITY data (CyInfo.h states the split). The options screen needs a label and a hover text per option and
+	// is handed those two strings; it is NOT handed the info object, which is the legacy escape hatch the
+	// rebuild closed. Their infos are XML-loaded and have no InfoRepo home, so the prefix plane cannot route
+	// them at all.
+	std::wstring getPlayerOptionDescription(int iOption) const;
+	std::wstring getPlayerOptionHelp(int iOption) const;
+	std::wstring getGraphicOptionDescription(int iOption) const;
+	std::wstring getGraphicOptionHelp(int iOption) const;
+
 	// The Cy* HANDLES. NOT infos -- they are the game-object wrappers the engine already hands to Python
 	// callbacks, so the ruling that this class serves no INFOS does not reach them. Cutting them was an
 	// over-reach: getPlayer/getTeam/getMap/getGame are the most-called names in the whole tree.


### PR DESCRIPTION
Fixes #469.

Three separate defects reported together, each named outright by the logs on the issue. **None is Linux-specific** — Wine only makes the third fatal instead of merely wrong.

## 1. The options menu drew empty

```
CvOptionsScreen line 288, drawGameOptionsTab
AttributeError: 'CyGlobalContext' object has no attribute 'getPlayerOptionsInfo'
```

The name is gone — wrapper and registration both — so the screen throws while drawing its first tab and renders nothing.

Player and graphic options are **settings**, so they are served on the global context, which is where `CyInfo.h` itself says settings belong: *"a script wanting a SETTING asks the global context; a script wanting ENTITY DATA asks here."* `CyInfo` could not route these anyway — their infos are XML-loaded with no `InfoRepo` home, so the prefix plane has no entry for them.

The screen is handed the **two strings it actually uses** — a label and a hover text per option — and *not* the info object. Handing the object back is the legacy escape hatch the rebuild deliberately closed, and it would have required publishing two further info classes to script.

## 2. Clicks did nothing while ESC and ENTER worked

```
CvCivicsScreen line 479, handleInput
ValueError: invalid literal for int(): b
```

```python
if NAME.startswith("Civic_Tab"):
    self.iTab = int(NAME[-1])
```

The tabs are `Civic_Tab0`/`Civic_Tab1`, but `startswith` also matches the bare container `Civic_Tab`, whose last character is `b`. The handler raises, so the screen never processes the click — while ESC and ENTER keep working because the EXE handles those itself.

**That asymmetry is the whole reason this reads as a mouse or window-manager problem rather than a Python one.** Only the numbered tabs carry an index, so the guard now says so.

## 3. Founding a city killed the process

```
[INFOPLANE] UNLOADED READ registry=CvCultureLevelInfo id=-1 mapped=19
```

That is **our own** diagnostic, and it fails in *every* config by design. A city with no culture yet answers `NO_CULTURELEVEL`, and four reads passed that `-1` straight to `getCultureLevelInfo`: the three wonder caps and the culture-distance walk.

`getCityRadius` sits beside them already guarding it, and its comment states the intended answer — `NO_CULTURELEVEL` reads as `CULTURELEVEL_NONE`, the entry that authors what "no culture yet" means (`worldWonders: 1`, `teamWonders: 1`, `nationalWonders: 2`, radius 2).

Resolved in **one** place rather than four guards, so a fifth read cannot reintroduce it, and the id is looked up **by name** rather than assuming the NONE level sits at index 0.

## Verification

- `Assert rebuild` green.
- `verify-python24` clean (229 files) — the embedded interpreter is 2.4, and `.isdigit()` is 2.4-safe.
- `verify-python-callbacks` clean (457 XML files against 1644 functions).
- No remaining caller of `getPlayerOptionsInfo` / `getGraphicOptionsInfo` anywhere in `Assets/Python`, `PrivateMaps` or `PublicMaps`.

⛔ **NOT PLAYTESTED.** Worth checking in this order, since each is independent: open the options menu (should populate), click a civics tab with the mouse, then found a city.

## Note

The reporter also could not click the **tech tree** and the **leader intro**. Only the civics screen produced a traceback, so those two are not proven fixed by this. If they persist after 2 lands, they are a separate cause and should not be assumed covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
