### PR TITLE
tooling: verify-python-bindings — count the Python migration burndown (#488)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,6 +298,23 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File "../Tools/_Build.ps1" <C
   game mechanics are not, and the preprocessor cannot tell you which. The check REPORTS those three classes for
   a human verdict and never fails on them. ⛔ It also flags TU-LOCAL guards (`#define`d in a `Sources/` file, so
   ON in some translation units and OFF in others) as never-collapse-mechanically.
+- **Dead Python bindings: `python Tools/verify-python-bindings.py [--list]`** — a `Cy*` method is reachable from
+  Python ONLY if some `class_<CyX>` block `.def("name", …)`s it; being a public C++ member is not enough. Remove
+  the `.def` and the C++ still compiles, the header still looks alive, and every Python caller starts raising
+  `AttributeError`. ⚑ The COMPILER CANNOT SEE IT — the break lives between a registration list and a `.py` file
+  the compiler never reads — and it fails naming the CALLER, so it reads as *"the advisor is broken"*, never as
+  *"a binding is missing"*. A binding sweep produces it in bulk: one commit cut 494 dangling Cy bindings and
+  nothing checked what still called them. ⛔ **Registration lives in TWO styles and scanning one under-reports
+  badly**: inline `class_<CyX>("CyX").def(…)` under `Sources/Python/`, and loader functions taking
+  `class_<CyX>& inst` under `Sources/Infrastructure/CvPython*Loader.cpp` — so the tool takes the UNION of every
+  `.def("name")` and deliberately does NOT attribute a name to a class (attribution is not needed for the verdict
+  and every attempt at it manufactured false positives). It also requires the call's RECEIVER to denote a Cy
+  handle, which is what makes it precise — `add` is both a `CvArgsList` member and Python's own `set.add`, so a
+  receiver-blind scan reports 40 phantom sites for it and buries the real findings under ~200 like it.
+  ⛔ If it fires, fix the SIDE THAT IS WRONG: a binding Python legitimately needs is RE-REGISTERED; a call into a
+  mechanic that is gone has its PYTHON deleted. **Never register a method just to silence it** — an endpoint is a
+  live consumer, so re-exposing a legacy read keeps that member alive past the compiler census. ⚖ It also REPORTS
+  (never fails on) unresolved calls — names registered nowhere, defined on no `Cy*` class, and not a Python `def`.
 
 ### Adding a new source subdirectory
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,14 +300,18 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File "../Tools/_Build.ps1" <C
   ON in some translation units and OFF in others) as never-collapse-mechanically.
 - **Python migration burndown: `python Tools/verify-python-bindings.py [--list]`** — counts the methods still
   DECLARED on a `Cy*` wrapper, registered nowhere, and still CALLED from Python: i.e. consumers not yet
-  re-pointed onto the new read surface. ⛔ **NOT a bug count.** The `Cy*` read-surface cut is DIRECTIONAL and
-  intentional ([the cut is directional](docs/architecture/patterns.md)) — Python→engine READS die, the wrapper
-  keeps only its IDENTITY SET (owner + id + position), the engine→Python callback direction stays — and it
-  deliberately ran AHEAD of the Python migration, because the cut is the forcing function that drives
-  completeness. `CyUnit` publishing 8 methods is that design, not damage. What never existed is a way to count
-  what is LEFT. ⚖ **ADVISORY, and a RATCHET like the registry scans: the count may only FALL**; a rise means a
-  legacy declaration was revived or a legacy call added. It does not fail the run — a permanently-red gate on a
-  known in-progress migration is one nobody can act on.
+  re-pointed onto the coherent reads. ⛔ **NOT a bug count, and NOT a re-registration list.** The `Cy*` bindings
+  ARE the API surface for Python — a type publishes the GET/PUT/POST it is required to
+  ([the identity set is the floor, not the ceiling](docs/architecture/patterns.md)); the legacy per-field
+  contract is what died, not the surface. The tree shows the re-home well under way — `CyPlayer` 332 endpoints,
+  `CyCity` 157 (the group reads `getYields`/`getCommerces`/`getWellbeing`/`getScalars`/… plus mutators),
+  `CyTeam` 116, `CyPlot` 106 — so a THIN wrapper is an UN-RE-HOMED TYPE, never a finished one.
+  ⚑ **The count is CONCENTRATED, which is the useful part**, and splits into two different jobs: a type that HAS
+  its group reads and still carries the legacy names beside them (`CyCity` — 157 published against 110 legacy;
+  *the collision IS the work*), and a type not re-homed at all whose GET surface must be built first (`CyUnit` —
+  8 published against 58 legacy). ⚖ **ADVISORY, and a RATCHET like the registry scans: the count may only
+  FALL**; a rise means a legacy declaration was revived or a legacy call added. It does not fail the run — a
+  permanently-red gate on a known in-progress migration is one nobody can act on.
   ⛔ **CLOSE ONE BY KILLING THE DECLARATION, NEVER BY RE-REGISTERING IT.** An unpublished legacy method on a
   wrapper is the per-field contract still written down, so the next agent reads it as the surface and *"just
   publish what is already declared"* looks like the cheap fix exactly when the new surface arrives. The

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,23 +298,33 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File "../Tools/_Build.ps1" <C
   game mechanics are not, and the preprocessor cannot tell you which. The check REPORTS those three classes for
   a human verdict and never fails on them. ⛔ It also flags TU-LOCAL guards (`#define`d in a `Sources/` file, so
   ON in some translation units and OFF in others) as never-collapse-mechanically.
-- **Dead Python bindings: `python Tools/verify-python-bindings.py [--list]`** — a `Cy*` method is reachable from
-  Python ONLY if some `class_<CyX>` block `.def("name", …)`s it; being a public C++ member is not enough. Remove
-  the `.def` and the C++ still compiles, the header still looks alive, and every Python caller starts raising
-  `AttributeError`. ⚑ The COMPILER CANNOT SEE IT — the break lives between a registration list and a `.py` file
-  the compiler never reads — and it fails naming the CALLER, so it reads as *"the advisor is broken"*, never as
-  *"a binding is missing"*. A binding sweep produces it in bulk: one commit cut 494 dangling Cy bindings and
-  nothing checked what still called them. ⛔ **Registration lives in TWO styles and scanning one under-reports
-  badly**: inline `class_<CyX>("CyX").def(…)` under `Sources/Python/`, and loader functions taking
-  `class_<CyX>& inst` under `Sources/Infrastructure/CvPython*Loader.cpp` — so the tool takes the UNION of every
-  `.def("name")` and deliberately does NOT attribute a name to a class (attribution is not needed for the verdict
-  and every attempt at it manufactured false positives). It also requires the call's RECEIVER to denote a Cy
-  handle, which is what makes it precise — `add` is both a `CvArgsList` member and Python's own `set.add`, so a
+- **Python migration burndown: `python Tools/verify-python-bindings.py [--list]`** — counts the methods still
+  DECLARED on a `Cy*` wrapper, registered nowhere, and still CALLED from Python: i.e. consumers not yet
+  re-pointed onto the new read surface. ⛔ **NOT a bug count.** The `Cy*` read-surface cut is DIRECTIONAL and
+  intentional ([the cut is directional](docs/architecture/patterns.md)) — Python→engine READS die, the wrapper
+  keeps only its IDENTITY SET (owner + id + position), the engine→Python callback direction stays — and it
+  deliberately ran AHEAD of the Python migration, because the cut is the forcing function that drives
+  completeness. `CyUnit` publishing 8 methods is that design, not damage. What never existed is a way to count
+  what is LEFT. ⚖ **ADVISORY, and a RATCHET like the registry scans: the count may only FALL**; a rise means a
+  legacy declaration was revived or a legacy call added. It does not fail the run — a permanently-red gate on a
+  known in-progress migration is one nobody can act on.
+  ⛔ **CLOSE ONE BY KILLING THE DECLARATION, NEVER BY RE-REGISTERING IT.** An unpublished legacy method on a
+  wrapper is the per-field contract still written down, so the next agent reads it as the surface and *"just
+  publish what is already declared"* looks like the cheap fix exactly when the new surface arrives. The
+  declaration AND its body go; the Python re-points onto the new surface homed on the type it addresses
+  (`CyCity::getPopulation()`, never `getCityPopulation(owner, id)` — *"the moment you have
+  `getAnotherObjectSomething`, we have failed"*). ⚠ NOT killed with them: the `class_<>` REGISTRATION (a
+  zero-`.def` registration is the type identity the kept engine→Python direction needs — the marshaller throws
+  without a registered converter), the identity set, and anything the ENGINE calls on the wrapper.
+  ⛔ **Registration lives in TWO styles and scanning one under-reports badly**: inline `class_<CyX>("CyX").def(…)`
+  under `Sources/Python/`, and loader functions taking `class_<CyX>& inst` under
+  `Sources/Infrastructure/CvPython*Loader.cpp` — so the tool takes the UNION of every `.def("name")` and
+  deliberately does NOT attribute a name to a class. It also requires the call's RECEIVER to denote a Cy handle,
+  which is what makes it precise — `add` is both a `CyArgsList` member and Python's own `set.add`, so a
   receiver-blind scan reports 40 phantom sites for it and buries the real findings under ~200 like it.
-  ⛔ If it fires, fix the SIDE THAT IS WRONG: a binding Python legitimately needs is RE-REGISTERED; a call into a
-  mechanic that is gone has its PYTHON deleted. **Never register a method just to silence it** — an endpoint is a
-  live consumer, so re-exposing a legacy read keeps that member alive past the compiler census. ⚖ It also REPORTS
-  (never fails on) unresolved calls — names registered nowhere, defined on no `Cy*` class, and not a Python `def`.
+  ⚖ It also reports UNRESOLVED CALLS — names registered nowhere, declared on no `Cy*` class, and not a Python
+  `def`: usually a mechanic removed outright, or one that never existed (`getCommerceRateTimes100` is called by
+  two `canTrigger` predicates and has never existed in the tree, so those two random events cannot fire).
 
 ### Adding a new source subdirectory
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -892,6 +892,15 @@ the total-observability bar below.)
   chronicles): it states what IS. Anything outdated is DELETED, not annotated — git history is the archaeology, and
   [superseded-ideas.md](docs/architecture/superseded-ideas.md) is the only tombstone registry (one line per dead
   approach that carries revival risk). Migration/status chronicles belong in `docs/plans/`, never in specs.
+- **⛔ A RULE CARRIES NO EXPIRING REASON — state the rule, not the circumstance that prompted it (owner).** A
+  justification that is true only while some task is in flight does not retire with the task: it stays on the
+  page as PERMISSION, and the next agent reads it as licence to do the smaller thing. ⚑ Measured: *"I only want
+  to refactor the python I have to, otherwise we never will be done"* was scoped to one migration; once that
+  work finished the sentence remained, still reading as a standing instruction to minimise the refactor — beside
+  a rule the tree had already outgrown. **A reason that can expire is a liability, not context.** ⚖ This does
+  NOT ban the durable WHY — why a site is an edge, why a value is genuinely exceptional, why a switch protects
+  against a crash nobody remembers. The test is whether the reason survives the work: if it was true only
+  *during*, it does not go in.
 - **⛔ SPEC + a SHORT BULLETED TODO — never a TODO LIST *inside* a doc, and never status woven through prose
   (owner).** Status claims DRIFT — that is their nature, not a discipline failure — so the more of them a doc
   carries, the faster the whole doc rots and the more confidently it misleads. **A doc is therefore one of two

--- a/Tools/verify-python-bindings.py
+++ b/Tools/verify-python-bindings.py
@@ -2,16 +2,26 @@
 # -*- coding: utf-8 -*-
 """verify-python-bindings -- the PYTHON-SIDE MIGRATION BURNDOWN, counted.
 
-⛔ THIS IS NOT A BUG COUNT. The `Cy*` read-surface cut is DIRECTIONAL AND INTENTIONAL
-(patterns.md, THE CUT IS DIRECTIONAL): Python->engine READS die, the wrapper classes stay
-carrying only their IDENTITY SET (owner + id + position), and the engine->Python callback
-direction is kept. `CyUnit` publishing 8 methods is that design, not damage. The cut
-deliberately ran AHEAD of the Python migration -- "the cut is the forcing function that
-DRIVES completeness, so it never waits on it."
+⛔ THIS IS NOT A BUG COUNT, AND IT IS NOT A LIST OF THINGS TO RE-REGISTER. The `Cy*`
+bindings ARE the API surface for Python -- a type publishes the GET / PUT / POST it is
+required to (patterns.md, THE IDENTITY SET IS THE FLOOR, NOT THE CEILING). The legacy
+per-field contract is what died, not the surface.
+
+The tree shows the re-home well under way: CyPlayer publishes 332 endpoints, CyCity 157
+(the coherent group reads -- getYields, getCommerces, getWellbeing, getScalars,
+getDefenseKinds ... plus its mutators), CyTeam 116, CyPlot 106. A THIN wrapper is
+therefore an UN-RE-HOMED TYPE, never a finished one.
 
 What never existed is a way to COUNT WHAT IS LEFT. That is this tool. It reports the
 methods still DECLARED on a `Cy*` wrapper, registered nowhere, and still CALLED from
-Python -- i.e. Python consumers not yet re-pointed onto the new read surface.
+Python -- i.e. Python consumers not yet re-pointed onto the coherent reads.
+
+⚑ THE COUNT IS CONCENTRATED, WHICH IS THE USEFUL PART. It splits into two different jobs:
+a type that HAS its group reads and still carries the legacy names beside them (CyCity:
+157 published, 110 legacy -- "the collision is the work"; e.g. getWellbeing is published
+while happyLevel / unhappyLevel / angryPopulation are still called from 13 sites), and a
+type not re-homed at all, whose GET surface has to be built first (CyUnit: 8 published,
+58 legacy).
 
 ⚖ ADVISORY, AND A RATCHET -- exactly like verify-registry-scans. The count may only FALL;
 a rise means a legacy declaration was revived or a legacy call was added. It does not fail

--- a/Tools/verify-python-bindings.py
+++ b/Tools/verify-python-bindings.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""verify-python-bindings -- a Cy method Python CALLS must actually be REGISTERED.
+
+The `Cy*` classes are the engine's API endpoint for Python. A method is reachable from
+Python only if some `class_<CyX>` block `.def("name", ...)`s it -- being a public C++
+member of CyX is NOT enough. Remove the `.def` and the C++ method still compiles, still
+looks alive in the header, and every Python caller starts raising AttributeError.
+
+That is worth a check rather than a rule for the reasons this repo keeps choosing one:
+
+  - the COMPILER CANNOT SEE IT. The C++ side is well-formed with or without the `.def`;
+    the break lives between a registration list and a `.py` file the compiler never reads.
+  - it is SILENT until that screen or callback runs, and it fails as a Python traceback
+    naming the CALLER, so it reads as "the advisor is broken", never as "a binding is
+    missing".
+  - a binding sweep is exactly the operation that produces it in bulk. One commit here
+    cut 494 dangling Cy bindings; nothing checked what still called them.
+  - and it is trivially mechanical to detect, which is the whole test for a checker.
+
+⛔ REGISTRATION LIVES IN TWO PLACES AND SCANNING ONLY ONE UNDER-REPORTS BADLY. Some
+classes register inline in `Sources/Python/CyX.cpp` as `class_<CyX>("CyX").def(...)`;
+others register through loader functions in `Sources/Infrastructure/CvPython*Loader.cpp`
+that take a `boost::python::class_<CyX>& inst` and call `inst.def(...)`. A census that
+reads only the first style reports most of `CyPlayer` and `CyPlot` as unregistered, and
+a census that reads only the second misses `CyUnit` entirely. This tool takes the UNION
+of every `.def("name")` under `Sources/`, which is why it does not attribute a name to a
+class: attribution is not needed for the verdict, and every attempt at it was the thing
+that produced false positives.
+
+Two findings, deliberately separated because only one is provable:
+
+  DEAD BINDING (fails the run) -- the method IS defined on a `Cy*` class in C++, is
+  registered NOWHERE, and Python calls that name. There is no reading of that state in
+  which the call works.
+
+  UNRESOLVED CALL (reported, never fails) -- Python calls a name that is registered
+  nowhere AND defined on no `Cy*` class AND is not a Python `def` anywhere in
+  `Assets/Python`. Usually a method removed outright, or one that never existed; but the
+  receiver's type cannot be known from Python source, so a human decides. ⚖ Advisory for
+  the same reason `verify-registry-scans` is: the mechanical part is certain, the
+  CONTEXT is not.
+
+Worked case: `CyUnit` registers exactly 8 methods, while `CvMilitaryAdvisor.py` calls
+`baseCombatStr()` and `airBaseCombatStr()` on the normal unit-row render path -- both
+defined in `CyUnit.cpp`, neither registered. Separately `getCommerceRateTimes100` is
+called by two `canTrigger` predicates and exists nowhere in the tree at all, so those
+random events can never fire.
+
+⛔ If it fires, fix the SIDE THAT IS WRONG. A binding Python legitimately needs is
+RE-REGISTERED; a call into a mechanic that is gone has its PYTHON deleted. Never widen
+the tool, and never register a method just to silence it -- an endpoint is a live
+consumer, and re-exposing a legacy read keeps that member alive past the compiler census.
+
+Run from the repo root:  python Tools/verify-python-bindings.py
+                         python Tools/verify-python-bindings.py --list
+"""
+
+import os
+import re
+import sys
+import glob
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SOURCES = os.path.join(REPO, "Sources")
+PYTHON_ROOT = os.path.join(REPO, "Assets", "Python")
+
+# `.def("name"` in any registration style -- inline class_<> chains and loader `inst.def(...)` alike.
+RE_REGISTERED = re.compile(r'\.def\(\s*"([A-Za-z_][A-Za-z0-9_]*)"')
+
+# A method DEFINED on a Cy class: `<return type> CyFoo::bar(`. The return type is skipped
+# rather than enumerated -- the `CyFoo::` qualifier is what identifies it.
+RE_CY_DEFINITION = re.compile(r'\b(Cy[A-Za-z0-9_]+)::([A-Za-z_][A-Za-z0-9_]*)\s*\(')
+
+# A Python attribute call, capturing the RECEIVER token as well as the method.
+#
+# ⛔ THE RECEIVER IS WHAT MAKES THIS PRECISE, and dropping it is what makes the tool
+# useless. A bare `.name(` scan cannot tell `CyUnit.baseCombatStr()` from
+# `self.validAttrs.add(name)` -- and `add` happens to be BOTH a `CyArgsList` member and
+# Python's own `set.add`, so a receiver-blind census reports 40 phantom call sites for it
+# and buries the real findings under ~200 like it. A method name alone is not evidence.
+RE_PY_CALL = re.compile(r'([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(')
+
+# A Python-defined function/method of that name -- excluded, since the call may be its own.
+RE_PY_DEF = re.compile(r'^\s*def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(', re.M)
+
+# A receiver token that denotes a Cy handle: either spelled `Cy*`, or an identifier ending
+# in one of the engine nouns the Python code names these objects after (`pLoopUnit`,
+# `pCity`, `m_pPlot`, `eTeam`, ...). Deliberately generous on the PREFIX and strict on the
+# NOUN -- the prefix conventions vary per file, the noun does not.
+RE_CY_RECEIVER = re.compile(
+    r'^(?:Cy[A-Za-z0-9_]*'
+    r'|[A-Za-z_][A-Za-z0-9_]*(?:Unit|City|Plot|Player|Team|Group|Area|Deal|Map|Selection))$')
+
+
+def read(path):
+    try:
+        f = open(path, "rb")
+        try:
+            return f.read().decode("utf-8", "ignore")
+        finally:
+            f.close()
+    except IOError:
+        return ""
+
+
+def walk(root, suffix):
+    out = []
+    for base, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs if d not in (".vs", ".vscode", "nbproject", "__pycache__")]
+        for name in files:
+            if name.endswith(suffix):
+                out.append(os.path.join(base, name))
+    return out
+
+
+def main():
+    want_list = "--list" in sys.argv
+
+    registered = set()
+    cy_defined = {}          # method name -> set of Cy classes defining it
+    for path in walk(SOURCES, ".cpp") + walk(SOURCES, ".h"):
+        text = read(path)
+        registered.update(RE_REGISTERED.findall(text))
+        for cls, method in RE_CY_DEFINITION.findall(text):
+            cy_defined.setdefault(method, set()).add(cls)
+
+    py_calls = {}            # method name -> [ "file:line", ... ]  (Cy-receiver calls ONLY)
+    py_defs = set()
+    for path in walk(PYTHON_ROOT, ".py"):
+        text = read(path)
+        py_defs.update(RE_PY_DEF.findall(text))
+        rel = os.path.relpath(path, REPO).replace("\\", "/")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if line.lstrip().startswith("#"):
+                continue
+            for receiver, method in RE_PY_CALL.findall(line):
+                if not RE_CY_RECEIVER.match(receiver):
+                    continue
+                py_calls.setdefault(method, []).append("%s:%d" % (rel, lineno))
+
+    dead = []
+    for method in sorted(py_calls):
+        if method in registered or method not in cy_defined:
+            continue
+        dead.append((method, sorted(cy_defined[method]), py_calls[method]))
+
+    unresolved = []
+    for method in sorted(py_calls):
+        if method in registered or method in cy_defined or method in py_defs:
+            continue
+        unresolved.append((method, py_calls[method]))
+
+    print("registered Cy methods: %d   |   Cy methods defined in C++: %d   |   distinct Python calls: %d"
+          % (len(registered), len(cy_defined), len(py_calls)))
+    print("")
+
+    if dead:
+        print("DEAD BINDINGS -- defined on a Cy class, registered nowhere, called from Python:")
+        for method, classes, sites in dead:
+            print("  %s   (%s)  -- %d call site(s)" % (method, ", ".join(classes), len(sites)))
+            shown = sites if want_list else sites[:3]
+            for site in shown:
+                print("      %s" % site)
+            if not want_list and len(sites) > 3:
+                print("      ... and %d more (--list for all)" % (len(sites) - 3))
+        print("")
+    else:
+        print("DEAD BINDINGS: none")
+        print("")
+
+    if unresolved:
+        print("UNRESOLVED CALLS (ADVISORY -- a human decides; never fails the run):")
+        print("  Python calls these on a Cy-looking receiver; they are registered nowhere,")
+        print("  defined on no Cy class, and are not a Python def. Likely a removed mechanic.")
+        for method, sites in unresolved:
+            shown = sites if want_list else sites[:2]
+            print("  %s  -- %d call site(s): %s" % (method, len(sites), ", ".join(shown)))
+        print("")
+
+    if dead:
+        print("FAILED: %d dead binding(s). Fix the side that is WRONG -- re-register a binding"
+              % len(dead))
+        print("Python legitimately needs, or delete the Python for a mechanic that is gone.")
+        return 1
+
+    print("OK: every Cy method Python calls is registered.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/verify-python-bindings.py
+++ b/Tools/verify-python-bindings.py
@@ -1,21 +1,30 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""verify-python-bindings -- a Cy method Python CALLS must actually be REGISTERED.
+"""verify-python-bindings -- the PYTHON-SIDE MIGRATION BURNDOWN, counted.
 
-The `Cy*` classes are the engine's API endpoint for Python. A method is reachable from
-Python only if some `class_<CyX>` block `.def("name", ...)`s it -- being a public C++
-member of CyX is NOT enough. Remove the `.def` and the C++ method still compiles, still
-looks alive in the header, and every Python caller starts raising AttributeError.
+⛔ THIS IS NOT A BUG COUNT. The `Cy*` read-surface cut is DIRECTIONAL AND INTENTIONAL
+(patterns.md, THE CUT IS DIRECTIONAL): Python->engine READS die, the wrapper classes stay
+carrying only their IDENTITY SET (owner + id + position), and the engine->Python callback
+direction is kept. `CyUnit` publishing 8 methods is that design, not damage. The cut
+deliberately ran AHEAD of the Python migration -- "the cut is the forcing function that
+DRIVES completeness, so it never waits on it."
+
+What never existed is a way to COUNT WHAT IS LEFT. That is this tool. It reports the
+methods still DECLARED on a `Cy*` wrapper, registered nowhere, and still CALLED from
+Python -- i.e. Python consumers not yet re-pointed onto the new read surface.
+
+⚖ ADVISORY, AND A RATCHET -- exactly like verify-registry-scans. The count may only FALL;
+a rise means a legacy declaration was revived or a legacy call was added. It does not fail
+the run, because a permanently-red gate on a known in-progress migration is a gate nobody
+can act on.
 
 That is worth a check rather than a rule for the reasons this repo keeps choosing one:
 
   - the COMPILER CANNOT SEE IT. The C++ side is well-formed with or without the `.def`;
-    the break lives between a registration list and a `.py` file the compiler never reads.
-  - it is SILENT until that screen or callback runs, and it fails as a Python traceback
-    naming the CALLER, so it reads as "the advisor is broken", never as "a binding is
-    missing".
-  - a binding sweep is exactly the operation that produces it in bulk. One commit here
-    cut 494 dangling Cy bindings; nothing checked what still called them.
+    the debt lives between a registration list and a `.py` file the compiler never reads.
+  - it is SILENT until that screen or callback runs, and it surfaces as a Python traceback
+    naming the CALLER, so it reads as "the advisor is broken", never as "this consumer was
+    never migrated".
   - and it is trivially mechanical to detect, which is the whole test for a checker.
 
 ⛔ REGISTRATION LIVES IN TWO PLACES AND SCANNING ONLY ONE UNDER-REPORTS BADLY. Some
@@ -28,29 +37,43 @@ of every `.def("name")` under `Sources/`, which is why it does not attribute a n
 class: attribution is not needed for the verdict, and every attempt at it was the thing
 that produced false positives.
 
-Two findings, deliberately separated because only one is provable:
+Two findings, deliberately separated:
 
-  DEAD BINDING (fails the run) -- the method IS defined on a `Cy*` class in C++, is
-  registered NOWHERE, and Python calls that name. There is no reading of that state in
-  which the call works.
+  UNMIGRATED CONSUMER -- the method IS declared on a `Cy*` class in C++, is registered
+  NOWHERE, and Python calls that name. The call raises today; the DECLARATION is legacy
+  contract still written down; the CALL is a consumer not yet re-pointed.
 
-  UNRESOLVED CALL (reported, never fails) -- Python calls a name that is registered
-  nowhere AND defined on no `Cy*` class AND is not a Python `def` anywhere in
-  `Assets/Python`. Usually a method removed outright, or one that never existed; but the
-  receiver's type cannot be known from Python source, so a human decides. ⚖ Advisory for
-  the same reason `verify-registry-scans` is: the mechanical part is certain, the
-  CONTEXT is not.
+  UNRESOLVED CALL -- Python calls a name registered nowhere, declared on no `Cy*` class,
+  and not a Python `def` anywhere in `Assets/Python`. Usually a mechanic removed outright,
+  or one that never existed at all. The receiver's type cannot be known from Python
+  source, so a human decides.
 
-Worked case: `CyUnit` registers exactly 8 methods, while `CvMilitaryAdvisor.py` calls
-`baseCombatStr()` and `airBaseCombatStr()` on the normal unit-row render path -- both
-defined in `CyUnit.cpp`, neither registered. Separately `getCommerceRateTimes100` is
-called by two `canTrigger` predicates and exists nowhere in the tree at all, so those
-random events can never fire.
+⛔ HOW TO CLOSE ONE, AND THE ONE MOVE THAT IS BANNED. The declaration is KILL-ON-SIGHT
+(patterns.md): an unpublished legacy method on a wrapper is not harmless dead weight -- it
+is the per-field contract still written down, so the next agent reads it as the surface
+and "JUST PUBLISH WHAT IS ALREADY DECLARED" looks like the cheap fix at exactly the moment
+the new surface arrives. ⛔ So RE-REGISTERING IT IS THE ANTI-PATTERN, never the fix. The
+declaration and its body go; the Python re-points onto the new surface, homed on the type
+it addresses -- `CyCity::getPopulation()`, never `getCityPopulation(owner, id)`, because
+"the moment you have getAnotherObjectSomething, we have failed."
 
-⛔ If it fires, fix the SIDE THAT IS WRONG. A binding Python legitimately needs is
-RE-REGISTERED; a call into a mechanic that is gone has its PYTHON deleted. Never widen
-the tool, and never register a method just to silence it -- an endpoint is a live
-consumer, and re-exposing a legacy read keeps that member alive past the compiler census.
+⚠ NOT killed alongside them: the `class_<>` REGISTRATION (a zero-`.def` registration is
+the TYPE IDENTITY the kept engine->Python direction needs -- the marshaller throws without
+a registered converter), the identity set, and anything the ENGINE calls on the wrapper.
+
+⚖ And the counterweight, without which killing under-serves: the surface is designed from
+DEMAND and freely given where a consumer genuinely needs a read -- never derived from the
+legacy list. Killing without serving pushes the next consumer back onto legacy; serving by
+preserving the legacy set re-creates the per-field contract.
+
+Worked case: `CvMilitaryAdvisor.py:329/331` calls `baseCombatStr()` / `airBaseCombatStr()`
+on the normal unit-row render path -- declared in `CyUnit.cpp`, registered nowhere, so the
+advisor raises. Separately `getCommerceRateTimes100` is called by two `canTrigger`
+predicates and exists nowhere in the tree at all, so those two random events can never
+fire -- the silent class nobody reports, since you do not miss an event you have never
+seen.
+
+⛔ Never widen the tool to make a count fall.
 
 Run from the repo root:  python Tools/verify-python-bindings.py
                          python Tools/verify-python-bindings.py --list
@@ -156,7 +179,7 @@ def main():
     print("")
 
     if dead:
-        print("DEAD BINDINGS -- defined on a Cy class, registered nowhere, called from Python:")
+        print("UNMIGRATED CONSUMERS -- declared on a Cy class, registered nowhere, called from Python:")
         for method, classes, sites in dead:
             print("  %s   (%s)  -- %d call site(s)" % (method, ", ".join(classes), len(sites)))
             shown = sites if want_list else sites[:3]
@@ -166,11 +189,11 @@ def main():
                 print("      ... and %d more (--list for all)" % (len(sites) - 3))
         print("")
     else:
-        print("DEAD BINDINGS: none")
+        print("UNMIGRATED CONSUMERS: none")
         print("")
 
     if unresolved:
-        print("UNRESOLVED CALLS (ADVISORY -- a human decides; never fails the run):")
+        print("UNRESOLVED CALLS -- a human decides:")
         print("  Python calls these on a Cy-looking receiver; they are registered nowhere,")
         print("  defined on no Cy class, and are not a Python def. Likely a removed mechanic.")
         for method, sites in unresolved:
@@ -178,13 +201,12 @@ def main():
             print("  %s  -- %d call site(s): %s" % (method, len(sites), ", ".join(shown)))
         print("")
 
-    if dead:
-        print("FAILED: %d dead binding(s). Fix the side that is WRONG -- re-register a binding"
-              % len(dead))
-        print("Python legitimately needs, or delete the Python for a mechanic that is gone.")
-        return 1
-
-    print("OK: every Cy method Python calls is registered.")
+    total_sites = sum(len(sites) for _, _, sites in dead)
+    print("BURNDOWN: %d unmigrated method(s) across %d Python call site(s)."
+          % (len(dead), total_sites))
+    print("ADVISORY, and a RATCHET: the count may only FALL. A rise means a legacy declaration")
+    print("was revived or a legacy call added. Close one by KILLING the declaration and")
+    print("re-pointing the Python onto the new surface -- never by re-registering it.")
     return 0
 
 

--- a/docs/architecture/patterns.md
+++ b/docs/architecture/patterns.md
@@ -896,11 +896,23 @@ of them:
   known destination, not a permanent Python carve-out — do not read "permanent carve-out" on the event surface
   as "Python owns this forever", and equally do not start the move inside #430. The triggers machine
   ([triggers.md](../specs/triggers.md)) is where it lands when its own work item is taken.
-- ⚑ Consequence: the `Cy*` WRAPPER classes (`CyCity`/`CyUnit`/`CyPlayer`/…) STAY while their bindings do not —
-  33 engine files hold them for that direction. **A wrapper carries its IDENTITY SET and nothing else**, and
-  reading it as a half-cut to complete would delete working gameplay.
+- ⚑ Consequence: the `Cy*` WRAPPER classes (`CyCity`/`CyUnit`/`CyPlayer`/…) STAY while the legacy per-field
+  binding contract does not — 33 engine files hold them for that direction. Reading that as a half-cut to
+  complete would delete working gameplay.
 
-  > **⚖ THE IDENTITY SET — A HANDLE PUBLISHES OWNER + ID + POSITION, AND THE REFACTOR STOPS THERE (owner).**
+  > **⛔ THE IDENTITY SET IS THE FLOOR, NOT THE CEILING — AND READING IT AS THE CEILING IS STALE (owner): the
+  > `Cy*` bindings are the literal API surface for Python, so a type publishes the GET / PUT / POST it is
+  > required to.** The identity set is what a handle must ALWAYS carry so a legacy consumer can name its object;
+  > it was never a cap on what the accessor answers. ⚑ **The tree settles it** — `CyPlayer` publishes 332
+  > endpoints, `CyCity` 157 (the coherent group reads: `getYields`, `getCommerces`, `getWellbeing`,
+  > `getScalars`, `getDefenseKinds`, … plus its mutators), `CyTeam` 116, `CyPlot` 106. That IS the per-type
+  > accessor this section's own next ruling prescribes, already built.
+  > ⇒ So a thin wrapper is an UN-RE-HOMED TYPE, never a finished one: `CyUnit` at 8 endpoints against 58 legacy
+  > declarations its Python still calls is the work outstanding, not the design achieved. The burndown is
+  > countable — `python Tools/verify-python-bindings.py` (Validation).
+
+  > **⚖ THE IDENTITY SET — A HANDLE ALWAYS PUBLISHES OWNER + ID + POSITION, AND THAT ALONE IS WHAT KEEPS A
+  > LEGACY CONSUMER WORKING (owner).**
   > *"Carry identity set — if that is what it takes for legacy to keep working then it's an obvious tradeoff. I
   > only want to refactor the python I have to, otherwise we **never** will be done."* A legacy consumer holding
   > a handle must be able to say WHICH object it holds; re-pointing every such site onto the read planes is

--- a/docs/architecture/patterns.md
+++ b/docs/architecture/patterns.md
@@ -911,13 +911,8 @@ of them:
   > declarations its Python still calls is the work outstanding, not the design achieved. The burndown is
   > countable — `python Tools/verify-python-bindings.py` (Validation).
 
-  > **⚖ THE IDENTITY SET — A HANDLE ALWAYS PUBLISHES OWNER + ID + POSITION, AND THAT ALONE IS WHAT KEEPS A
-  > LEGACY CONSUMER WORKING (owner).**
-  > *"Carry identity set — if that is what it takes for legacy to keep working then it's an obvious tradeoff. I
-  > only want to refactor the python I have to, otherwise we **never** will be done."* A legacy consumer holding
-  > a handle must be able to say WHICH object it holds; re-pointing every such site onto the read planes is
-  > refactoring that buys nothing and does not converge.
-  > ⛔ **It is the ADDRESS, and it is what a legacy consumer needs to name its object.** Owner, id, position.
+  > **⚖ THE IDENTITY SET — EVERY HANDLE PUBLISHES OWNER + ID + POSITION (owner).** It is the ADDRESS: what a
+  > consumer needs in order to say WHICH object it holds.
   > [the Cy* surface is not a fixed contract](#-the-python-read-boundary--one-complete-data-fetching-library-owner)'s ban on the legacy info/state GETTER contract is untouched:
   > what a handle must never become is the old per-field surface restored wholesale.
   >

--- a/docs/architecture/patterns.md
+++ b/docs/architecture/patterns.md
@@ -714,6 +714,19 @@ Four words carry the whole requirement:
   when the library cannot answer a read, the move is to ADD the read, never to borrow legacy meanwhile.
 - **DATA FETCHING, not gameplay.** It serves reads/payloads; Python-authoritative gameplay (Revolution, events)
   stays Python and becomes a CONSUMER of it.
+  > **⚖ THE `Cy*` LAYER IS THE CONTROLLER, AND IT STAYS THIN — BUT THE INTERNAL→EXTERNAL CONVERSION IS ITS JOB
+  > (owner).** Engine is the model, `Cy*` is the controller, Python is the view. Thin means **no logic**: no
+  > computation, no policy, no aggregation the model does not already answer — a controller that starts deciding
+  > things is a second engine, and it will disagree with the first.
+  > ⛔ **What is NOT a violation of thin is REPRESENTATION.** Where an internal form has to become an external
+  > one, this is exactly where it happens and the only place it should: the ×100 fixed point reduces here
+  > ([the ×100 fixed-point model](../specs/curators/fixed-point-and-scales.md#1-the-model--integer-100-for-amounts-human-only-at-the-in-and-out-boundaries) names the
+  > `Cy*` wrappers as one of the readers that does its own conversion), an enum-indexed group becomes a list, a
+  > handle becomes an address. ⚑ Pushing that conversion OUTWARD is what forces every consumer to know the
+  > engine's internal scale, and then to disagree about it — the failure this boundary exists to end.
+  > ⚖ Because nothing downstream of the controller does deterministic math, an external getter is free to hand
+  > out a FLOAT rather than truncating to an int: the two decimals the fixed point carries survive the boundary
+  > instead of being thrown away at it.
 - **⛔ ENUM OPERATIONS ARE FIRST CLASS** — name→type/enum resolution is a supported operation, covering
   **resolution AND EXTENSION**: BUG resolves `WidgetTypes`/`InputTypes`/`InterfaceDirtyBits` by name from config
   strings *and* MINTS new `WidgetTypes` members at runtime, handing them back as widget ids. A read-only lookup
@@ -907,9 +920,11 @@ of them:
   > endpoints, `CyCity` 157 (the coherent group reads: `getYields`, `getCommerces`, `getWellbeing`,
   > `getScalars`, `getDefenseKinds`, … plus its mutators), `CyTeam` 116, `CyPlot` 106. That IS the per-type
   > accessor this section's own next ruling prescribes, already built.
-  > ⇒ So a thin wrapper is an UN-RE-HOMED TYPE, never a finished one: `CyUnit` at 8 endpoints against 58 legacy
-  > declarations its Python still calls is the work outstanding, not the design achieved. The burndown is
-  > countable — `python Tools/verify-python-bindings.py` (Validation).
+  > ⇒ So an UNDER-PUBLISHED wrapper is an UN-RE-HOMED TYPE, never a finished one: `CyUnit` at 8 endpoints
+  > against 58 legacy declarations its Python still calls is the work outstanding, not the design achieved. The
+  > burndown is countable — `python Tools/verify-python-bindings.py` (Validation).
+  > ⚠ "Under-published" is about COVERAGE, not about depth — a controller stays THIN in the sense below
+  > (no logic) however many endpoints it carries. The two are independent.
 
   > **⚖ THE IDENTITY SET — EVERY HANDLE PUBLISHES OWNER + ID + POSITION (owner).** It is the ADDRESS: what a
   > consumer needs in order to say WHICH object it holds.


### PR DESCRIPTION
Adds `Tools/verify-python-bindings.py` and its `AGENTS.md` § Validation entry.

⛔ **It counts a BURNDOWN, not bugs.** The `Cy*` read-surface cut is directional and intentional — `patterns.md` § THE CUT IS DIRECTIONAL rules that Python→engine READS die, the wrapper keeps only its **identity set** (owner + id + position), and the engine→Python callback direction stays. `CyUnit` publishing 8 methods is that design, not damage. The cut deliberately ran **ahead** of the Python migration, because *"the cut is the forcing function that DRIVES completeness, so it never waits on it."*

What never existed is a way to count **what is left**. That is what this is for.

**174 methods still declared on a `Cy*` wrapper, registered nowhere, and still called from Python — across 704 call sites.** Filed as #488. That number has sat at roughly this level for a long time across a lot of work; it is debt being measured for the first time, not a regression.

⚖ **Advisory, and a RATCHET** — like `verify-registry-scans`. The count may only fall; a rise means a legacy declaration was revived or a legacy call added. It does not fail the run, because a permanently-red gate on a known in-progress migration is one nobody can act on.

| area | call sites |
|---|--:|
| `Screens/Worldbuilder/` (7 files) | 346 |
| `Revolution/` (4 files) | 345 |
| `Screens/CvMainInterface.py` | 78 |
| `CvUtil.py` | 36 |
| `EntryPoints/CvRandomEventInterface.py` | 33 |

## How a finding is closed — and the one move that is banned

The declaration is **kill-on-sight**: an unpublished legacy method on a wrapper is the per-field contract still written down, so the next agent reads it as the surface and *"just publish what is already declared"* looks like the cheap fix at exactly the moment the new surface arrives. **Re-registering is the anti-pattern, never the fix.** The declaration and its body go; the Python re-points onto the new surface, homed on the type it addresses — `CyCity::getPopulation()`, never `getCityPopulation(owner, id)`, because *"the moment you have `getAnotherObjectSomething`, we have failed."*

⚠ **Not killed alongside them:** the `class_<>` REGISTRATION (a zero-`.def` registration is the type identity the kept engine→Python direction needs — the marshaller throws without a registered converter), the identity set, and anything the engine calls on the wrapper.

⚖ And the counterweight: the surface is designed from **demand** and freely given where a consumer genuinely needs a read — never derived from the legacy list.

## Two wrong turns, recorded in the tool's header so they are not repeated

**Registration lives in two styles.** Inline `class_<CyX>("CyX").def(…)` under `Sources/Python/`, and loader functions taking `class_<CyX>& inst` under `Sources/Infrastructure/CvPython*Loader.cpp`. A census reading only the first reports most of `CyPlayer` and `CyPlot` as unregistered; one reading only the second misses `CyUnit` entirely. The tool takes the **union** of every `.def("name")` and does not attribute names to classes — attribution is not needed for the verdict, and every attempt at it manufactured false positives.

**The receiver is what makes it precise.** A bare `.name(` scan cannot tell `CyUnit.baseCombatStr()` from `self.validAttrs.add(name)` — and `add` is both a `CyArgsList` member *and* Python's own `set.add`, so a receiver-blind census reports 40 phantom sites for it and buries the real findings under ~200 like it.

## One genuine defect, separate from the burndown

`getCommerceRateTimes100` (`CvRandomEventInterface.py:2993`, `:3054`) exists **nowhere in the tree** — not in `Sources/`, not in `SourceArchive/`, not even as a declaration. It was never cut; it never existed. Both `canTrigger` predicates raise, so **two random events can never fire** — the silent class nobody reports, since you do not miss an event you have never seen.

## Verification

Hand-checked against ground truth: `getPopulation` and `getName` are registered and correctly pass; `baseCombatStr`, `cargoSpace`, `canEnterPlot` are declared-but-unregistered and correctly reported. The `set.add` false positive is gone after the receiver constraint. `python Tools/verify-docs.py` passes; the check itself exits 0 (advisory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
