### PR TITLE
docs: correct six statements the tree contradicts

### DIFF
--- a/Sources/Infos/CvHideAndSeekSection.h
+++ b/Sources/Infos/CvHideAndSeekSection.h
@@ -5,7 +5,7 @@
 //
 //	CvHideAndSeekSection -- the json.md par.9 `hideAndSeek` own-block as ONE composable typed section object
 //	(patterns.md par. THE GETTER SETUP category 1: sections are whole typed objects). The concealment-vs-detection
-//	CONTEST, gated by GAMEOPTION_COMBAT_HIDE_AND_SEEK, and the own-block sibling of CvSizeMattersSection. Units,
+//	CONTEST, gated by GAMEOPTION_COMBAT_HIDE_SEEK, and the own-block sibling of CvSizeMattersSection. Units,
 //	promotions and unit-combats share the exact key vocabulary, so ONE unit serves all three.
 //
 //	⛔ THIS IS NOT `vision`, AND THE SPLIT IS THE POINT (owner). `vision` is an ordinary modifier FAMILY answering

--- a/Sources/Mainpage.md
+++ b/Sources/Mainpage.md
@@ -189,8 +189,8 @@ Groups multiple `CvSelectionGroup` objects under a unified command:
 - Tracks a leader group, a list of member group IDs, a target plot, and a mission type.
 - `doTurn()` drives coordinated movement; `CheckTargetCity()` and
   `CheckTargetDefendPlot()` evaluate objective validity each turn.
-- Guarded by the `CVARMY_BREAKSAVE` compile switch (disabled by default to maintain
-  save-game compatibility).
+- Compiled in: `CVARMY_BREAKSAVE` is defined unconditionally in `Sources/Defines/CvDefines.h`, and
+  `CvPlayerAI::AI_formArmies()` runs from the per-turn AI pass.
 
 ### Map and Plot (`CvMap`, `CvPlot`)
 

--- a/docs/cascade.md
+++ b/docs/cascade.md
@@ -1657,8 +1657,12 @@ OPEN (a new predicate/type is a new key, never a reshape). It is also the destin
 component retires ONTO ([ContextDict replaces CvDerivedCache](#-cvderivedcache-is-replaced-by-contextdict--virtually-everywhere-owner)). `plotAttrs` keys on the `CASC_PRED_*` HAS_/IS_ plot
 predicate ids; `policies` on the `POLICY_*` classification ids.
 
-Non-dictionary scalars stay plain: population/power are `int` (power carries 0/1 today but stays `int` so a future
-**volumetric** model needs no reshape); state religion is a **single enum**, not a dictionary (there is exactly one).
+Non-dictionary scalars stay plain: population is an `int` forwarded from `CvCity::m_iPopulation`; state religion is a
+**single enum**, not a dictionary (there is exactly one). ⛔ **Power is NOT one of them** — it is an amenity
+DICTIONARY count (`CityContext::amenityCount(CLS_AMENITY_PROVIDES_POWER)`), which is why a removal DECREMENTS and a
+city with two plants stays lit. A **volumetric** power model would not widen a scalar either: it would move power
+from a classification key to a modifier-family CHANNEL (§ the airlift worked case), so there is nothing here to
+future-proof.
 
 ### Maintained EVENT-DRIVEN — never a per-turn recompute
 

--- a/docs/plans/structural-cleanup/README.md
+++ b/docs/plans/structural-cleanup/README.md
@@ -1,7 +1,17 @@
 # Structural cleanup — the #430 work tier
 
-> #430 is effectively over; what remains is polish, tracked per-concept in `docs/specs/`/`docs/reference/`
-> rather than as a standing migration worklist here.
+> **The #430 ENGINE is built and wired; its CONSUMER half is not.** The cascade, enabler and spine are in the tree
+> and maintained rather than recomputed, and that half's leftovers are polish, tracked per-concept in
+> `docs/specs/`/`docs/reference/` rather than as a standing worklist here.
+>
+> ⛔ **What is NOT polish: the AI/engine consumers that still walk the INFO REGISTRIES instead of reading the
+> compiled edges.** `python Tools/verify-registry-scans.py` is that census — ENABLER-DOMAIN sites re-point onto the
+> maintained frontier, OTHER-REGISTRY sites invert onto the entity's own compiled entries.
+> ⚖ Only a DECISION path is a defect: init, reset, serialization, save/load, UI enumeration and text rendering
+> legitimately walk a registry, so triage per site. The counts are a **RATCHET** — they may only fall, and a rise
+> means a scan was re-introduced.
+> ⚑ This is about INFO registries, not iteration in general: a plot is a game-world object, not an info, so bounded
+> plot iteration is normal and is not what this tracks.
 
 ## Owner-LOCKED
 

--- a/docs/specs/json.md
+++ b/docs/specs/json.md
@@ -1546,7 +1546,7 @@ Data read by a specific system, not the cascade. Use only when the entity needs 
   > ([AGENTS.md](../../AGENTS.md#design)), which is why the reason is recorded here rather than left in a
   > comment. Leave the member, its save tag and the commented plane as they are; the verdict is re-taken when
   > revolutions are.
-- **`hideAndSeek`** — the concealment-vs-detection CONTEST (gated by `GAMEOPTION_COMBAT_HIDE_AND_SEEK`), the
+- **`hideAndSeek`** — the concealment-vs-detection CONTEST (gated by `GAMEOPTION_COMBAT_HIDE_SEEK`), the
   own-block sibling of `sizeMatters`. **Two contest members, one per side of the equation:** `concealment` (how
   well this unit hides) and `detection` (how well it finds a hidden one, per method it answers, each entry
   qualified `{unit: HAS_<SKILL>}`). Both are graduated magnitudes and both may be NEGATIVE — a negative

--- a/docs/specs/save.md
+++ b/docs/specs/save.md
@@ -8,10 +8,17 @@
 
 ## 1. The format — name-keyed, not positional
 
-Saves are `(id, type-code, value)` tuples keyed by a normalized **`"ClassName::memberName"`** tag; there is **no
-save-version number** — compatibility resolves dynamically by name (`CvTaggedSaveFormatWrapper`). A read asks for a
-tag and `Expect()` matches it against the stream. Because position doesn't matter, adding / removing / reordering
-fields is handled by name, never by a version gate.
+Saves are `(id, type-code, value)` tuples keyed by a normalized **`"ClassName::memberName"`** tag: **field-level**
+compatibility resolves dynamically by name (`CvTaggedSaveFormatWrapper`). A read asks for a tag and `Expect()` matches
+it against the stream. Because position doesn't matter, adding / removing / reordering fields is handled by name,
+never by a version gate.
+
+⚠ **There IS a whole-save version stamp, and it is an all-or-nothing GATE, not a migration router.**
+`SAVE_FORMAT_VERSION` (`Sources/Defines/CvDefines.h`) is written by `CvInitCore::write` and read back by
+`CvInitCore::read`, which throws `std::invalid_argument` behind an "Unreadable Save Game!" message box on any
+mismatch (`Sources/Engine/CvInitCore.cpp` ~:1701-1709). Bumping it makes **every** existing save unreadable in one
+step — it is the deliberate hard-break switch, and it is unrelated to the per-field name matching above. ⛔ Do not
+reach for it to solve a field-level change: that is what §3's soft-remove exists for.
 
 ## 2. Adding a field is SOFT (nothing to declare)
 

--- a/docs/specs/validation.md
+++ b/docs/specs/validation.md
@@ -82,9 +82,10 @@ Live verification reads the HTTP surface ([http-endpoints.md](http-endpoints.md)
 still-open work of building ONE new uniform getter set and disconnecting the legacy channel-shaped getters —
 [build a new getter surface, never widen a legacy one](../architecture/patterns.md#-the-two-read-roles--one-grammar-two-answers-owner),
 [patterns.md § THE TWO READ ROLES](../architecture/patterns.md)), so a
-manifestation poll reads the SPINE-WRITTEN LOGS plus the four stored-side DECOMPOSITION censuses that survive
-(`/computed/cascade/packages`, `/computed/enabler/operating`, `/computed/city/yield`, `/computed/capabilities` —
-[http-endpoints.md](http-endpoints.md)). ⛔ Their `oracle` twins are DEAD for the reason above (§ THERE IS NO
+manifestation poll reads the SPINE-WRITTEN LOGS plus the stored-side DECOMPOSITION censuses that survive. ⚠ Their
+number is deliberately NOT stated here — an enumerated route list in a doc has drifted twice: the `ROUTES` table in
+`Sources/Tools/CvHttpServer.cpp::handleRequest` is their census, and `GET /computed` serves the live index
+([http-endpoints.md](http-endpoints.md)). ⛔ Their `oracle` twins are DEAD for the reason above (§ THERE IS NO
 COMPARISON TWIN) and must not be run as evidence nor rebuilt. Everything else a check wants must be EMITTED
 first; emitting it is step one of that item's fix, and a value not on the surface is not verifiable — never
 eyeballed off the screen as a substitute.


### PR DESCRIPTION
Found while auditing the open issue list against the post-migration tree. **Every claim was verified against `Sources/` before the doc was touched** — the tree is the authority, and these six had drifted from it. Two of them were actively dangerous: they would send the next reader down a path the code does not support.

| doc | said | tree says |
|---|---|---|
| `specs/save.md` §1 | "there is **no** save-version number" | `SAVE_FORMAT_VERSION` is written, read, and hard-throws on mismatch |
| `cascade.md` | power is a plain `int` non-dictionary scalar | power is an amenity **dictionary** count |
| `plans/structural-cleanup/README.md` | "#430 is effectively over; what remains is polish" | true of the engine, false of the consumers |
| `specs/json.md` | `GAMEOPTION_COMBAT_HIDE_AND_SEEK` | `GAMEOPTION_COMBAT_HIDE_SEEK` |
| `Sources/Infos/CvHideAndSeekSection.h` | same nonexistent option | same |
| `Sources/Mainpage.md` | armies "disabled by default" | `CVARMY_BREAKSAVE` defined unconditionally; `AI_formArmies()` runs |
| `specs/validation.md` | "the four ... censuses" | the `ROUTES` table holds eight |

## The two that mattered most

**`save.md`** — `SAVE_FORMAT_VERSION` is written by `CvInitCore::write` and read back by `CvInitCore::read`, which throws `std::invalid_argument` behind an "Unreadable Save Game!" message box on any mismatch (`Sources/Engine/CvInitCore.cpp` ~:1701-1709). The doc's underlying point was right — *field-level* compatibility is name-keyed — but stating that no version number exists hides the exact lever a deliberate save break would reach for, and it is the hook #426 was asking about. The passage now separates the two mechanisms and says explicitly not to reach for the version gate to solve a field-level change.

**`structural-cleanup/README.md`** — "effectively over ... polish" is true of the cascade/enabler/spine engine and false of the consumer half. Calling the surviving info-registry walks polish is how an agent concludes the work is done and builds on top of a scan. It now names `verify-registry-scans.py` as the census, states the decision-path rule so legitimate init/reset/serialization/UI walks are not swept up, and records that the counts are a ratchet. It also states that this concerns **info** registries only — a plot is a game-world object, not an info, so bounded plot iteration is explicitly not what it tracks.

## Notes on approach

- **`cascade.md`**: the file already ruled that a volumetric power model would move power to a modifier-family *channel*, so the "stays `int` so a future volumetric model needs no reshape" clause was both factually wrong about today's storage and arguing for the wrong future. Verified: no plain int power member exists; `CvCity::getPowerCount()` is `m_cityContext.amenityCount(CLS_AMENITY_PROVIDES_POWER)`, and `CityContext.h` documents the decrement-on-removal behaviour that only a refcount has.
- **`validation.md`**: fixed by **removing** the enumeration rather than extending it to eight. An enumerated route list in a doc has now drifted twice, so it points at the `ROUTES` table and the live `GET /computed` index instead — extending it would just re-arm the same trap.
- No behaviour changes. The two `Sources/` edits are a comment and a Doxygen page.

`python Tools/verify-docs.py` passes (exit 0). The advisory symbol census is unchanged and pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)