### PR TITLE
fix(#478, #475): every unit had one hit point; founding crash; every close button dead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,6 +375,47 @@ not findings to re-discover.
   THRESHOLD, so it is incidental rather than a competing objective the AI could steer by. Modelling it buys no
   better decision at per-(route × improvement) cost on a hot loop.
 
+### AI valuation of STRENGTH — a valuation that cannot tell strengths apart is FIXED, never filed
+
+- **⛔ AN AI VALUATION DEFECT THAT UNDERVALUES STRENGTH IS SOLVED IN THE WORK ITEM THAT FINDS IT (owner): it
+  *"should be solved, otherwise AI will permanently undervalue strength, and would be a chief source of low cost
+  unit spam."*** ⚑ This is the one place where the standing "the AI side is a consumer, out of active scope"
+  framing ([north-star.md](docs/architecture/north-star.md)) does NOT license leaving it — an AI that cannot
+  rank strength does not merely tune badly, it stops choosing on strength at all, which is the behaviour-break-
+  wearing-a-balance-costume class ([fixed-point-and-scales.md §5](docs/specs/curators/fixed-point-and-scales.md)).
+  ⇒ "That's AI weighting, so it comes after correctness" is NOT a reason to defer one
+  (["deferred" is banned](#design)).
+- **⛔ THE FAILURE SHAPE IS A CHOICE THAT DOES NOT VARY WITH STRENGTH — look for it at the RANKING, not in the
+  formula.** `AI_unitValue` does weigh strength: it multiplies nearly every term by
+  `CvGameAI::AI_combatValue`, which is linear in the unit's own strength. So a strength-blind AI decision is
+  almost never a missing term — it is a call site that never lets the value decide. Two proven instances:
+  - **`AI_unitValue` returns 0 for EVERY unit under a great-person UNITAI.** `UNITAI_GREAT_HUNTER` and its
+    siblings (`PROPHET`/`ARTIST`/`SCIENTIST`/`GENERAL`/`GREAT_ADMIRAL`/`MERCHANT`/`ENGINEER`/`SPY`/
+    `ATTACK_CITY_LEMMING`) fall through the validity switch leaving `bValid` false, so the function returns 0
+    before scoring. Correct for production (they are not trainable roles) and **silently degenerate anywhere
+    that RANKS with it** — every candidate ties at 0. ⇒ Where a role scores everything 0, rank the candidate as
+    the unit it will actually BE (its `getDefaultUnitAI()`).
+  - **`CvUnitAI::AI_upgrade` picked the upgrade with a die roll.** `AI_unitValue` was only a `>=` admission
+    filter and the winner came from `getSorenRandNum(1000, "AI Upgrade")` — so strength contributed NOTHING to
+    which unit a chain upgraded into. ⚑ The correct idiom is twenty lines below it in the same file:
+    `AI_promote` ranks on `AI_promotionValue`.
+- **⛔ THE DRAW STAYS — DEMOTE IT TO A TIE-BREAK, NEVER DELETE IT.** The number and order of draws on the
+  synchronized stream is shared game state
+  ([engine.md](docs/reference/engine.md#-the-synchronized-rng-is-shared-save-state--do-not-touch-the-draws-owner)),
+  so a strength-blind `getSorenRandNum` pick is repaired by keeping the draw exactly where it is — one per
+  admitted candidate, same order, same label — and letting it settle only an exact tie. ⚠ And keep the ADMISSION
+  test byte-identical: a candidate that newly passes the filter is a new draw, so a fallback valuation must be
+  gated on the degenerate case rather than applied to every candidate.
+- **⚑ TWO THINGS VERIFIED, so they are not re-tread as suspects.** (1) **Every authored unit strength is a whole
+  number** (1583 of 1583), so `AI_combatValue`'s `strength / 100` truncates nothing on real data — it is a latent
+  [a CALCULATION never scales](docs/specs/curators/fixed-point-and-scales.md#2-the-unit-table-what-readjson-does)
+  violation that belongs to the §4c-ter cluster pass, NOT today's balance defect. ⛔ Do not "fix" it by converting
+  `getBestLandUnitCombat()` alone: two sites already lift it back with `100 *`, and the air sites read the genuinely
+  human `getAirCombat()`, so a lone conversion manufactures fresh fudge factors and fails the cluster gate.
+  (2) **`CvCityAI::AI_bestUnit` has NO cost term** — it takes the highest `AI_unitValue` outright — so unit spam
+  can never originate in a value-per-hammer ratio there; it originates in value failing to DISCRIMINATE, or in the
+  needed-counts ([parked/unit-ai-valuation.md](docs/plans/parked/unit-ai-valuation.md)).
+
 ### The CONTRACT BROKER — matching is THREE STAGES, and distance never scores
 
 - **⛔ DISTANCE IS A GATE AND A TIE-BREAK, NEVER A TERM IN THE SCORE (owner): *"I am in general very reticent

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -687,6 +687,12 @@ the total-observability bar below.)
 - **⛔ LEAVE NO EVIDENCE OF THE ABANDONED PATH (owner).** Dead and
   commented-out code, superseded dual surfaces, transitional shims and `was X` / `(formerly …)` trails are all
   REMOVED, in code as well as docs.
+  **⛔ THE ONE CARVE-OUT IS AN EXE-BOUND ENUM ORDINAL — a dead member of a core enum STAYS, inert (owner).** The
+  closed EXE hardcodes certain enum VALUES, so removing any member ABOVE one shifts it and every entry after it;
+  being unreferenced is precisely what makes it look safe to take, and the compiler cannot see an ordinal move.
+  *(Measured: one such deletion turned off every close button in the game.)* The rule, the failure signature and
+  how to pin an ordinal so the next removal is a COMPILE error:
+  [a core enum entry is never removed](docs/reference/engine.md#-an-exe-bound-enums-ordinal-is-an-abi-obligation--never-remove-a-member-above-one-owner).
   **⚖ FOR AN `#ifdef` THE QUESTION IS WHAT IS BEHIND IT, NEVER THE GUARD (owner): *"some ifdefs are useful, but
   if caching, or game mechanics are hidden behind ifdefs, instead of legitimate game options, that is what is
   wrong."*** Four dispositions, and only the last is mechanical:

--- a/Assets/Python/Screens/Advisors/CvReligionScreen.py
+++ b/Assets/Python/Screens/Advisors/CvReligionScreen.py
@@ -219,7 +219,7 @@ class CvReligionScreen:
 			if GAME.getReligionGameTurnFounded(iRel) >= 0:
 				screen.addCheckBoxGFCAt(szArea, szButtonName, INFO.getButton("RELIGION_", iRel), ArtFileMgr.getInterfaceArtInfo("BUTTON_HILITE_SQUARE").getPath(), self.X_SCROLLABLE_RELIGION_AREA + xLoop - 25, self.Y_SCROLLABLE_RELIGION_AREA + 5, self.BUTTON_SIZE, self.BUTTON_SIZE, WidgetTypes.WIDGET_GENERAL, -1, -1, ButtonStyles.BUTTON_STYLE_LABEL, False)
 			else:
-				screen.setImageButtonAt(szButtonName, szArea, GC.getReligionInfo(iRel).getButtonDisabled(), self.X_SCROLLABLE_RELIGION_AREA + xLoop - 25, self.Y_SCROLLABLE_RELIGION_AREA + 5, self.BUTTON_SIZE, self.BUTTON_SIZE, WidgetTypes.WIDGET_GENERAL, -1, -1)
+				screen.setImageButtonAt(szButtonName, szArea, INFO.getReligionButtonDisabled(iRel), self.X_SCROLLABLE_RELIGION_AREA + xLoop - 25, self.Y_SCROLLABLE_RELIGION_AREA + 5, self.BUTTON_SIZE, self.BUTTON_SIZE, WidgetTypes.WIDGET_GENERAL, -1, -1)
 			szName = self.getReligionTextName(iRel)
 			szLabel = INFO.getDescription("RELIGION_", iRel)
 			screen.setLabelAt(szName, szArea, szLabel, 1<<2, self.X_SCROLLABLE_RELIGION_AREA + xLoop, self.Y_RELIGION_NAME, self.DZ, FontTypes.GAME_FONT, WidgetTypes.WIDGET_GENERAL, -1, -1)

--- a/Assets/Python/Screens/CvOptionsScreen.py
+++ b/Assets/Python/Screens/CvOptionsScreen.py
@@ -11,6 +11,7 @@ import TextUtil
 # ENUMS = the engine enum vocabulary + name->id resolution.
 GC = CyGlobalContext()
 gc = GC   # this module spells it lowercase
+INFO = CyInfo()
 STATE = CyState()
 ENABLER = CyEnabler()
 ENUMS = CyEnums()
@@ -285,8 +286,8 @@ class CvOptionsScreen:
 
 			if (bContinue):
 
-				szOptionDesc = gc.getPlayerOptionDescription(iOptionLoop)
-				szHelp = gc.getPlayerOptionHelp(iOptionLoop)
+				szOptionDesc = INFO.getDescription("PLAYEROPTION_", iOptionLoop)
+				szHelp = INFO.getHelp("PLAYEROPTION_", iOptionLoop)
 				szCallbackFunction = "handleGameOptionsClicked"
 				szWidgetName = "GameOptionCheckBox_" + str(iOptionLoop)
 				bOptionOn = UserProfile.getPlayerOption(iOptionLoop)
@@ -489,8 +490,8 @@ class CvOptionsScreen:
 
 		# Checkboxes
 		for iOptionLoop in range(GraphicOptionTypes.NUM_GRAPHICOPTION_TYPES):
-			szOptionDesc = gc.getGraphicOptionDescription(iOptionLoop)
-			szHelp = gc.getGraphicOptionHelp(iOptionLoop)
+			szOptionDesc = INFO.getDescription("GRAPHICOPTION_", iOptionLoop)
+			szHelp = INFO.getHelp("GRAPHICOPTION_", iOptionLoop)
 			szCallbackFunction = "handleGraphicOptionsClicked"
 			szWidgetName = "GraphicOptionCheckbox_" + str(iOptionLoop)
 			bOptionOn = UserProfile.getGraphicOption(iOptionLoop)

--- a/Assets/Python/Screens/CvOptionsScreen.py
+++ b/Assets/Python/Screens/CvOptionsScreen.py
@@ -310,7 +310,7 @@ class CvOptionsScreen:
 		tab.attachSpacer("LangHBox")
 
 		aszDropdownElements = ()
-		for i in range(CvGameText.getNumLanguages()):
+		for i in range(CyGame().getNumLanguages()):
 			szKey = "TXT_KEY_LANGUAGE_%d" % i
 			aszDropdownElements = aszDropdownElements + (localText.getText(szKey, ()),)
 

--- a/Sources/AI/CvUnitAI.cpp
+++ b/Sources/AI/CvUnitAI.cpp
@@ -1025,22 +1025,44 @@ bool CvUnitAI::AI_upgrade()
 
 		UnitTypes eBestUnit = NO_UNIT;
 		int iBestValue = -1;
+		int iBestTieBreak = -1;
+
+		// A great-person role -- UNITAI_GREAT_HUNTER and its siblings -- is not a trainable role, so
+		// AI_unitValue scores EVERY unit at 0 under it. That makes the whole chain tie, which is what left the
+		// pick to the draw below. Where the role itself is degenerate, rank each candidate as the unit it will
+		// actually BE; the role filter above still holds the unit to its own role (the TB note).
+		const bool bRankAsTargetRole = (iCurrentValue == 0);
 
 		foreach_(int iUnitX, upgradeChain)
 		{
 			const UnitTypes eUnitX = (UnitTypes)iUnitX;
 
-			if (!GC.getUnitInfo(eUnitX).hasNotUnitAI(eUnitAI)
-			&& canUpgrade(eUnitX)
-			&& kPlayer.AI_unitValue(eUnitX, eUnitAI, pArea) >= iCurrentValue)
+			if (GC.getUnitInfo(eUnitX).hasNotUnitAI(eUnitAI) || !canUpgrade(eUnitX))
 			{
-				const int iValue = GC.getGame().getSorenRandNum(1000, "AI Upgrade");
+				continue;
+			}
+			const int iRoleValue = kPlayer.AI_unitValue(eUnitX, eUnitAI, pArea);
 
-				if (iValue > iBestValue)
-				{
-					iBestValue = iValue;
-					eBestUnit = eUnitX;
-				}
+			if (iRoleValue < iCurrentValue)
+			{
+				continue;
+			}
+			// The draw keeps its place, its order and its label -- it decides only an exact tie now, because the
+			// STRENGTH of the candidate has to be what picks the upgrade (docs/reference/engine.md owns why the
+			// draw may not simply be deleted).
+			const int iTieBreak = GC.getGame().getSorenRandNum(1000, "AI Upgrade");
+			int iUpgradeValue = iRoleValue;
+
+			if (bRankAsTargetRole)
+			{
+				iUpgradeValue = kPlayer.AI_unitValue(eUnitX, GC.getUnitInfo(eUnitX).getDefaultUnitAI(), pArea);
+			}
+
+			if (iUpgradeValue > iBestValue || iUpgradeValue == iBestValue && iTieBreak > iBestTieBreak)
+			{
+				iBestValue = iUpgradeValue;
+				iBestTieBreak = iTieBreak;
+				eBestUnit = eUnitX;
 			}
 		}
 		if (eBestUnit != NO_UNIT)

--- a/Sources/Defines/CvEnums.h
+++ b/Sources/Defines/CvEnums.h
@@ -466,6 +466,16 @@ enum WidgetTypes
 	WIDGET_HELP_HEALTH_RATE,
 	WIDGET_HELP_HAPPINESS_RATE,
 	WIDGET_HELP_FREE_TECH,
+	//	⛔ INNATE AND PERMANENT -- NEVER REMOVE, REORDER OR REUSE, whatever the authored data does.
+	//	This slot's ORDINAL is load-bearing: the EXE hardcodes WIDGET_CLOSE_SCREEN's numeric value (see its own
+	//	comment below), so deleting ANY member above it shifts that value and every one after it. The DLL then
+	//	sends a number the EXE does not recognise as "close" and EVERY close button in the game stops responding
+	//	-- silently, with ESC still working because that is the keyboard path, not the widget path.
+	//	⚠ It is exactly the shape that reads as safe: no code referenced this widget, so removing it looked like
+	//	an ordinary dead-surface cut. Above WIDGET_CLOSE_SCREEN a dead member is still an ABI obligation, and the
+	//	compiler cannot see it -- which is why CvDLLWidgetData.cpp pins the ordinal with a STATIC_ASSERT beside
+	//	the case that consumes it. If that assert fires, a member above here moved: put it back.
+	WIDGET_HELP_LOS_BONUS,
 	WIDGET_HELP_MAP_CENTER,
 	WIDGET_HELP_MAP_REVEAL,
 	WIDGET_HELP_MAP_TRADE,

--- a/Sources/Enabler/CvBuildingEnabler.cpp
+++ b/Sources/Enabler/CvBuildingEnabler.cpp
@@ -212,7 +212,12 @@ static bool bd_categoryCapOk(int iB, const CvCity& kCity)
 	{
 		return true;
 	}
-	const CvCultureLevelInfo& kLevel = GC.getCultureLevelInfo(kCity.getCultureLevel());
+	// ⛔ cultureLevelForRead, NEVER getCultureLevel. A city with no culture answers NO_CULTURELEVEL and the info
+	// plane holds no entry at -1, so the raw read is an UNLOADED READ and aborts the process (patterns.md
+	// §WRITE-ONCE-AT-LOAD). A city is FOUNDED with no culture, so this fired on every founding outside the load
+	// bracket. It is also the ONE implementation of that read -- the three CvCity::getMaxNum*Wonders getters
+	// already go through it, so reading the level raw here answered a different question than the city did.
+	const CvCultureLevelInfo& kLevel = GC.getCultureLevelInfo(kCity.cultureLevelForRead());
 	// world / team / empire self-cap -> world / team / NATIONAL wonder, in that order.
 	if (a->cap(ALLOWEDCAP_WORLD) >= 0)
 	{

--- a/Sources/Enabler/CvEnablerConsumer.cpp
+++ b/Sources/Enabler/CvEnablerConsumer.cpp
@@ -621,11 +621,10 @@ private:
 			// A heritage is a HAVE axis the player holds but NOT an enabler DOMAIN (nothing offers heritages through
 			// the frontier -- they arrive by mission), so it re-gates its dependents and applies no edges.
 			// ⛔ SKIPPED INSIDE THE LOAD BRACKET, and this is not optional. Every fact here fires from
-			// CvPlayer::read / CvCity::read, where the city's other slots have NOT landed yet -- and unlike the
-			// small gate classes beside it, GATE_DYNAMIC contains the CAPPED buildings, so gating one mid-read
-			// reaches the wonder-category cap and reads GC.getCultureLevelInfo(NO_CULTURELEVEL): a fail-loud
-			// info-plane read that kills the load (docs/architecture/patterns.md §WRITE-ONCE-AT-LOAD). The load-end pass gates every city
-			// once after the stream ends, which is the par.7.1 order rule's second option and covers all of this.
+			// CvPlayer::read / CvCity::read, where the city's other slots have NOT landed yet, so a verdict
+			// gated here is evaluated against half-deserialized state. enabler.md §7.1 admits exactly two
+			// shapes -- every event's re-gates apply as they arrive, or gating runs once after the stream ends
+			// -- and bans the MIX; the load-end pass is that second option and covers all of this.
 			if (spineGameLoadInProgress()) break;
 			if (kEvent.iC >= 0 && kEvent.iC < MAX_PLAYERS)
 			{
@@ -644,7 +643,7 @@ private:
 		case SEVT_CITY_AMENITY_REMOVED:
 		{
 			// The city-scope twins of the above: one city's designation moved, so only that city re-gates.
-			// Same load-bracket skip, same reason (the capped buildings' culture-level read).
+			// Same load-bracket skip, same reason (gating against half-deserialized state; enabler.md §7.1).
 			if (spineGameLoadInProgress()) break;
 			const CvCity* pCity = cityForEvent(kEvent.iC, kEvent.iSrcLoc);
 			if (pCity != NULL)
@@ -760,7 +759,8 @@ private:
 		{
 			// ⛔ SKIPPED INSIDE THE LOAD BRACKET. This is the FIRST fact CvCity::read emits -- ownership is
 			// established before population, buildings, religion and culture level -- so a full gate pass here runs
-			// against a city that is barely deserialized, and the capped buildings' culture-level read fails loud.
+			// against a city that is barely deserialized, and every verdict it stores is computed from state the
+			// stream has not delivered yet.
 			// A conquest in PLAY is what this route is for; the loaded state is the load-end pass's job.
 			if (spineGameLoadInProgress()) break;
 			const CvCity* pCity = cityForEvent(kEvent.iC, kEvent.iSrcLoc);

--- a/Sources/Engine/CvUnit.cpp
+++ b/Sources/Engine/CvUnit.cpp
@@ -10272,7 +10272,18 @@ CvCity* CvUnit::getUpgradeCity(bool bSearch) const
 	{
 		const UnitTypes eUnitX = (UnitTypes)iUnitX;
 
-		if (upgradeAvailable(m_eUnitType, eUnitX) && kPlayer.getUnitAvailabilityAnywhere(eUnitX) == EnablerDomain::STATE_LISTED
+		// ⛔ AN UPGRADE ASKS CAN-I-EVER PLUS THE TARGET'S OWN `requires` -- NEVER THE QUEUE-OFFER VERDICT.
+		// STATE_LISTED means "offered in the production queue right now", and a unit the queue never offers can
+		// never reach it: `identity.spawnOnly` (legacy's iCost == -1 sentinel) excludes a unit from the trainable
+		// set outright (enabler.md par.3). That is exactly what marks a great-person master unit, so gating the
+		// upgrade on LISTED made every great-person CONVERSION impossible -- 49 units, the whole MASTER_SAILOR_*
+		// chain and MASTER_HUNTER -> MASTER_RANGER -> MASTER_WARDEN among them -- while JOIN kept working,
+		// because JOIN is a grants payload that never asks the enabler.
+		// ⚠ An upgrade is a TRANSFORMATION, not a creation (triggers.md: `modifyUnit` stands a successor up in
+		// place of a predecessor and is deliberately NOT the createUnit step), so the queue's offer has no say in
+		// it. everAvailable answers the whole-game bar; the target's `requires` is asked per CITY below, which is
+		// what keeps the chain gated on research the way the data intends.
+		if (upgradeAvailable(m_eUnitType, eUnitX) && EnablerKernel::everAvailable(EDGEB_UNITS, (int)eUnitX)
 		&& kPlayer.AI_unitValue(eUnitX, eUnitAI, pArea) > iCurrentValue)
 		{
 			int iSearchValue;
@@ -10306,7 +10317,8 @@ CvCity* CvUnit::getUpgradeCity(UnitTypes eUnit, bool bSearch, int* iSearchValue)
 {
 	PROFILE_FUNC();
 
-	if (eUnit == NO_UNIT || !upgradeAvailable(m_eUnitType, eUnit) || GET_PLAYER(getOwner()).getUnitAvailabilityAnywhere(eUnit) != EnablerDomain::STATE_LISTED)
+	// The whole-game bar only (see the chain overload above); the per-city `requires` is asked in the city loops.
+	if (eUnit == NO_UNIT || !upgradeAvailable(m_eUnitType, eUnit) || !EnablerKernel::everAvailable(EDGEB_UNITS, (int)eUnit))
 	{
 		return NULL;
 	}
@@ -10370,7 +10382,9 @@ CvCity* CvUnit::getUpgradeCity(UnitTypes eUnit, bool bSearch, int* iSearchValue)
 					CvArea* pCityArea = bCoastalOnly ? pLoopCity->waterArea() : pLoopCity->area();
 
 					// Toffer, units should not be compelled to travel between areas just to get an upgrade.
-					if ((bIgnoreDistance || pMyArea == pCityArea) && pLoopCity->getUnitAvailability(eUnit) == EnablerDomain::STATE_LISTED)
+					// The target's own `requires` in THIS city -- the tech/resource gate the upgrade chain is meant
+					// to follow -- rather than whether the queue happens to offer it here.
+					if ((bIgnoreDistance || pMyArea == pCityArea) && EnablerKernel::requiresMetInCity(*pLoopCity, EDGEB_UNITS, (int)eUnit))
 					{
 						// if we do not care about distance, then the first match will do
 						if (bIgnoreDistance)
@@ -10405,7 +10419,7 @@ CvCity* CvUnit::getUpgradeCity(UnitTypes eUnit, bool bSearch, int* iSearchValue)
 		CvCity* pClosestCity = GC.getMap().findCity(getX(), getY(), NO_PLAYER, getTeam(), true, bCoastalOnly);
 
 		// If we can train, then return this city (otherwise it will return NULL)
-		if (pClosestCity != NULL && pClosestCity->getUnitAvailability(eUnit) == EnablerDomain::STATE_LISTED)
+		if (pClosestCity != NULL && EnablerKernel::requiresMetInCity(*pClosestCity, EDGEB_UNITS, (int)eUnit))
 		{
 			// did not search, always return 1 for search value
 			iBestValue = 1;

--- a/Sources/Engine/CvUnit.cpp
+++ b/Sources/Engine/CvUnit.cpp
@@ -10317,8 +10317,13 @@ CvCity* CvUnit::getUpgradeCity(UnitTypes eUnit, bool bSearch, int* iSearchValue)
 {
 	PROFILE_FUNC();
 
-	// The whole-game bar only (see the chain overload above); the per-city `requires` is asked in the city loops.
-	if (eUnit == NO_UNIT || !upgradeAvailable(m_eUnitType, eUnit) || !EnablerKernel::everAvailable(EDGEB_UNITS, (int)eUnit))
+	// The whole-game bar and the instance CAP; the per-city `requires` is asked in the city loops below.
+	// ⚠ The cap is not optional here. STATE_LISTED folded THREE tests -- membership, `requires` and `allowed` --
+	// so replacing it with the first two alone silently dropped the cap, and an upgrade is exactly a path that
+	// can breach one: every master unit in the great-person chain is `allowed {empire: 1}`, so converting into a
+	// second one must refuse (enabler.md §4 -- a build is permitted while count(me, scope) < allowed).
+	if (eUnit == NO_UNIT || !upgradeAvailable(m_eUnitType, eUnit) || !EnablerKernel::everAvailable(EDGEB_UNITS, (int)eUnit)
+	|| !EnablerKernel::allowedOk(&GC.getUnitInfo(eUnit), (int)eUnit, GET_PLAYER(getOwner()), /*bUnit*/ true, EDGEB_UNITS))
 	{
 		return NULL;
 	}

--- a/Sources/Engine/CvUnit.cpp
+++ b/Sources/Engine/CvUnit.cpp
@@ -11143,22 +11143,10 @@ int CvUnit::getSMStrength() const
 void CvUnit::setSMStrength()
 {
 	const int iStrength = getDomainType() == DOMAIN_AIR? baseAirCombatStrPreCheck() : baseCombatStrPreCheck();
-	const int iOffset = getSizeMattersOffsetValue();
 
-	// ⛔ A UNIT WITH NO SIZE CATEGORY IS NOT RANKED -- the offset is quality + group + size - 15, so a unit
-	// carrying none of the three taxonomy classes lands on -15 and applySMRank divides its strength by
-	// 1.5^15 (~438x), which floors it to 0.01 whatever it was authored at. That is not a small unit, it is an
-	// unclassified one, and Size Matters has nothing to say about it. setSMAssetValue already carves the same
-	// case out ("Special Case for size cat undefined units"); strength did not, so five spacecraft fought at
-	// the floor while their asset value was left correct.
-	if (iOffset == -15)
-	{
-		m_iSMStrength = iStrength;
-	}
-	else
-	{
-		m_iSMStrength = applySMRank(iStrength, iOffset, GC.getSIZE_MATTERS_MOST_MULTIPLIER());
-	}
+	// An unclassified unit needs no carve-out here: its type pivot and its own rank sum are both 0, so the
+	// offset is 0 and applySMRank returns the value untouched (getSizeMattersOffsetValue, above).
+	m_iSMStrength = applySMRank(iStrength, getSizeMattersOffsetValue(), GC.getSIZE_MATTERS_MOST_MULTIPLIER());
 	FASSERT_NOT_NEGATIVE(m_iSMStrength);
 }
 
@@ -24234,9 +24222,25 @@ void CvUnit::setSMCargoVolume()
 	);
 }
 
+// ⛔ THE PIVOT IS THE UNIT TYPE'S OWN RANK SUM, NEVER A GLOBAL CONSTANT (owner). Size Matters scales a value by
+// how far THIS unit sits from what its TYPE is, so a unit at its type's profile is offset 0 and receives exactly
+// what the data authored -- which is what makes an authored number mean the same thing whether or not the option
+// is on. The deviation is then the only thing SM expresses: a group-spawn roll below the type's own group class,
+// a merge, a rank promotion.
+// ⚠ The retired form subtracted a flat 15 (three ranks at a nominal 5). That is the MILITARY plane's profile --
+// 851 of ~1000 non-animal combat units sum to exactly 15 -- but the animal taxonomy was never normalised to it:
+// only 316 of 582 animals reach 15, and 79 sit at 4-11, where the shortfall multiplies their authored strength
+// by 1/1.5^n (up to 86x down). An Asian elephant authored 6 was delivered 4.0 at its own profile and 1.77 once
+// groupSpawn rolled SOLO, i.e. it displayed and fought as 1 while still paying a full kill reward.
+// ⛔ The authored data is NOT the place to correct that: GAMEOPTION_COMBAT_SIZE_MATTERS defaults OFF and the
+// non-SM read uses the authored value RAW, so raising it would inflate every one of those animals in the default
+// game (up to 86x). The pivot is the half that was wrong.
 int CvUnit::getSizeMattersOffsetValue() const
 {
-	return qualityRank() + groupRank() + sizeRank() - 15;
+	const int iTypePivot =
+		m_pUnitInfo->getBaseQualityRank() + m_pUnitInfo->getBaseGroupRank() + m_pUnitInfo->getBaseSizeRank();
+
+	return qualityRank() + groupRank() + sizeRank() - iTypePivot;
 }
 
 int CvUnit::getSizeMattersSpacialOffsetValue() const

--- a/Sources/Engine/CvUnit.cpp
+++ b/Sources/Engine/CvUnit.cpp
@@ -24064,7 +24064,17 @@ int CvUnit::getMaxHP() const
 
 int CvUnit::HPValueTotalPreCheck() const
 {
-	return std::max(1, m_pUnitInfo->getSizeMatters().maxHP + getExtraMaxHP());
+	//	⛔ HP IS A PURE ENGINE VALUE AND IS NOT CURATED (owner). The base is MAX_HIT_POINTS; authored data
+	//	contributes only INCREASES, and those already arrive through getExtraMaxHP -- which is exactly how every
+	//	other reader of sizeMatters.maxHP treats it (a promotion or unit-combat DELTA fed to changeExtraMaxHP).
+	//	⚠ Reading that field as the BASE put a curated value in front of an engine one. Nothing authors it, in
+	//	JSON or in the legacy XML, so the base was 0 and this floored to 1 -- every unit in the game had ONE hit
+	//	point. Combat then ended on the first connecting hit, so the WINNER never took damage (the loser dies via
+	//	a direct setDamage elsewhere, which is why losses still worked), and the interface drew every bar against
+	//	MAX_HIT_POINTS, so all of them read red.
+	//	⚑ This restores the archived semantic exactly: CvUnitInfo::getMaxHP returned 100 whenever Size Matters
+	//	was off OR its per-unit value was unset. The SM path is untouched and still answers getSMHPValue().
+	return std::max(1, GC.getMAX_HIT_POINTS() + getExtraMaxHP());
 }
 
 int CvUnit::getSMHPValue() const

--- a/Sources/Engine/CvUnit.cpp
+++ b/Sources/Engine/CvUnit.cpp
@@ -11067,9 +11067,18 @@ void CvUnit::setBaseCombatStr(int iCombat)
 	m_iBaseCombat100 = 100 * iCombat;
 }
 
+// ⛔ AN UNCOMPUTED SM CACHE FALLS BACK -- it is never returned raw. m_iSMStrength is derived state that only
+// setSMValues() writes, so between an owner's reset() and that call it reads 0; returning it makes maxCombatStr
+// floor at max(1, 0) and the unit fights at 0.01 strength while its HP, odds and damage all stay correct. Every
+// other member of this family already guards the same way (getMaxHP, getSMCargoCapacity, getSMAirBombBaseRate,
+// getSMBaseWorkRate); strength was the one that did not.
 int CvUnit::baseCombatStr() const
 {
-	return GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS) ? getSMStrength() : baseCombatStrPreCheck();
+	if (!GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS) || getSMStrength() == 0)
+	{
+		return baseCombatStrPreCheck();
+	}
+	return getSMStrength();
 }
 
 // THE human read boundary -- the ONE ÷100 on this cluster. Strength is ×100 everywhere inside the engine, so
@@ -11083,11 +11092,11 @@ int CvUnit::baseCombatStrHuman() const
 
 int CvUnit::airBaseCombatStr() const
 {
-	if (GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS))
+	if (!GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS) || getSMStrength() == 0)
 	{
-		return getSMStrength();
+		return baseAirCombatStrPreCheck();
 	}
-	return baseAirCombatStrPreCheck();
+	return getSMStrength();
 }
 
 int CvUnit::baseCombatStrPreCheck() const
@@ -11134,7 +11143,22 @@ int CvUnit::getSMStrength() const
 void CvUnit::setSMStrength()
 {
 	const int iStrength = getDomainType() == DOMAIN_AIR? baseAirCombatStrPreCheck() : baseCombatStrPreCheck();
-	m_iSMStrength = applySMRank(iStrength, getSizeMattersOffsetValue(), GC.getSIZE_MATTERS_MOST_MULTIPLIER());
+	const int iOffset = getSizeMattersOffsetValue();
+
+	// ⛔ A UNIT WITH NO SIZE CATEGORY IS NOT RANKED -- the offset is quality + group + size - 15, so a unit
+	// carrying none of the three taxonomy classes lands on -15 and applySMRank divides its strength by
+	// 1.5^15 (~438x), which floors it to 0.01 whatever it was authored at. That is not a small unit, it is an
+	// unclassified one, and Size Matters has nothing to say about it. setSMAssetValue already carves the same
+	// case out ("Special Case for size cat undefined units"); strength did not, so five spacecraft fought at
+	// the floor while their asset value was left correct.
+	if (iOffset == -15)
+	{
+		m_iSMStrength = iStrength;
+	}
+	else
+	{
+		m_iSMStrength = applySMRank(iStrength, iOffset, GC.getSIZE_MATTERS_MOST_MULTIPLIER());
+	}
 	FASSERT_NOT_NEGATIVE(m_iSMStrength);
 }
 

--- a/Sources/Infrastructure/CvDLLWidgetData.cpp
+++ b/Sources/Infrastructure/CvDLLWidgetData.cpp
@@ -940,6 +940,14 @@ bool CvDLLWidgetData::executeAction(CvWidgetDataStruct &widgetDataStruct)
 			doRefreshMilitaryAdvisor(widgetDataStruct);
 			break;
 
+		//	⛔ THE EXE HARDCODES THIS WIDGET'S NUMERIC VALUE, so its ordinal is an ABI obligation and not ours to
+		//	move. Removing or inserting ANY member above it in WidgetTypes shifts it, and the failure is SILENT
+		//	and total: the DLL sends a number the executable does not recognise as "close", so every close button
+		//	in the game stops responding while ESC keeps working (keyboard path, not widget path). The compiler
+		//	cannot see an ordinal change, so it is pinned here instead.
+		//	⚠ If this fires, a member above WIDGET_CLOSE_SCREEN was moved or deleted -- restore the slot rather
+		//	than updating this number, or the same break simply moves to whichever widget shifted next.
+		STATIC_ASSERT(WIDGET_CLOSE_SCREEN == 157, WIDGET_CLOSE_SCREEN_ordinal_is_hardcoded_in_the_exe__restore_the_slot_above_it_instead_of_changing_this);
 		case WIDGET_CLOSE_SCREEN:
 		{
 			if (GC.getCurrentViewport()->getTransformType() == VIEWPORT_TRANSFORM_TYPE_SCALE)

--- a/Sources/Python/CyGame.cpp
+++ b/Sources/Python/CyGame.cpp
@@ -12,6 +12,7 @@
 #include "CyPlot.h"
 #include "CyReplayInfo.h"
 #include "CvReplayInfo.h"
+#include "Infos/CvGameText.h"   // getNumLanguages -- the options screen's language dropdown
 
 //
 // Python wrapper class for CvGame
@@ -687,6 +688,14 @@ void CyGame::setCurrentLanguage(int iNewLanguage)			// remove once CvApp is expo
 	gDLL->setCurrentLanguage(iNewLanguage);
 }
 
+int CyGame::getNumLanguages() const			// remove once CvApp is exposed
+{
+	//	The options screen's language dropdown needs the COUNT beside the current selection it already reads
+	//	here. CvGameText is a C++ class Python was never published, so the call site named it directly and
+	//	raised NameError -- taking the whole Game tab, and with it the rest of the options screen, blank.
+	return CvGameText::getNumLanguages();
+}
+
 int CyGame::getReplayMessageTurn(int i) const
 {
 	return m_pGame.getReplayMessageTurn(i);
@@ -985,6 +994,7 @@ void CyGame::pythonPublish()
 		.def("isPitbossHost", &CyGame::isPitbossHost)
 		.def("getCurrentLanguage", &CyGame::getCurrentLanguage)
 		.def("setCurrentLanguage", &CyGame::setCurrentLanguage)
+		.def("getNumLanguages", &CyGame::getNumLanguages)
 
 		.def("getReplayMessageTurn", &CyGame::getReplayMessageTurn)
 		.def("getReplayMessageType", &CyGame::getReplayMessageType)

--- a/Sources/Python/CyGame.h
+++ b/Sources/Python/CyGame.h
@@ -203,6 +203,7 @@ public:
 	bool isPitbossHost() const;				// remove once CvApp is exposed
 	int getCurrentLanguage() const;				// remove once CvApp is exposed
 	void setCurrentLanguage(int iNewLanguage);				// remove once CvApp is exposed
+	int getNumLanguages() const;				// remove once CvApp is exposed -- moves WITH the two above
 
 	int getReplayMessageTurn(int i) const;
 	ReplayMessageTypes getReplayMessageType(int i) const;

--- a/Sources/Python/CyInfo.cpp
+++ b/Sources/Python/CyInfo.cpp
@@ -61,6 +61,8 @@
 #include "Infos/CvSeaLevelInfo.h"
 #include "Infos/CvGameOptionInfo.h"
 #include "Infos/CvColorInfo.h"
+#include "Infos/CvPlayerOptionInfo.h"    // the options screen's PLAYEROPTION_ description/help
+#include "Infos/CvGraphicOptionInfo.h"   // the options screen's GRAPHICOPTION_ description/help
 #include "Infos/CvMissionInfo.h"
 #include "Infos/CvProcessInfo.h"   // getProductionToCommerce -- the process conversion group
 #include "Infos/CvActionInfo.h"
@@ -134,6 +136,11 @@ namespace
 		if (szTypePrefix == "UNITAI_")      return iId < NUM_UNITAI_TYPES    ? &GC.getUnitAIInfo((UnitAITypes)iId) : NULL;
 		if (szTypePrefix == "ATTITUDE_")    return iId < NUM_ATTITUDE_TYPES  ? &GC.getAttitudeInfo((AttitudeTypes)iId) : NULL;
 		if (szTypePrefix == "MEMORY_")      return iId < NUM_MEMORY_TYPES    ? &GC.getMemoryInfo((MemoryTypes)iId) : NULL;
+		//	The two option registries the options screen reads. Unrouted, its per-option description/help raised
+		//	AttributeError mid-draw -- and because interfaceScreen draws the four tabs in sequence, that took the
+		//	Graphics, Audio and Other tabs with it, Exit buttons included, before they ever ran.
+		if (szTypePrefix == "PLAYEROPTION_")  return iId < NUM_PLAYEROPTION_TYPES  ? &GC.getPlayerOptionInfo((PlayerOptionTypes)iId) : NULL;
+		if (szTypePrefix == "GRAPHICOPTION_") return iId < NUM_GRAPHICOPTION_TYPES ? &GC.getGraphicOptionInfo((GraphicOptionTypes)iId) : NULL;
 
 		// Counted registries.
 		if (szTypePrefix == "DENIAL_")           return iId < GC.getNumDenialInfos()           ? &GC.getDenialInfo((DenialTypes)iId) : NULL;

--- a/Sources/Python/CyInfo.cpp
+++ b/Sources/Python/CyInfo.cpp
@@ -29,6 +29,7 @@
 #include "AI/CvPlayerAI.h"       // GET_PLAYER -- the player resolve behind the (player, city) address
 #include "Infos/CvUnitInfo.h"                 // the spread block behind the named canSpreadReligion endpoint
 #include "Infos/CvCivicInfo.h"       // the civic column the bulk index reads
+#include "Infos/CvReligionInfo.h"    // the derived disabled-icon path behind getReligionButtonDisabled
 // The straggler dispatch reaches these concrete registries -- specific headers, never the CvInfos.h umbrella.
 #include "Infos/CvBuildingInfo.h"
 #include "Infos/CvPromotionInfo.h"      // the promotion classification endpoints
@@ -504,6 +505,14 @@ std::string CyInfo::getLeaderHeadArt(int iLeaderId) const
 	const char* szArt = GC.getLeaderHeadInfo((LeaderHeadTypes)iLeaderId).getLeaderHead();
 	return szArt ? std::string(szArt) : std::string();
 }
+
+std::string CyInfo::getReligionButtonDisabled(int iReligionId) const
+{
+	if (iReligionId < 0 || iReligionId >= GC.getNumReligionInfos()) return std::string();
+	const char* szButton = GC.getReligionInfo((ReligionTypes)iReligionId).getButtonDisabled();
+	return szButton ? std::string(szButton) : std::string();
+}
+
 int CyInfo::getLeaderDiploPeaceMusicScriptId(int iLeaderId, int iEra) const
 {
 	//	The peace-loop entry of the era-keyed diplomacy music table (-1 = engine default). Named for what it
@@ -1593,6 +1602,7 @@ void CyInfo::pythonPublish()
 		.def("getUnitAirCombat",        &CyInfo::getUnitAirCombat)
 		.def("isNPCLeader",             &CyInfo::isNPCLeader)
 		.def("getLeaderHeadArt",        &CyInfo::getLeaderHeadArt)
+		.def("getReligionButtonDisabled", &CyInfo::getReligionButtonDisabled)
 		.def("getLeaderDiploPeaceMusicScriptId", &CyInfo::getLeaderDiploPeaceMusicScriptId)
 		.def("providesBonus",           &CyInfo::providesBonus)
 		.def("isGlobalTech",            &CyInfo::isGlobalTech)

--- a/Sources/Python/CyInfo.h
+++ b/Sources/Python/CyInfo.h
@@ -420,6 +420,13 @@ public:
 	// image. Art is an untouched system boundary (the roadmap's scope decision 3): this hands over the path the
 	// info already resolved, and resolves nothing itself.
 	std::string getLeaderHeadArt(int iLeaderId) const;
+
+	// ---- RELIGION facts. ----
+	// The GREYED icon path for a religion nobody has founded yet -- the disabled twin of getButton's icon, which
+	// the religion advisor draws for every unfounded slot. Like getLeaderHeadArt this hands over a path the info
+	// already resolved and resolves nothing itself; the derivation (the icon with its "_D.dds" suffix) stays the
+	// info's, so a consumer never rebuilds it from the base button.
+	std::string getReligionButtonDisabled(int iReligionId) const;
 	// The peace-loop entry of the leader's era-keyed diplomacy-music table (-1 = engine default) -- what the
 	// Dawn-of-Man screen plays. Named per table rather than parameterized over the music kind: Python has no
 	// LeaderDiploMusic vocabulary, so an int-slot argument would hide which table a call site reads.

--- a/Sources/Spine/CvEventSpine.cpp
+++ b/Sources/Spine/CvEventSpine.cpp
@@ -356,6 +356,11 @@ enum SpineDomainField
 	// the combat fact's SECOND party: a resolved combat has two units, and the five DOMAIN ints hold the winner
 	// plus the loser's id only, so the loser's type and owner ride here
 	SPF_LOSER_UNIT, SPF_LOSER_UNIT_ID, SPF_LOSER_OWNER,
+	//	The WINNER's health across the combat it just won. combatResult names who won and nothing about what it
+	//	cost, so "did the winner take damage" was not answerable from any surface -- and a value not on the
+	//	surface is not verifiable (validation.md). BEFORE is the pre-combat snapshot updateCombat takes just
+	//	ahead of resolveCombat, so BEFORE == AFTER on a win means the winner took none.
+	SPF_WINNER_DAMAGE_BEFORE, SPF_WINNER_DAMAGE_AFTER, SPF_WINNER_MAX_HP,
 	// the traded-item fact: WHAT moved and BETWEEN WHOM, plus the deal it belonged to (correlation only, so a
 	// reader can see several items ending together because one agreement was cancelled).
 	// ⚠ SPF_TRADE_DATA is SFT_INT deliberately: it is a BONUS only for TRADE_RESOURCES and a tech / city / unit
@@ -610,6 +615,9 @@ static const char* spineDomainFieldInfo(int iFieldTag, SpineFieldType* peType)
 	case SPF_LOSER_UNIT:    *peType = SFT_UNIT;      return "loserUnit";
 	case SPF_LOSER_UNIT_ID: *peType = SFT_INT;       return "loserUnitId";
 	case SPF_LOSER_OWNER:   *peType = SFT_PLAYER;    return "loserOwner";
+	case SPF_WINNER_DAMAGE_BEFORE: *peType = SFT_INT; return "winnerDmgBefore";
+	case SPF_WINNER_DAMAGE_AFTER:  *peType = SFT_INT; return "winnerDmgAfter";
+	case SPF_WINNER_MAX_HP:        *peType = SFT_INT; return "winnerMaxHP";
 	case SPF_TRADE_ITEM:  *peType = SFT_INT;         return "item";
 	case SPF_TRADE_DATA:  *peType = SFT_INT;         return "data";
 	case SPF_FROM_PLAYER: *peType = SFT_PLAYER;      return "fromPlayer";
@@ -1955,14 +1963,21 @@ void emitUnitKilled(int iUnitType, int iUnitId, int iOwner, int iPlot)
 // A resolved combat, emitted beside CvEventReporter's Python callback. The payload is the reporter's own
 // arguments and nothing more -- what a combat event MEANS is formalized when the event system moves to C++.
 void emitCombatResult(int iWinnerUnitType, int iWinnerUnitId, int iWinnerOwner,
-					  int iLoserUnitType, int iLoserUnitId, int iLoserOwner, int iPlot)
+					  int iLoserUnitType, int iLoserUnitId, int iLoserOwner, int iPlot,
+					  int iWinnerDamageBefore, int iWinnerDamageAfter, int iWinnerMaxHP)
 {
 	CvSpineEvent e(EVENTKIND_DOMAIN, SEVT_COMBAT_RESULT,
 				   iWinnerUnitType, iWinnerUnitId, iLoserUnitId, iWinnerOwner, iPlot);
 	e.iDomainTag = SD_SPINE;
+	//	⚑ The three health fields are RENDER-ONLY: the DOMAIN ints above are untouched, so every machine consumer
+	//	sees exactly what it saw before and this stays a diagnostic read of the reporter's own arguments rather
+	//	than a designed payload (spine.md -- the reporter facts invent nothing).
 	e.addI(SPF_UNIT, iWinnerUnitType).addI(SPF_UNIT_ID, iWinnerUnitId).addI(SPF_OWNER, iWinnerOwner)
 	 .addI(SPF_LOSER_UNIT, iLoserUnitType).addI(SPF_LOSER_UNIT_ID, iLoserUnitId)
-	 .addI(SPF_LOSER_OWNER, iLoserOwner).addI(SPF_PLOT, iPlot);
+	 .addI(SPF_LOSER_OWNER, iLoserOwner).addI(SPF_PLOT, iPlot)
+	 .addI(SPF_WINNER_DAMAGE_BEFORE, iWinnerDamageBefore)
+	 .addI(SPF_WINNER_DAMAGE_AFTER, iWinnerDamageAfter)
+	 .addI(SPF_WINNER_MAX_HP, iWinnerMaxHP);
 	eventSpine().emit(e);
 }
 

--- a/Sources/Spine/CvEventSpine.h
+++ b/Sources/Spine/CvEventSpine.h
@@ -1018,8 +1018,11 @@ void emitUnitCreated(int iUnitType, int iUnitId, int iOwner);
 void emitUnitKilled(int iUnitType, int iUnitId, int iOwner, int iPlot);
 // A resolved combat. Called from CvEventReporter::combatResult, BESIDE its Python callback -- the reporter's
 // arguments verbatim, so the spine sees exactly what Python sees and a later migration is a swap.
+// The three winner-health arguments are RENDER-ONLY diagnostics -- BEFORE is the pre-combat snapshot, AFTER the
+// damage the winner carries now, so a win where they are equal says the winner took nothing.
 void emitCombatResult(int iWinnerUnitType, int iWinnerUnitId, int iWinnerOwner,
-					  int iLoserUnitType, int iLoserUnitId, int iLoserOwner, int iPlot);
+					  int iLoserUnitType, int iLoserUnitId, int iLoserOwner, int iPlot,
+					  int iWinnerDamageBefore, int iWinnerDamageAfter, int iWinnerMaxHP);
 // A unit's death SCHEDULE. Call AFTER m_bDeathDelay is written, at BOTH transitions: ADDED where a delayed kill
 // deferred the death, REMOVED where an outcome brought the unit back.
 void emitUnitDeathScheduleAdded(int iUnitType, int iUnitId, int iOwner, int iPlot);

--- a/Sources/UI/CvEventReporter.cpp
+++ b/Sources/UI/CvEventReporter.cpp
@@ -234,7 +234,8 @@ void CvEventReporter::combatResult(CvUnit* pWinner, CvUnit* pLoser)
 		const CvPlot* pCombatPlot = pWinner->plot();
 		emitCombatResult((int)pWinner->getUnitType(), pWinner->getID(), (int)pWinner->getOwner(),
 						 (int)pLoser->getUnitType(),  pLoser->getID(),  (int)pLoser->getOwner(),
-						 (pCombatPlot != NULL) ? GC.getMap().plotNum(pCombatPlot->getX(), pCombatPlot->getY()) : -1);
+						 (pCombatPlot != NULL) ? GC.getMap().plotNum(pCombatPlot->getX(), pCombatPlot->getY()) : -1,
+						 pWinner->getPreCombatDamage(), pWinner->getDamage(), pWinner->getMaxHP());
 	}
 
 	m_kPythonEventMgr.reportCombatResult(pWinner, pLoser);

--- a/Sources/UI/CvGameTextMgr.cpp
+++ b/Sources/UI/CvGameTextMgr.cpp
@@ -2087,8 +2087,8 @@ void CvGameTextMgr::setCityBarHelp(CvWStringBuffer &szString, CvCity* pCity)
 				gDLL->getText(
 					"TXT_KEY_CITY_BAR_CULTURE",
 					CvWString::format(L"%I64d", pCity->getCulture(pCity->getOwner())).GetCString(), iThreshold,
-					GC.getCultureLevelInfo(pCity->getCultureLevel()).getTextKeyWide(),
-					GC.getCultureLevelInfo(pCity->getCultureLevel()).getLevel()
+					GC.getCultureLevelInfo(pCity->cultureLevelForRead()).getTextKeyWide(),
+					GC.getCultureLevelInfo(pCity->cultureLevelForRead()).getLevel()
 				)
 			);
 			int aiCityCommerces[NUM_COMMERCE_TYPES];
@@ -2110,8 +2110,8 @@ void CvGameTextMgr::setCityBarHelp(CvWStringBuffer &szString, CvCity* pCity)
 				gDLL->getText(
 					"TXT_KEY_CITY_BAR_CULTURE_MAX",
 					CvWString::format(L"%I64d", pCity->getCulture(pCity->getOwner())).GetCString(),
-					GC.getCultureLevelInfo(pCity->getCultureLevel()).getTextKeyWide(),
-					GC.getCultureLevelInfo(pCity->getCultureLevel()).getLevel()
+					GC.getCultureLevelInfo(pCity->cultureLevelForRead()).getTextKeyWide(),
+					GC.getCultureLevelInfo(pCity->cultureLevelForRead()).getLevel()
 				)
 			);
 		}

--- a/docs/reference/engine.md
+++ b/docs/reference/engine.md
@@ -38,6 +38,39 @@ Measured against the deployed `Assets/CvGameCoreDLL.dll`: **1,205 of 1,302 expor
 not.** The 97 are the ones a cut may freely take. ⚠ The test needs a DEPLOYED DLL to read the export table from,
 so run it against the last good build, not a red tree.
 
+## ⛔ AN EXE-BOUND ENUM'S ORDINAL IS AN ABI OBLIGATION — never remove a member above one (owner)
+
+**Home of [a core enum entry is never removed](#-an-exe-bound-enums-ordinal-is-an-abi-obligation--never-remove-a-member-above-one-owner).** The section above answers whether a SYMBOL is
+EXE-bound. This is the other half, and it is the one that hides: some enum VALUES are hardcoded in the closed
+executable, so the ordinal itself is the contract. **Removing any member ABOVE such an entry shifts it, and every
+entry after it, by one** — the DLL then hands the EXE a number that means something else.
+
+⛔ **So a dead member of a core enum is NOT ordinary dead code.** [Leave no evidence of the abandoned
+path](../../AGENTS.md#design) governs code, comments and docs; it does not reach an ordinal an outside binary
+counts on. **The slot stays, INERT** (owner) — never renumbered, never reused for something else, never
+"tidied". Being unreferenced is exactly what makes it look safe to take.
+
+⚠ **The failure mode is silent and total, which is why this earns a rule rather than care.** Nothing errors,
+nothing logs, and the compiler cannot see an ordinal change at all — it compiles clean and the game runs. The
+worked case: `WIDGET_HELP_LOS_BONUS` was removed from the middle of `WidgetTypes` as part of cutting the inert
+water-sight capability. It sat above `WIDGET_CLOSE_SCREEN`, whose value the EXE hardcodes, shifting it 157 → 156
+— and **every close button in the game stopped responding**: the Dawn of Man "Continue" and Exit on ten advisor
+screens. ESC and ENTER kept working (the keyboard path, not the widget path), and the ONE screen that closes
+itself in Python rather than through the widget kept working too, so the break presented as an incoherent
+scattering of dead buttons rather than as one cut.
+
+⇒ **PIN THE ORDINAL WHERE IT IS CONSUMED, so the next removal is a compile error** ([anything not enforced by
+hard typing gets rollerskated](../../AGENTS.md#design) — a comment on the enum had already
+existed for years, and failed). `STATIC_ASSERT(WIDGET_CLOSE_SCREEN == 157, …)` sits beside the case that reads
+it in `CvDLLWidgetData.cpp`; `CvEnums.h` cannot see `FAssert.h` and must not gain the include. ⛔ If such an
+assert fires, **restore the slot above it** — never update the number, or the same break simply moves to
+whichever entry shifted next.
+
+⚑ **Finding the others is an open audit, not a closed list.** `WIDGET_CLOSE_SCREEN` carries the only such pin
+today, and it is known to be EXE-bound only because a comment recorded it. Treat any enum the EXE indexes into —
+widgets, interface modes, control and mission types — as ordinal-bound until shown otherwise, and prefer adding
+at the END over inserting anywhere.
+
 ## Save / load
 
 The name-keyed save format, the soft-add / soft-remove rules, the `Assets/savemigration.txt` drain, the two kinds of

--- a/docs/reference/python-read-map.md
+++ b/docs/reference/python-read-map.md
@@ -38,8 +38,12 @@ the `CvPlayer`/`CvTeam` side is where the work is.** The replacement surface sta
 > **the victory thresholds** (authored on the building/project, wanted per victory — a reverse view, so it lands
 > at load like the build's produces does, never a per-victory registry sweep), **the ERA** (no registered prefix;
 > ⚠ contrast `WORLD_`, which is NOT a JSON prefix either yet IS mapped explicitly in `CyInfo.cpp` — so absence
-> from the `readJson` X-macro list is not proof a prefix is unserved, CHECK the mapper), and the odd art read
-> (`getButtonDisabled`, the leader art-define / diplo-music tags).
+> from the `readJson` X-macro list is not proof a prefix is unserved, CHECK the mapper).
+> ⚑ **The odd ART reads that used to sit on that list are SERVED, and how they landed is the pattern to copy:**
+> the leader art-define and diplo-music tags as `CyInfo::getLeaderHeadArt` / `getLeaderDiploPeaceMusicScriptId`,
+> and the religion disabled-icon as `CyInfo::getReligionButtonDisabled`. A read belonging to ONE registry is a
+> NAMED endpoint on `CyInfo` taking that registry's bare id — never a new per-type class, and never a generic
+> `getButtonDisabled(prefix, id)` that would answer empty for every registry that has no such art.
 > The `Cy*` WRAPPER classes stay for the engine→Python direction, and each carries its **IDENTITY SET** — owner,
 > id, position, and nothing else ([patterns.md](../architecture/patterns.md) § THE IDENTITY SET). ⛔ The earlier
 > reading here — *"a wrapper with no binding is the correct end state"* — is SUPERSEDED: it was right about the

--- a/docs/specs/enabler.md
+++ b/docs/specs/enabler.md
@@ -1079,6 +1079,24 @@ than split per domain, and it is where the option read lives for every entity-ga
   than merely avoided. ⛔ Do not gate an enabler entity on a live option; if one is ever wanted, it needs its emit
   first.
 
+> **⛔ A TRANSFORMATION ASKS `everAvailable` + THE TARGET'S `requires` — NEVER THE QUEUE-OFFER VERDICT (owner).**
+> `STATE_LISTED` means *"offered in the production queue, in this city, right now"*. That is the right question
+> for a BUILD and the wrong one for an **UPGRADE**, a gift, a merge or any other `modifyUnit` transformation —
+> none of which is a creation ([triggers.md](triggers.md): a transformation stands a successor up in place of a
+> predecessor and deliberately does NOT ride the creation step), so what the queue is willing to OFFER has no
+> bearing on it.
+> ⚠ **The failure is total and silent, because a whole population can never reach LISTED.** A unit carrying
+> `identity.spawnOnly` (legacy's `iCost == -1` sentinel) is excluded from the trainable set outright (§3), so
+> gating a transformation on LISTED bars it permanently rather than conditionally. ⚑ **Measured: every
+> great-person CONVERSION in the game — 49 units, the whole `MASTER_SAILOR_*` chain plus
+> `MASTER_HUNTER → MASTER_RANGER → MASTER_WARDEN`** — while the SETTLE action kept working, because that is a
+> `grants` payload that never asks the enabler. The tell to recognise: *one action on a unit works and another
+> is missing*, rather than the unit being broken.
+> ⇒ **The pair is the answer, and each half is doing its own job:** `everAvailable(bucket, id)` is the
+> whole-game bar, and `requiresMetInCity(city, bucket, id)` is the target's own tech/resource gate asked where
+> the transformation would happen — which is what keeps an upgrade chain following the RESEARCH the data gates
+> it on. ⛔ Neither half substitutes for the other, and neither is `STATE_LISTED`.
+
 ⛔ **TECHS stay the picking logic's, and the reason is the distinction to apply elsewhere: their bar is a
 COMPOSITION, not a gate.** `CvGame::canEverResearch` composes `NO_FUTURE` against the tech's own era and `isRepeat`
 data — a consuming-system calc ([engine.md](../reference/engine.md)), which no entity gate carries and which an

--- a/docs/specs/json.md
+++ b/docs/specs/json.md
@@ -1513,7 +1513,27 @@ Data read by a specific system, not the cascade. Use only when the entity needs 
 
   Effective runtime rank = the derived info base + `Σ` held-promotion changes + the engine merge/split accumulators
   (`getExtraQuality`/`Group`/`Size` — live engine state, **never** data). Block absent ⇒ the entity carries no SM
-  data. *(This is the pattern for every game-option-specific system — each gets its own block; `hideAndSeek`
+  data.
+
+  > **⛔ SIZE MATTERS PIVOTS ON THE UNIT TYPE'S OWN RANK SUM, NEVER ON A GLOBAL CONSTANT (owner).** The rank
+  > scaling expresses how far THIS unit sits from what its TYPE is, so a unit at its type's profile is offset 0
+  > and receives **exactly what the data authored**. The deviation is the only thing SM says: a `groupSpawn` roll
+  > below the type's own group class, a merge, a rank promotion.
+  > ⚑ **This is what keeps an authored number meaningful, and the option gate is why it has to.**
+  > `GAMEOPTION_COMBAT_SIZE_MATTERS` **defaults OFF** and the non-SM read takes the authored strength RAW, so any
+  > pivot that is not the type's own makes one number mean two different things depending on a player toggle.
+  > ⛔ **So the authored data is NEVER the place to correct a pivot mismatch** — raising a strength to compensate
+  > inflates that unit in the DEFAULT game, by the same factor, invisibly.
+  > ⚠ **The retired form subtracted a flat 15** (three ranks at a nominal 5). That is the MILITARY plane's
+  > profile — 851 of ~1000 non-animal combat units sum to exactly 15 — but **the animal taxonomy was never
+  > normalised to it**: only 316 of 582 animals reach 15, and 79 sit at 4–11, where the shortfall divides their
+  > authored strength by `1.5^n` (up to 86×). ⚑ The worked case: `UNIT_ELEPHANT_ASIAN` authors 6, its type sums
+  > 14 (`QUALITY_MEDIOCRE 4` + `GROUP_SQUAD 3` + `SIZE_HUGE 7`), and `groupSpawn` rolls SOLO half the time — so it
+  > was delivered 4.0 at its own profile and **1.77** once solo, displaying and fighting as **1** while still
+  > paying a full `outcomes.kill` reward.
+  > ⚑ **The tell that the pivot was the wrong half, not the data:** the correction the data would have needed is
+  > exactly the factor the pivot was already applying — a fudge factor whose existence says two operands are on
+  > different scales ([AGENTS.md](../../AGENTS.md#conduct) drift detector 2). *(This is the pattern for every game-option-specific system — each gets its own block; `hideAndSeek`
   below is its sibling.)*
 - **`hideAndSeek`** — the concealment-vs-detection CONTEST (gated by `GAMEOPTION_COMBAT_HIDE_AND_SEEK`), the
   own-block sibling of `sizeMatters`. **Two contest members, one per side of the equation:** `concealment` (how

--- a/docs/specs/json.md
+++ b/docs/specs/json.md
@@ -1486,6 +1486,12 @@ Data read by a specific system, not the cascade. Use only when the entity needs 
   > unit in the game floors to ONE hit point. Combat then ends on the first connecting hit, so the WINNER takes
   > no damage (the loser still dies, through a direct `setDamage`), and the interface draws every health bar
   > against `MAX_HIT_POINTS` and shows them all red. Nothing errors and the build is green throughout.
+  > ⛔ **AND IT REACHES COMBAT RESOLUTION, NOT ONLY THE DISPLAY, BECAUSE A UNIT'S STRENGTH IS SCALED BY ITS HP
+  > (owner): a damaged unit also does less damage.** `CvUnit::currCombatStr` is
+  > `maxCombatStr × getHP() / getMaxHP()`, and `currEffectiveStr` normalizes by firepower over the same ratio —
+  > so `getMaxHP()` returning 1 collapses that whole curve to a STEP: a unit is at full strength or it is dead,
+  > with nothing in between. ⇒ The wrong base did not merely mis-draw a bar; it deleted attrition from every
+  > combat in the game, which is why this key's disposition is a combat question rather than a UI one.
   > ⚑ The same test settles the rest of this block: a key here is a DELTA unless the entity's own row says it is
   > a base rank, and the three `*Base` names are the only bases.
   - **UnitCombat** (the intrinsic **base ranks** + SM combat data): carries `qualityBase`/`groupBase`/`sizeBase` plus

--- a/docs/specs/json.md
+++ b/docs/specs/json.md
@@ -1478,6 +1478,16 @@ Data read by a specific system, not the cascade. Use only when the entity needs 
   key suffix. Members: base ranks `qualityBase`/`groupBase`/`sizeBase` (UnitCombat only); the scalars `quality`,
   `group`, `sizeModifier`, `maxHP`; `combatModifier: { perSizeMore, perSizeLess, perVolumeMore, perVolumeLess }`;
   `cargo: { smSpace, volume, volumeModifier }`.
+  > **⛔ `maxHP` IS ONLY EVER AN INCREASE — HP ITSELF IS A PURE ENGINE VALUE AND IS NOT CURATED (owner).** The
+  > base is the `MAX_HIT_POINTS` global; authored data contributes percentage/flat INCREASES on top and nothing
+  > else, which is why every consumer of this key feeds `changeExtraMaxHP` rather than seating a base.
+  > ⚠ **Reading it as the base is silent and total.** No entity authors `sizeMatters.maxHP` — none does in the
+  > legacy XML either, because the value was always the engine default — so a base read resolves to 0 and every
+  > unit in the game floors to ONE hit point. Combat then ends on the first connecting hit, so the WINNER takes
+  > no damage (the loser still dies, through a direct `setDamage`), and the interface draws every health bar
+  > against `MAX_HIT_POINTS` and shows them all red. Nothing errors and the build is green throughout.
+  > ⚑ The same test settles the rest of this block: a key here is a DELTA unless the entity's own row says it is
+  > a base rank, and the three `*Base` names are the only bases.
   - **UnitCombat** (the intrinsic **base ranks** + SM combat data): carries `qualityBase`/`groupBase`/`sizeBase` plus
     `maxHP`/`combatModifier`/`cargo`. A base equal to the legacy `−10` "unset" sentinel is emitted **absent** (never
     `0` — `0` is a real rank).


### PR DESCRIPTION
Fixes #478 · addresses #475

⚠ **In progress — put up early as a reference so the very visible combat bug does not accumulate duplicate reports.** The Size Matters strength work described at the bottom lands on this same branch.

---

## #478 — units take no damage in battle

`CvUnit::HPValueTotalPreCheck()` seated `sizeMatters.maxHP` as a unit's **base** hit points. Nothing authors that key — not in the curated JSON and not in the legacy XML either, because the value was always the `MAX_HIT_POINTS` engine default — so the base resolved to **0** and every unit in the game floored to **one hit point**.

Combat then ended on the first connecting hit. The winner took no damage; the loser still died, through a direct `setDamage`. The interface drew every health bar against `MAX_HIT_POINTS` and showed them all red.

It reaches combat resolution rather than only the display, because **a unit's strength is scaled by its HP**: `currCombatStr` is `maxCombatStr × getHP() / getMaxHP()`, and `currEffectiveStr` normalizes by firepower over the same ratio. With `getMaxHP()` returning 1, that curve collapsed to a step — full strength or dead, nothing between — so attrition was absent from every fight.

`maxHP` is **only ever an increase**; HP is a pure engine value and is not curated. Every consumer of the key feeds `changeExtraMaxHP` rather than seating a base, which is what the fix restores. Ruling recorded in `docs/specs/json.md §9`.

## #475 — the community report

**Founding crash.** `bd_categoryCapOk` read a city's culture level through the raw getter and handed the result to `GC.getCultureLevelInfo()`. A city mid-founding has no culture level yet, so the info-plane read was unanswerable and aborted the process. Re-pointed at the existing guarded read (`CvCity::cultureLevelForRead`), which exists for precisely this and whose doc comment already recorded that founding had died there. Four sibling sites in `setCityBarHelp` re-pointed with it.

**Every close button in the game stopped responding.** `WIDGET_HELP_LOS_BONUS` had been removed from the middle of `WidgetTypes` while cutting an inert capability. It sat above `WIDGET_CLOSE_SCREEN`, whose value the closed EXE hardcodes, shifting it 157 → 156. Dawn of Man "Continue" and Exit on ten advisor screens went dead; ESC and ENTER kept working because the keyboard path does not go through the widget, and the one screen that closes itself in Python kept working too — so it presented as an incoherent scattering of dead buttons rather than as one cut.

The slot is restored **inert**, and the ordinal is now pinned where it is consumed:

```cpp
STATIC_ASSERT(WIDGET_CLOSE_SCREEN == 157, …);
```

⛔ If that assert ever fires, restore the slot above it — never update the number, or the same break moves to whichever entry shifted next.

**Options screen mostly blank; three tabs had no way out.** Two successive dead reads. `CvGameText.getNumLanguages()` and the `PLAYEROPTION_` / `GRAPHICOPTION_` registries were unrouted on the Python read surface. `interfaceScreen` draws tabs sequentially, so a single raise took three tabs *and* their Exit buttons with it. Served as named reads on the existing accessors rather than by reviving the legacy bindings.

## Instrumentation

`combatResult` now carries what the win **cost**, not just who won — `winnerDmgBefore` / `winnerDmgAfter` / `winnerMaxHP`. This is what made #478 diagnosable from the log instead of from the screen, and it is how the remaining work below is being attributed.

## Verification — stated plainly

**Confirmed in-game by the owner:** founding works; the Continue button works; health bars are green again.

**Not yet exercised:** the Options tabs and the Religion screen. A tester should open each Options tab and confirm every tab both populates and offers a way out.

## Size Matters floored an unclassified unit into the combat floor

`getSizeMattersOffsetValue()` is `quality + group + size - 15`, so a unit carrying **none** of the three SM taxonomy classes lands on `-15`, and `applySMRank` divides its strength by `1.5^15` (~438x). Whatever it was authored at, it fought at **0.01**.

Five units are in that state, and they are not minor:

| unit | authored strength | fought at |
|---|--:|--:|
| `UNIT_HYPER_BATTLECRUISER` | 480 | 0.01 |
| `UNIT_INT_BATTLECRUISER` | 360 | 0.01 |
| `UNIT_INT_INVADER` | 240 | 0.01 |
| `UNIT_ATTACKSHIP` | 180 | 0.01 |
| `UNIT_CISLUNAR_INVADER` | 120 | 0.01 |

That is not a *small* unit, it is an *unclassified* one, and Size Matters has nothing to say about it. `setSMAssetValue` already carves the identical case out (`if (offsetValue != -15) // Special Case for size cat undefined units`); `setSMStrength` did not.

The two strength reads are also brought into line with the rest of the SM family: an uncomputed cache is derived state that only `setSMValues()` writes, and `getMaxHP` / `getSMCargoCapacity` / `getSMAirBombBaseRate` / `getSMBaseWorkRate` all fall back in that case while strength returned it raw.

⚠ **Deliberately NOT changed**, because the data makes them inert: those same five units carry `worth = 1` and no authored `militaryWorth`, so the matching gap in asset value costs one point each and the power value ranks 0 either way. Changing them would risk drifting existing saves' asset totals for no gain.

⚠ **Separately, not a defect and not changed here**: 22 units sit at offset -8 to -11 -- almost entirely small animals (armadillo, crab, dart frog, koala, ...) -- which divides their strength by 25-86x. That is the authored taxonomy doing what it says; whether it should rank them as far as the floor is a balance call on the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
