### PR TITLE
fix(#471): a process paid fifty times the hammers instead of half

### DIFF
--- a/Sources/AI/CvCityAI.cpp
+++ b/Sources/AI/CvCityAI.cpp
@@ -6901,7 +6901,9 @@ int64_t CvCityAI::AI_processValue(ProcessTypes eProcess, CommerceTypes eCommerce
 		{
 			continue;
 		}
-		int64_t iTempValue = GC.getProcessInfo(eProcess).getProductionToCommerce(eCommerce, CASC_SCOPE_CITY);
+		// The authored PERCENT, reduced from its ×100 storage. The divisor below accounts for the commerce
+		// WEIGHT's ×100 only ("60 * 100"), so leaving this operand scaled valued every process a hundredfold.
+		int64_t iTempValue = GC.getProcessInfo(eProcess).getProductionToCommerce(eCommerce, CASC_SCOPE_CITY) / 100;
 
 		iTempValue *= GET_PLAYER(getOwner()).AI_commerceWeight(eCommerce, this); // scaled by 100 at this point
 		if (iTempValue == 0) continue; // weight may very well be 0 if commerce is worthless.

--- a/Sources/AI/CvPlayerAI.cpp
+++ b/Sources/AI/CvPlayerAI.cpp
@@ -5418,7 +5418,9 @@ int CvPlayerAI::AI_techValue(TechTypes eTech, int iPathLength, bool bIgnoreCost,
 
 		for (int iK = 0; iK < NUM_COMMERCE_TYPES; iK++)
 		{
-			iTempValue = (GC.getProcessInfo(eLoopProcess).getProductionToCommerce((CommerceTypes)iK, CASC_SCOPE_CITY) * 4);
+			// The authored PERCENT, reduced from its ×100 storage -- the ÷100 below accounts for the commerce
+			// WEIGHT's scale, not this operand's.
+			iTempValue = (GC.getProcessInfo(eLoopProcess).getProductionToCommerce((CommerceTypes)iK, CASC_SCOPE_CITY) / 100 * 4);
 
 			iTempValue *= AI_commerceWeight((CommerceTypes)iK);
 			iTempValue /= 100;

--- a/Sources/Data/CvInfoValuation.cpp
+++ b/Sources/Data/CvInfoValuation.cpp
@@ -715,9 +715,11 @@ int64_t InfoValuation::commerceSplit(int64_t commerceYieldRate, int iSliderPerce
 		iModifier = 0;
 	}
 	// TIER 2 -- the process conversion, added AFTER the percentages and never multiplied by them. The production
-	// yield truncates to whole hammers BEFORE the conversion scales it (the engine's order, mirrored verbatim);
-	// the conversion rate is ×100, so it de-scales to the authored human percent.
-	int64_t iProcessConversion = (productionYieldRate / 100) * ((int64_t)iProductionToCommerce / 100);
+	// yield truncates to whole hammers BEFORE the conversion scales it (the engine's order, mirrored verbatim).
+	// ⚠ The rate is an authored PERCENT carried ×100, so reducing it needs ÷100 for the fixed point AND ÷100 for
+	// the percent. Only the first was applied, so a 50% process paid FIFTY times the hammers instead of half.
+	// Reduced ONCE here, at the read edge, so the authored two decimals survive the multiply.
+	int64_t iProcessConversion = (productionYieldRate / 100) * (int64_t)iProductionToCommerce / 10000;
 	const int64_t iRate = iShare * iModifier / 100 + channelDeposits + iProcessConversion;
 	if (pTerms != NULL)
 	{


### PR DESCRIPTION
Fixes #471.

## The arithmetic

The conversion rate is an authored **percent** — `process_research.json` says `conversion: { research: 50 }`, meaning *half* the hammers — and it is stored ×100 like every other authored magnitude, so the member holds `5000`.

Reducing it therefore needs **two** divisions: one for the fixed point, one for the percent. Only the first was there.

```cpp
// before
(productionYieldRate / 100) * (iProductionToCommerce / 100)
   = hammers * 50          // fifty times the hammers

// after
(productionYieldRate / 100) * iProductionToCommerce / 10000
   = hammers * 50 / 100    // half the hammers
```

A hundredfold, which is exactly the reported magnitude: a 300-beaker tech finishing in one turn from 150 remaining, on a city making 30 a turn, with change left for another tech.

Reduced **once**, at the read edge, so the two decimals the ×100 model carries survive the multiply instead of being truncated away before it. The hammer truncation stays ahead of the conversion, which is the engine's own order.

## The same operand is mis-scaled in the AI's process valuation

Same defect, not a second one. Both sites divide by a constant that accounts for the commerce **weight's** ×100 and not for this operand's, so every process scored a hundredfold high against buildings and units:

| site | divisor | comment |
|---|---|---|
| `CvCityAI::AI_processValue` | `/ 6000` | literally `// 60 * 100` |
| `CvPlayerAI` unlocked-process valuation | `/ 100` after the weight | — |

The surviving fudge factor is the tell: the divisor is legacy expectation meeting the ×100 surface at an AI call site, so the **read** is what gets re-pointed, never the constant.

⚠ Worth knowing when judging AI behaviour: this made processes look far more attractive than building anything. I have **not** claimed it explains any particular AI report — but it is a real thumb on that scale and it is now off.

## Two readers checked and left alone

This is what confirms the human percent is the intended reading rather than my guess:

- the gold+research check is `> 0` — a presence test no scale can reach;
- the culture-greed read already applies its own `/ 100`.

## Verification

- `Assert rebuild` green.
- Worked by hand against the authored data: `50` → stored `5000` → `5000 / 10000` = half the hammers.

⛔ **NOT PLAYTESTED.** The reporter's save is attached to the issue. Verify by running a research process for one turn and confirming the beakers gained are roughly half the city's hammers, not fifty times them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
