### PR TITLE
The seven prehistoric dances enter the build queue (#386)

### DIFF
--- a/Assets/Data/_additions/buildings.json
+++ b/Assets/Data/_additions/buildings.json
@@ -22,5 +22,70 @@
  "BUILDING_WATERPROOF_CEMENT_MAKER": { "PROPERTY_FLAMMABILITY": { "city": { "flat": -5 } } },
  "BUILDING_BRICK_BRIDGE": { "PROPERTY_FLAMMABILITY": { "city": { "flat": -3 } } },
  "BUILDING_MOAT": { "PROPERTY_FLAMMABILITY": { "city": { "flat": -12 } } },
- "BUILDING_GUILD_MASONS": { "PROPERTY_FLAMMABILITY": { "city": { "flat": -6 } } }
+ "BUILDING_GUILD_MASONS": { "PROPERTY_FLAMMABILITY": { "city": { "flat": -6 } } },
+
+ "BUILDING_RAIN_DANCE": {
+  "cost": { "production": 120, "sizeModifier": 1, "countModifier": 1, "materialsModifier": 1, "complexityModifier": 1, "hurryModifier": 100 },
+  "identity": { "notConstructible": false },
+  "requires": { "build": { "all": [
+   "TECH_PREHISTORIC_DANCE",
+   { "any": [ "BUILDING_DANCE_HUT", "BUILDING_DANCE_HALL", "BUILDING_NIGHT_CLUB" ] },
+   { "type": "MAPCATEGORY_EARTH", "scope": "plot" }
+  ] } }
+ },
+ "BUILDING_WAR_DANCE": {
+  "cost": { "production": 120, "sizeModifier": 1, "countModifier": 1, "materialsModifier": 1, "complexityModifier": 1, "hurryModifier": 100 },
+  "identity": { "notConstructible": false },
+  "requires": { "build": { "all": [
+   "TECH_PREHISTORIC_DANCE",
+   { "any": [ "BUILDING_DANCE_HUT", "BUILDING_DANCE_HALL", "BUILDING_NIGHT_CLUB" ] },
+   { "type": "MAPCATEGORY_EARTH", "scope": "plot" }
+  ] } }
+ },
+ "BUILDING_FIRE_DANCE": {
+  "cost": { "production": 120, "sizeModifier": 1, "countModifier": 1, "materialsModifier": 1, "complexityModifier": 1, "hurryModifier": 100 },
+  "identity": { "notConstructible": false },
+  "requires": { "build": { "all": [
+   "TECH_PREHISTORIC_DANCE",
+   "TECH_CONTROLLED_FIRE",
+   { "any": [ "BUILDING_IMU", "BUILDING_FIRE_PIT", "BUILDING_BONFIRE", "BUILDING_CHARCOAL_BURNER" ] },
+   { "type": "MAPCATEGORY_EARTH", "scope": "plot" }
+  ] } }
+ },
+ "BUILDING_NATURE_DANCE": {
+  "cost": { "production": 120, "sizeModifier": 1, "countModifier": 1, "materialsModifier": 1, "complexityModifier": 1, "hurryModifier": 100 },
+  "identity": { "notConstructible": false },
+  "requires": { "build": { "all": [
+   "TECH_PREHISTORIC_DANCE",
+   { "any": [ "BUILDING_DANCE_HUT", "BUILDING_DANCE_HALL", "BUILDING_NIGHT_CLUB" ] },
+   { "type": "MAPCATEGORY_EARTH", "scope": "plot" }
+  ] } }
+ },
+ "BUILDING_MOON_DANCE": {
+  "cost": { "production": 120, "sizeModifier": 1, "countModifier": 1, "materialsModifier": 1, "complexityModifier": 1, "hurryModifier": 100 },
+  "identity": { "notConstructible": false },
+  "requires": { "build": { "all": [
+   "TECH_PREHISTORIC_DANCE",
+   { "any": [ "BUILDING_DANCE_HUT", "BUILDING_DANCE_HALL", "BUILDING_NIGHT_CLUB" ] },
+   { "type": "MAPCATEGORY_EARTH", "scope": "plot" }
+  ] } }
+ },
+ "BUILDING_FERTILITY_DANCE": {
+  "cost": { "production": 120, "sizeModifier": 1, "countModifier": 1, "materialsModifier": 1, "complexityModifier": 1, "hurryModifier": 100 },
+  "identity": { "notConstructible": false },
+  "requires": { "build": { "all": [
+   "TECH_PREHISTORIC_DANCE",
+   { "any": [ "BUILDING_DANCE_HUT", "BUILDING_DANCE_HALL", "BUILDING_NIGHT_CLUB" ] },
+   { "type": "MAPCATEGORY_EARTH", "scope": "plot" }
+  ] } }
+ },
+ "BUILDING_BLOOD_DANCE": {
+  "cost": { "production": 120, "sizeModifier": 1, "countModifier": 1, "materialsModifier": 1, "complexityModifier": 1, "hurryModifier": 100 },
+  "identity": { "notConstructible": false },
+  "requires": { "build": { "all": [
+   "TECH_PREHISTORIC_DANCE",
+   { "any": [ "BUILDING_DANCE_HUT", "BUILDING_DANCE_HALL", "BUILDING_NIGHT_CLUB", "BUILDING_FIRE_PIT", "BUILDING_BONFIRE", "BUILDING_IMU", "BUILDING_CHARCOAL_BURNER" ] },
+   { "type": "MAPCATEGORY_EARTH", "scope": "plot" }
+  ] } }
+ }
 }

--- a/Assets/Data/buildings/prehistoric/building_blood_dance.json
+++ b/Assets/Data/buildings/prehistoric/building_blood_dance.json
@@ -31,6 +31,26 @@
      "scope": "plot"
     }
    ]
+  },
+  "build": {
+   "all": [
+    "TECH_PREHISTORIC_DANCE",
+    {
+     "any": [
+      "BUILDING_DANCE_HUT",
+      "BUILDING_DANCE_HALL",
+      "BUILDING_NIGHT_CLUB",
+      "BUILDING_FIRE_PIT",
+      "BUILDING_BONFIRE",
+      "BUILDING_IMU",
+      "BUILDING_CHARCOAL_BURNER"
+     ]
+    },
+    {
+     "type": "MAPCATEGORY_EARTH",
+     "scope": "plot"
+    }
+   ]
   }
  },
  "happiness": {
@@ -65,11 +85,19 @@
  "identity": {
   "description": "TXT_KEY_BUILDING_BLOOD_DANCE",
   "civilopedia": "TXT_KEY_BUILDING_BLOOD_DANCE_PEDIA",
-  "notConstructible": true,
+  "notConstructible": false,
   "worth": 1,
   "advisor": "ADVISOR_ECONOMY",
   "mapCategories": [
    "MAPCATEGORY_EARTH"
   ]
+ },
+ "cost": {
+  "production": 120,
+  "sizeModifier": 1,
+  "countModifier": 1,
+  "materialsModifier": 1,
+  "complexityModifier": 1,
+  "hurryModifier": 100
  }
 }

--- a/Assets/Data/buildings/prehistoric/building_fertility_dance.json
+++ b/Assets/Data/buildings/prehistoric/building_fertility_dance.json
@@ -29,6 +29,22 @@
      "scope": "plot"
     }
    ]
+  },
+  "build": {
+   "all": [
+    "TECH_PREHISTORIC_DANCE",
+    {
+     "any": [
+      "BUILDING_DANCE_HUT",
+      "BUILDING_DANCE_HALL",
+      "BUILDING_NIGHT_CLUB"
+     ]
+    },
+    {
+     "type": "MAPCATEGORY_EARTH",
+     "scope": "plot"
+    }
+   ]
   }
  },
  "food": {
@@ -58,11 +74,19 @@
  "identity": {
   "description": "TXT_KEY_BUILDING_FERTILITY_DANCE",
   "civilopedia": "TXT_KEY_BUILDING_FERTILITY_DANCE_PEDIA",
-  "notConstructible": true,
+  "notConstructible": false,
   "worth": 1,
   "advisor": "ADVISOR_ECONOMY",
   "mapCategories": [
    "MAPCATEGORY_EARTH"
   ]
+ },
+ "cost": {
+  "production": 120,
+  "sizeModifier": 1,
+  "countModifier": 1,
+  "materialsModifier": 1,
+  "complexityModifier": 1,
+  "hurryModifier": 100
  }
 }

--- a/Assets/Data/buildings/prehistoric/building_fire_dance.json
+++ b/Assets/Data/buildings/prehistoric/building_fire_dance.json
@@ -28,6 +28,24 @@
      "scope": "plot"
     }
    ]
+  },
+  "build": {
+   "all": [
+    "TECH_PREHISTORIC_DANCE",
+    "TECH_CONTROLLED_FIRE",
+    {
+     "any": [
+      "BUILDING_IMU",
+      "BUILDING_FIRE_PIT",
+      "BUILDING_BONFIRE",
+      "BUILDING_CHARCOAL_BURNER"
+     ]
+    },
+    {
+     "type": "MAPCATEGORY_EARTH",
+     "scope": "plot"
+    }
+   ]
   }
  },
  "culture": {
@@ -62,12 +80,20 @@
  "identity": {
   "description": "TXT_KEY_BUILDING_FIRE_DANCE",
   "civilopedia": "TXT_KEY_BUILDING_FIRE_DANCE_PEDIA",
-  "notConstructible": true,
+  "notConstructible": false,
   "worth": 1,
   "conquestProbability": 70,
   "advisor": "ADVISOR_CULTURE",
   "mapCategories": [
    "MAPCATEGORY_EARTH"
   ]
+ },
+ "cost": {
+  "production": 120,
+  "sizeModifier": 1,
+  "countModifier": 1,
+  "materialsModifier": 1,
+  "complexityModifier": 1,
+  "hurryModifier": 100
  }
 }

--- a/Assets/Data/buildings/prehistoric/building_moon_dance.json
+++ b/Assets/Data/buildings/prehistoric/building_moon_dance.json
@@ -26,6 +26,22 @@
      "scope": "plot"
     }
    ]
+  },
+  "build": {
+   "all": [
+    "TECH_PREHISTORIC_DANCE",
+    {
+     "any": [
+      "BUILDING_DANCE_HUT",
+      "BUILDING_DANCE_HALL",
+      "BUILDING_NIGHT_CLUB"
+     ]
+    },
+    {
+     "type": "MAPCATEGORY_EARTH",
+     "scope": "plot"
+    }
+   ]
   }
  },
  "culture": {
@@ -55,11 +71,19 @@
  "identity": {
   "description": "TXT_KEY_BUILDING_MOON_DANCE",
   "civilopedia": "TXT_KEY_BUILDING_MOON_DANCE_PEDIA",
-  "notConstructible": true,
+  "notConstructible": false,
   "worth": 1,
   "advisor": "ADVISOR_ECONOMY",
   "mapCategories": [
    "MAPCATEGORY_EARTH"
   ]
+ },
+ "cost": {
+  "production": 120,
+  "sizeModifier": 1,
+  "countModifier": 1,
+  "materialsModifier": 1,
+  "complexityModifier": 1,
+  "hurryModifier": 100
  }
 }

--- a/Assets/Data/buildings/prehistoric/building_nature_dance.json
+++ b/Assets/Data/buildings/prehistoric/building_nature_dance.json
@@ -26,6 +26,22 @@
      "scope": "plot"
     }
    ]
+  },
+  "build": {
+   "all": [
+    "TECH_PREHISTORIC_DANCE",
+    {
+     "any": [
+      "BUILDING_DANCE_HUT",
+      "BUILDING_DANCE_HALL",
+      "BUILDING_NIGHT_CLUB"
+     ]
+    },
+    {
+     "type": "MAPCATEGORY_EARTH",
+     "scope": "plot"
+    }
+   ]
   }
  },
  "culture": {
@@ -55,11 +71,19 @@
  "identity": {
   "description": "TXT_KEY_BUILDING_NATURE_DANCE",
   "civilopedia": "TXT_KEY_BUILDING_NATURE_DANCE_PEDIA",
-  "notConstructible": true,
+  "notConstructible": false,
   "worth": 1,
   "advisor": "ADVISOR_ECONOMY",
   "mapCategories": [
    "MAPCATEGORY_EARTH"
   ]
+ },
+ "cost": {
+  "production": 120,
+  "sizeModifier": 1,
+  "countModifier": 1,
+  "materialsModifier": 1,
+  "complexityModifier": 1,
+  "hurryModifier": 100
  }
 }

--- a/Assets/Data/buildings/prehistoric/building_rain_dance.json
+++ b/Assets/Data/buildings/prehistoric/building_rain_dance.json
@@ -26,6 +26,22 @@
      "scope": "plot"
     }
    ]
+  },
+  "build": {
+   "all": [
+    "TECH_PREHISTORIC_DANCE",
+    {
+     "any": [
+      "BUILDING_DANCE_HUT",
+      "BUILDING_DANCE_HALL",
+      "BUILDING_NIGHT_CLUB"
+     ]
+    },
+    {
+     "type": "MAPCATEGORY_EARTH",
+     "scope": "plot"
+    }
+   ]
   }
  },
  "food": {
@@ -55,11 +71,19 @@
  "identity": {
   "description": "TXT_KEY_BUILDING_RAIN_DANCE",
   "civilopedia": "TXT_KEY_BUILDING_RAIN_DANCE_PEDIA",
-  "notConstructible": true,
+  "notConstructible": false,
   "worth": 1,
   "advisor": "ADVISOR_CULTURE",
   "mapCategories": [
    "MAPCATEGORY_EARTH"
   ]
+ },
+ "cost": {
+  "production": 120,
+  "sizeModifier": 1,
+  "countModifier": 1,
+  "materialsModifier": 1,
+  "complexityModifier": 1,
+  "hurryModifier": 100
  }
 }

--- a/Assets/Data/buildings/prehistoric/building_war_dance.json
+++ b/Assets/Data/buildings/prehistoric/building_war_dance.json
@@ -26,6 +26,22 @@
      "scope": "plot"
     }
    ]
+  },
+  "build": {
+   "all": [
+    "TECH_PREHISTORIC_DANCE",
+    {
+     "any": [
+      "BUILDING_DANCE_HUT",
+      "BUILDING_DANCE_HALL",
+      "BUILDING_NIGHT_CLUB"
+     ]
+    },
+    {
+     "type": "MAPCATEGORY_EARTH",
+     "scope": "plot"
+    }
+   ]
   }
  },
  "culture": {
@@ -75,11 +91,19 @@
  "identity": {
   "description": "TXT_KEY_BUILDING_WAR_DANCE",
   "civilopedia": "TXT_KEY_BUILDING_WAR_DANCE_PEDIA",
-  "notConstructible": true,
+  "notConstructible": false,
   "worth": 1,
   "advisor": "ADVISOR_CULTURE",
   "mapCategories": [
    "MAPCATEGORY_EARTH"
   ]
+ },
+ "cost": {
+  "production": 120,
+  "sizeModifier": 1,
+  "countModifier": 1,
+  "materialsModifier": 1,
+  "complexityModifier": 1,
+  "hurryModifier": 100
  }
 }


### PR DESCRIPTION
The rain, war, fire, nature, moon, fertility and blood dances were unreachable in practice. Their only route was an entertainer's construct mission, and nothing in the game described either the buildings or the mission — so unless you happened to build an entertainer and notice the button, the content did not exist for you.

They are now normally buildable: 120 hammers, gated on Prehistoric Dance plus a dance venue. **Entertainers can still construct them** — that route was slated for removal because the AI ignored it, but the mission handling improved during the data migration, so both paths now work.

Fixing this by conformance rather than by adding help text was the owner's call: the buildings now behave like every other building, which is the discoverability answer without more UI text.

## What changed

Authored in `Assets/Data/_additions/buildings.json` (curation is complete, so gameplay additions go in the overlay, not the legacy XML) and regenerated — 7 entity files.

Per building: `cost.production: 120`, `identity.notConstructible: false`, and a restored `requires.build`.

## Why `requires.build` had to be rebuilt

The legacy records carry no `<iCost>`. `curate_building.py:1756` reads that as the not-player-constructible sentinel and sets `identity.notConstructible`; line 1758 then folds `requires.build` into `requires.operate`, because a queue-excluded building has no build gate left to read. Clearing the flag without un-folding would have put the buildings in the queue **with no build gate at all**, so the overlay restores the `PrereqTech`, `PrereqOrBuildings` and `MapCategoryTypes` clauses.

Clauses that are genuinely ongoing deliberately stayed in `requires.operate`:

- **blood dance** is authored `<bRequiresActiveCivics>1</bRequiresActiveCivics>`, so its Anarchism/Chiefdom gate must keep holding, not be checked once at build time
- **fertility dance** keeps its `dormant` clause against `BUILDING_EFFECT_FERTILITY_FESTIVAL`

## Verification

- `curate_additions.py`: 25 buildings merged, 0 missing
- `readjson.exe --render`: all 7 parse
- each new `requires.build` is byte-identical in structure to the curator's own untouched `operate` clause on the same entity

**Not observed in a running game.** For a tester: the seven dances should appear in the build list once you hold Prehistoric Dance and a Dance Hut / Dance Hall / Night Club (fire dance wants Controlled Fire and a fire building instead), and an entertainer's construct mission should still work as before.

## Note for reviewers

`readjson --render` displays these gates misleadingly — it renders an `any` group of scalars as several `(one of: X)` entries joined by `AND`. That is a defect in the render tool (`Tools/ReadJson/readjson.cpp:292` assumes an array-of-groups; the corpus has 2,704 flat `any` groups and zero array-of-groups), not in this data. Filed separately rather than fixed here.

Closes #386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)