### PR TITLE
The process conversion percent was scaled at load (#485, #471)

### DIFF
--- a/Sources/AI/CvCityAI.cpp
+++ b/Sources/AI/CvCityAI.cpp
@@ -6901,9 +6901,9 @@ int64_t CvCityAI::AI_processValue(ProcessTypes eProcess, CommerceTypes eCommerce
 		{
 			continue;
 		}
-		// The authored PERCENT, reduced from its ×100 storage. The divisor below accounts for the commerce
-		// WEIGHT's ×100 only ("60 * 100"), so leaving this operand scaled valued every process a hundredfold.
-		int64_t iTempValue = GC.getProcessInfo(eProcess).getProductionToCommerce(eCommerce, CASC_SCOPE_CITY) / 100;
+		// The authored PERCENT, unscaled at the load edge. The divisor below accounts for the commerce
+		// WEIGHT's ×100 only ("60 * 100"); this operand carries no scale of its own.
+		int64_t iTempValue = GC.getProcessInfo(eProcess).getProductionToCommerce(eCommerce, CASC_SCOPE_CITY);
 
 		iTempValue *= GET_PLAYER(getOwner()).AI_commerceWeight(eCommerce, this); // scaled by 100 at this point
 		if (iTempValue == 0) continue; // weight may very well be 0 if commerce is worthless.

--- a/Sources/AI/CvPlayerAI.cpp
+++ b/Sources/AI/CvPlayerAI.cpp
@@ -2493,7 +2493,7 @@ int CvPlayerAI::AI_foundValue(int iX, int iY, int iMinRivalRange, bool bStarting
 				iGreed < 140 && itProcess != availableProcesses.end(); ++itProcess)
 			{
 				const CvProcessInfo& kProcess = GC.getProcessInfo((ProcessTypes)*itProcess);
-				iGreed = std::max(iGreed, 100 + 20 * std::min(2, (kProcess.getProductionToCommerce(COMMERCE_CULTURE, CASC_SCOPE_CITY) / 100)));
+				iGreed = std::max(iGreed, 100 + 20 * std::min(2, kProcess.getProductionToCommerce(COMMERCE_CULTURE, CASC_SCOPE_CITY)));
 			}
 
 			for (int iI = 0; (iGreed < 140 && iI < GC.getNumSpecialistInfos()); iI++)
@@ -5418,9 +5418,9 @@ int CvPlayerAI::AI_techValue(TechTypes eTech, int iPathLength, bool bIgnoreCost,
 
 		for (int iK = 0; iK < NUM_COMMERCE_TYPES; iK++)
 		{
-			// The authored PERCENT, reduced from its ×100 storage -- the ÷100 below accounts for the commerce
+			// The authored PERCENT, unscaled at the load edge -- the ÷100 below accounts for the commerce
 			// WEIGHT's scale, not this operand's.
-			iTempValue = (GC.getProcessInfo(eLoopProcess).getProductionToCommerce((CommerceTypes)iK, CASC_SCOPE_CITY) / 100 * 4);
+			iTempValue = (GC.getProcessInfo(eLoopProcess).getProductionToCommerce((CommerceTypes)iK, CASC_SCOPE_CITY) * 4);
 
 			iTempValue *= AI_commerceWeight((CommerceTypes)iK);
 			iTempValue /= 100;

--- a/Sources/Data/CvInfoValuation.cpp
+++ b/Sources/Data/CvInfoValuation.cpp
@@ -716,10 +716,9 @@ int64_t InfoValuation::commerceSplit(int64_t commerceYieldRate, int iSliderPerce
 	}
 	// TIER 2 -- the process conversion, added AFTER the percentages and never multiplied by them. The production
 	// yield truncates to whole hammers BEFORE the conversion scales it (the engine's order, mirrored verbatim).
-	// ⚠ The rate is an authored PERCENT carried ×100, so reducing it needs ÷100 for the fixed point AND ÷100 for
-	// the percent. Only the first was applied, so a 50% process paid FIFTY times the hammers instead of half.
-	// Reduced ONCE here, at the read edge, so the authored two decimals survive the multiply.
-	int64_t iProcessConversion = (productionYieldRate / 100) * (int64_t)iProductionToCommerce / 10000;
+	// The rate is an authored PERCENT, so it is unscaled: whole hammers × the percent IS the ×100 amount this
+	// sum is in, and no divisor belongs here.
+	int64_t iProcessConversion = (productionYieldRate / 100) * (int64_t)iProductionToCommerce;
 	const int64_t iRate = iShare * iModifier / 100 + channelDeposits + iProcessConversion;
 	if (pTerms != NULL)
 	{

--- a/Sources/Infos/CvProcessInfo.cpp
+++ b/Sources/Infos/CvProcessInfo.cpp
@@ -6,7 +6,7 @@
 
 #include "CvGameCoreDLL.h"
 #include "CvProcessInfo.h"
-#include "CvJsonParse.h"   // jsonChildObj + jsonX100 -- the shared parse primitives (never re-hand-rolled)
+#include "CvJsonParse.h"   // jsonChildObj + jsonIdInt -- the shared parse primitives (never re-hand-rolled)
 
 CvProcessInfo::CvProcessInfo()
 	: m_eTechPrereq(NO_TECH)
@@ -39,10 +39,6 @@ void CvProcessInfo::mapFrom(const picojson::value& entity)
 	const char* aszChannels[NUM_COMMERCE_TYPES] = { "gold", "research", "culture", "espionage" };
 	for (int iCommerce = 0; iCommerce < NUM_COMMERCE_TYPES; ++iCommerce)
 	{
-		picojson::object::const_iterator channelIt = pConversion->find(aszChannels[iCommerce]);
-		if (channelIt != pConversion->end() && channelIt->second.is<double>())
-		{
-			m_aiProductionToCommerce[iCommerce] = jsonX100(channelIt->second.get<double>());
-		}
+		m_aiProductionToCommerce[iCommerce] = jsonIdInt(*pConversion, aszChannels[iCommerce]);
 	}
 }

--- a/Sources/Infos/CvProcessInfo.h
+++ b/Sources/Infos/CvProcessInfo.h
@@ -30,7 +30,7 @@ public:
 	virtual const CvModifiers* getModifiers() const { return &m_modifiers; }
 
 	// ======================= 3. THE CONVERSION PLANE -- one materialized §9 block ============================
-	// The production->commerce conversion rate (×100: authored 50 reads 5000), per channel -- a bare member
+	// The production->commerce conversion rate -- an authored PERCENT, so it is NOT scaled, per channel -- a bare member
 	// read over the plane mapFrom materializes from the `conversion` block. The conversion is the CITY's
 	// hammers-fold (the §2a EXTRA leg `production × prodToCommerce`), so only the city scope answers; the
 	// scope parameter stays spelled out (docs/architecture/patterns.md §The coherent surface (scope is a separate axis) -- the signature the consumers already ask).


### PR DESCRIPTION
Running a wealth / research / culture / spy process showed a fraction of what it should — **90 hammers reading as 0.3 research** — while the research actually credited to the tech was a **hundred times too much**. Both are now the same number, and it is the authored one: a 50% process converts half the hammers.

## Root cause: one line at the IN boundary

The conversion rate is an authored **PERCENT**. `CvProcessInfo::mapFrom` put it through `jsonX100`, which converts **amounts**. Percents are never scaled.

`CvJsonParse.h` says so at the declaration, and names this exact failure:

> ⛔ IT IS NOT A BLANKET, AND READING IT AS ONE IS THE COSTLIEST MISTAKE ON THIS SURFACE … Believing this was a blanket is what produced a family of such divides — zeroed AI war declarations, culture thresholds and property decay among them.

And `fixed-point-and-scales.md` predicts the shape it produces:

> that magic `10000` then has to be threaded through every consumer — which is exactly the fudge-factor class §4c-bis exists to reject

That `10000` was sitting in `commerceSplit`.

## Re-pointing the load edge deletes the constants rather than moving them

| site | change |
|---|---|
| `CvProcessInfo::mapFrom` | `jsonX100` → `jsonIdInt` (the shared plain read) |
| `commerceSplit` | `/10000` **gone** — whole hammers × percent IS the ×100 amount that sum is already in |
| `AI_processValue` | `/100` dropped |
| `AI_techValue` | `/100` dropped |
| `AI_foundValue` | `/100` dropped — **this one had to change**: on an unscaled rate the integer divide floors 50 → 0 and silently zeroes culture greed |

Net **−5 lines**, and every edit removes a constant. Four further sites needed no edit and are correct now that the operand is — the four payment legs in `CvCity::changeProduction`, which already reduce the percent themselves, and the process tooltip, which was printing **"Converts 5000% of Production"**.

## Why #471 reopened

The previous fix read `commerceSplit`'s `hammers * 50` as fifty times the hammers. It isn't — that function returns a **×100 rate**, where `90 × 50` is `45.00`, i.e. half. It was already correct, and dividing it again is what made the displayed rate a hundredth.

The 50× overpay it was chasing is real, but it lives in the **payment** path (`CvCity.cpp:3142-3155`), and `git log -L` confirms that block was never opened by that commit. So the tree ended up with the rate 100× low and the payment 100× high — opposite directions, one root.

## Known remaining, not fixed here

The **Finance Advisor's per-city wealth column** (`CvFinanceAdvisor.py:478`) reads `CvCity::m_aiProductionToCommerceModifier`, a legacy accumulator whose only consumer is its own Python binding, and multiplies two ×100 operands under a single `/100`. It is a second implementation of `commerceSplit`'s `processConversion` term, which is why it drifted unnoticed.

⚠ **Correction to an earlier draft of this description:** that column does not mis-display a number, it **raises**. `CyCity::getProductionToCommerceModifier` is defined in C++ but registered to Python nowhere, so the call is an `AttributeError`. The accumulator is therefore entirely unreachable — written, serialized, and read only by a dead binding — which strengthens the case for deleting it rather than re-scaling it.

Tracked as #491 (deletion + `savemigration` soft-remove) and #488 (the wider binding breakage: 172 Cy methods Python calls are registered nowhere).

## Verification

`Assert rebuild` clean. **Not observed in a running game.**

For a tester: put a city on a Wealth/Research process and check that the yield tooltip, the city's commerce rate, and the actual gold/beakers gained all agree at half the hammers. The process tooltip should read "Converts 50% of Production", not 5000%.

Closes #485. Reopens and fixes the actual defect behind #471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

