### PR TITLE
fix(#472): Might deposited its strength into a family nothing reads

### DIFF
--- a/Assets/Data/promotions/promotion_might1.json
+++ b/Assets/Data/promotions/promotion_might1.json
@@ -1,6 +1,6 @@
 {
  "type": "PROMOTION_MIGHT1",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 1
   }

--- a/Assets/Data/promotions/promotion_might10.json
+++ b/Assets/Data/promotions/promotion_might10.json
@@ -1,6 +1,6 @@
 {
  "type": "PROMOTION_MIGHT10",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 15
   }

--- a/Assets/Data/promotions/promotion_might11.json
+++ b/Assets/Data/promotions/promotion_might11.json
@@ -1,6 +1,6 @@
 {
  "type": "PROMOTION_MIGHT11",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 20
   }

--- a/Assets/Data/promotions/promotion_might12.json
+++ b/Assets/Data/promotions/promotion_might12.json
@@ -1,6 +1,6 @@
 {
  "type": "PROMOTION_MIGHT12",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 25
   }

--- a/Assets/Data/promotions/promotion_might13.json
+++ b/Assets/Data/promotions/promotion_might13.json
@@ -1,6 +1,6 @@
 {
  "type": "PROMOTION_MIGHT13",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 30
   }

--- a/Assets/Data/promotions/promotion_might2.json
+++ b/Assets/Data/promotions/promotion_might2.json
@@ -1,6 +1,6 @@
 {
  "type": "PROMOTION_MIGHT2",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 1
   }

--- a/Assets/Data/promotions/promotion_might3.json
+++ b/Assets/Data/promotions/promotion_might3.json
@@ -1,6 +1,6 @@
 {
  "type": "PROMOTION_MIGHT3",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 2
   }

--- a/Assets/Data/promotions/promotion_might4.json
+++ b/Assets/Data/promotions/promotion_might4.json
@@ -1,6 +1,6 @@
 {
  "type": "PROMOTION_MIGHT4",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 2
   }

--- a/Assets/Data/promotions/promotion_might5.json
+++ b/Assets/Data/promotions/promotion_might5.json
@@ -1,6 +1,6 @@
 {
  "type": "PROMOTION_MIGHT5",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 3
   }

--- a/Assets/Data/promotions/promotion_might6.json
+++ b/Assets/Data/promotions/promotion_might6.json
@@ -1,6 +1,6 @@
 {
  "type": "PROMOTION_MIGHT6",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 4
   }

--- a/Assets/Data/promotions/promotion_might7.json
+++ b/Assets/Data/promotions/promotion_might7.json
@@ -1,6 +1,6 @@
 {
  "type": "PROMOTION_MIGHT7",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 5
   }

--- a/Assets/Data/promotions/promotion_might8.json
+++ b/Assets/Data/promotions/promotion_might8.json
@@ -1,6 +1,6 @@
 {
  "type": "PROMOTION_MIGHT8",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 7
   }

--- a/Assets/Data/promotions/promotion_might9.json
+++ b/Assets/Data/promotions/promotion_might9.json
@@ -1,6 +1,6 @@
 {
  "type": "PROMOTION_MIGHT9",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 10
   }

--- a/Tools/Migration/curate_promotion.py
+++ b/Tools/Migration/curate_promotion.py
@@ -57,11 +57,13 @@ from store import Store, REPO
 
 # ---- scalar deposits: tag -> (member|None, unit). All at `unit` scope (self-accumulator, §5). ----
 # The `combat` family = everything that MODIFIES the unit's base strength (ruling 5, info-rebuild.md):
-# general % + flat + situational members + the TB/S&D sub-stats. A promotion never authors `strength`
-# (that family holds ONLY a unit's base value, strength.unit.flat).
+# general % + situational members + the TB/S&D sub-stats.
+# ⛔ A FLAT STRENGTH DELTA IS NOT IN THIS FAMILY -- iStrengthChange lives in FAMILIES below, on `strength`.
+# The engine reads `combat` at PERCENT only (URS_STRENGTH_PERCENT), so a flat deposit here has no reader at
+# all and the promotion does nothing. `strength.unit.flat` is the DELTA channel by design: the gather excludes
+# the unit's own TYPE from it, and baseCombatStr is m_iBaseCombat100 + resolvedValue(URS_STRENGTH_FLAT).
 COMBAT_MODS = {
     "iCombatPercent":               (None, "percent"),        # general combat strength %
-    "iStrengthChange":              (None, "flat"),           # flat strength points
     "iAttackCombatModifierChange":  ("attack", "percent"),
     "iDefenseCombatModifierChange": ("defense", "percent"),
     "iVSBarbsChange":               ("vsBarbs", "percent"),
@@ -86,6 +88,7 @@ COMBAT_MODS = {
 }
 # other families: tag -> (family, member|None, unit)
 FAMILIES = {
+    "iStrengthChange":              ("strength", None, "flat"),   # the flat strength DELTA (URS_STRENGTH_FLAT)
     "iWithdrawalChange":            ("withdrawal", None, "percent"),
     "iFirstStrikesChange":          ("firstStrike", "strikes", "flat"),
     "iChanceFirstStrikesChange":    ("firstStrike", "chance", "flat"),


### PR DESCRIPTION
Fixes #472.

## What was wrong

Every Might rank authored `combat.unit.flat`:

```json
{ "type": "PROMOTION_MIGHT1", "combat": { "unit": { "flat": 1 } } }
```

The engine reads the combat family at **percent only** — `URS_STRENGTH_PERCENT` is `(MODFAM_COMBAT, COMBAT_AMOUNT, CASC_UNIT_PERCENT)`. A *flat* deposit there has no reader at all, so all thirteen ranks were inert: the promotion applied, the icon showed, the strength never moved.

## Where it belongs — and it already exists

`URS_STRENGTH_FLAT` reads `strength.unit.flat` and is **delta-only by design**: the gather deliberately excludes the unit's own type, because a unit's base is per-unit state that WorldBuilder edits and the save persists. So:

```cpp
int iStr = m_iBaseCombat100 + resolvedValue(URS_STRENGTH_FLAT);
```

Base plus delta, summed over the held promotions and combat classes by the unit's own resolved context — exactly the summation a +X-strength-per-level promotion needs, with no new slot and no engine change.

The legacy tag says the same thing outright: `<iStrengthChange>1</iStrengthChange>`.

## Why the data was wrong

A curator mis-home, not a design question. `curate_promotion.py` asserted in a comment that *"a promotion never authors `strength` (that family holds ONLY a unit's base value, strength.unit.flat)"* — which is the opposite of what the engine implements, since that family's flat leg is precisely the delta channel and the unit's type is excluded from it. The tree outranks the comment.

Fixed at the **curator** and regenerated, since the JSON is derived and right-or-wrong lives in the curator.

## Scope

Exactly **13 files** — the whole Might line and nothing else, which is also why the report named Might specifically. Regeneration is idempotent: 1212 written, 13 changed.

```diff
 {
  "type": "PROMOTION_MIGHT1",
- "combat": {
+ "strength": {
   "unit": {
    "flat": 1
```

⚠ **No engine change.** `combat.unit.flat` still has no reader, and that stays correct — `combat` *modifies* the base and does so as a percent. What was wrong was the address, not the plane.

⛔ **NOT PLAYTESTED.** Verify by taking a unit to level 3, granting Might I, and confirming its strength rises by 1 — then a higher rank for the larger steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
