### PR TITLE
Clear the Cy collisions + build the reader boundary (#493, #489)

### DIFF
--- a/Assets/Python/Contrib/Civ4lerts.py
+++ b/Assets/Python/Contrib/Civ4lerts.py
@@ -461,11 +461,9 @@ class CityHappiness(AbstractCityTestAlert):
 			iExtra = -1
 		else:
 			iExtra = 0
-		# The channels are x100 native; this comparison is in whole citizens, so it reduces at the point of use
-		# ([DEC-fixedpoint-x100]: no getter reduces).
 		aWellbeing = GC.getPlayer(cityId[0]).getCity(cityId[1]).getRealizedWellbeing(iExtra)
-		iHappy = aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS] / 100
-		iUnhappy = aWellbeing[WellbeingChannel.WELLBEING_ANGER] / 100
+		iHappy = aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS]
+		iUnhappy = aWellbeing[WellbeingChannel.WELLBEING_ANGER]
 		aCountdowns = GC.getPlayer(cityId[0]).getCity(cityId[1]).getCountdowns()
 		aDecaying = (
 			(CityCountdownKind.COUNTDOWN_HURRY_ANGER, CityCountdownKind.COUNTDOWN_HURRY_ANGER_PERIOD),
@@ -527,7 +525,7 @@ class CityHealthiness(AbstractCityTestAlert):
 			iExtra = 0
 		aWellbeing = GC.getPlayer(cityId[0]).getCity(cityId[1]).getRealizedWellbeing(iExtra)
 		iHealthRate = (aWellbeing[WellbeingChannel.WELLBEING_HEALTH]
-		               - aWellbeing[WellbeingChannel.WELLBEING_UNHEALTH]) / 100
+		               - aWellbeing[WellbeingChannel.WELLBEING_UNHEALTH])
 		aCountdowns = GC.getPlayer(cityId[0]).getCity(cityId[1]).getCountdowns()
 		if aCountdowns[CityCountdownKind.COUNTDOWN_ESPIONAGE_HEALTH] > 0:
 			iHealthRate += 1

--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -2974,11 +2974,11 @@ def canTriggerImmigrantCity(argsList):
     return False
 
   #  angryPopulation/healthRate are FINAL-STATE calculations over the four channels, so the surplus is read
-  #  off the channels themselves ([patterns.md] THE TWO READ ROLES rule 6). x100 native, compared x100.
+  #  off the channels themselves ([patterns.md] THE TWO READ ROLES rule 6).
   aWellbeing = GC.getPlayer(ePlayer).getCity(iCity).getRealizedWellbeing(0)
-  if aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS] - aWellbeing[WellbeingChannel.WELLBEING_ANGER] < 100:
+  if aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS] - aWellbeing[WellbeingChannel.WELLBEING_ANGER] < 1:
     return False
-  if aWellbeing[WellbeingChannel.WELLBEING_HEALTH] - aWellbeing[WellbeingChannel.WELLBEING_UNHEALTH] < 100:
+  if aWellbeing[WellbeingChannel.WELLBEING_HEALTH] - aWellbeing[WellbeingChannel.WELLBEING_UNHEALTH] < 1:
     return False
 
   if GC.getPlayer(ePlayer).getCity(iCity).getCommerces()[CommerceTypes.COMMERCE_CULTURE] < 5500:
@@ -5192,7 +5192,8 @@ def canTriggerMeasles(argsList):
     return False
 
   # city health is positive, no epidemic
-  if ((city.goodHealth() - city.badHealth(True)) > 1):
+  aWellbeing = city.getRealizedWellbeing(0)
+  if ((aWellbeing[WellbeingChannel.WELLBEING_HEALTH] - aWellbeing[WellbeingChannel.WELLBEING_UNHEALTH]) > 1):
     return False
 
   return True

--- a/Assets/Python/OOSLogger.py
+++ b/Assets/Python/OOSLogger.py
@@ -99,8 +99,9 @@ def writeLog():
 					pFile.write("Improved Plots: %d\n" % (pCity.countNumImprovedPlots()))
 					pFile.write("Tiles Worked: %d, Specialists: %d\n" % (pCity.getWorkingPopulation(), pCity.getSpecialistPopulation()))
 					pFile.write("Great People: %d\n" % pCity.getNumGreatPeople())
-					pFile.write("Good Health: %d, Bad Health: %d\n" % (pCity.goodHealth(), pCity.badHealth(False)))
-					pFile.write("Happy Level: %d, Unhappy Level: %d\n" % (pCity.happyLevel(), pCity.unhappyLevel(0)))
+					aWellbeing = pCity.getRealizedWellbeing(0)
+					pFile.write("Good Health: %d, Bad Health: %d\n" % (aWellbeing[WellbeingChannel.WELLBEING_HEALTH], aWellbeing[WellbeingChannel.WELLBEING_UNHEALTH]))
+					pFile.write("Happy Level: %d, Unhappy Level: %d\n" % (aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS], aWellbeing[WellbeingChannel.WELLBEING_ANGER]))
 					pFile.write("Food: %d\n" % pCity.getFood())
 					pCity, i = pPlayer.nextCity(i, False)
 			else:

--- a/Assets/Python/Revolution/Gameready/Revolution.py
+++ b/Assets/Python/Revolution/Gameready/Revolution.py
@@ -229,7 +229,7 @@ class Revolution:
 			# Get rev index change
 			revIdxCityList = []
 			for cityX in GC.getPlayer(iPlayer).cities():
-				revIdxCityList.append((cityX.getRevolutionIndex(), cityX))
+				revIdxCityList.append((cityX.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX], cityX))
 
 			if revIdxCityList:
 				revIdxCityList.sort()
@@ -242,7 +242,7 @@ class Revolution:
 			for revIdx, CyCityX in revIdxCityList:
 
 				localRevIdx = CyCityX.getLocalRevIndex()
-				deltaTrend = deltaTrend = revIdx - CyCityX.getRevIndexAverage()
+				deltaTrend = deltaTrend = revIdx - CyCityX.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_AVERAGE]
 
 				if revIdx >= self.revInstigatorThreshold:
 					if deltaTrend > self.showTrend:
@@ -333,7 +333,7 @@ class Revolution:
 		if self.isLocalHumanPlayer(iPlayer):
 			lCity = []
 			for city in GC.getPlayer(iPlayer).cities():
-				lCity.append((city.getRevolutionIndex(), city.getName(), city.getID()))
+				lCity.append((city.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX], city.getName(), city.getID()))
 
 			if not lCity:
 				popup = CyPopup(-1, EventContextTypes.NO_EVENTCONTEXT, True)
@@ -607,7 +607,7 @@ class Revolution:
 			return # Revolt has ended
 
 		# City must still be rebellious
-		revIdx = pCity.getRevolutionIndex()
+		revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 		localRevIdx = pCity.getLocalRevIndex()
 		localRevEffect = 0
 		revIdxHist = RevData.getCityVal( pCity, 'RevIdxHistory' )
@@ -650,7 +650,7 @@ class Revolution:
 		iy = pCity.getY()
 
 		for cityX in pRevPlayer.cities():
-			if GAME.getGameTurn() - cityX.getGameTurnAcquired() < 6 and cityX.getPreviousOwner() == ownerID:
+			if GAME.getGameTurn() - cityX.getCounts()[CityCountRead.CITY_COUNT_GAME_TURN_ACQUIRED] < 6 and cityX.getPreviousOwner() == ownerID:
 				bRecentSuccess = True
 				break
 		else: bRecentSuccess = False
@@ -1015,16 +1015,16 @@ class Revolution:
 		for pCity in cityList:
 
 			# Incase interturn stuff set out of range
-			if pCity.getRevolutionIndex() < 0:
+			if pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX] < 0:
 				pCity.setRevolutionIndex(0)
-			elif pCity.getRevolutionIndex() > (2*self.alwaysViolentThreshold):
+			elif pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX] > (2*self.alwaysViolentThreshold):
 				pCity.setRevolutionIndex( (2*self.alwaysViolentThreshold) )
 
 			revIdxHist = RevData.getCityVal(pCity, 'RevIdxHistory')
 			if revIdxHist == None:
 				revIdxHist = RevDefs.initRevIdxHistory()
 
-			prevRevIdx = pCity.getRevolutionIndex()
+			prevRevIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 
 			# Record lists of (#, string type) effects, seperate for positive and negative
 			posList = []
@@ -1033,7 +1033,7 @@ class Revolution:
 			# Sum up local factors for the city
 			localRevIdx = 0
 
-			recentlyAcquired = (GAME.getGameTurn()-pCity.getGameTurnAcquired() < 12*RevUtils.getGameSpeedMod())
+			recentlyAcquired = (GAME.getGameTurn()-pCity.getCounts()[CityCountRead.CITY_COUNT_GAME_TURN_ACQUIRED] < 12*RevUtils.getGameSpeedMod())
 
 			culturePercent = 0
 			maxCult = 0
@@ -1060,7 +1060,7 @@ class Revolution:
 
 				numUnhappy = max([numUnhappy - (pCity.getRevIndexPercentAnger()*pCity.getPopulation())/1000, 0])
 
-				if( pCity.getOccupationTimer() > 0 ) :
+				if( pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_OCCUPATION] > 0 ) :
 					# Resistance is counted below ...
 					numUnhappy = min([numUnhappy/3.0,0.5])
 				elif( recentlyAcquired ) :
@@ -1068,7 +1068,7 @@ class Revolution:
 
 				happyIdx = int((15 + 15*(min([numUnhappy,pCity.getPopulation()])/min([pCity.getPopulation(),12])))*pow(numUnhappy, .8) + .5)
 
-				if( pCity.getEspionageHappinessCounter() > 0 ) :
+				if( pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_ESPIONAGE_HAPPINESS] > 0 ) :
 					# Reduce effect if unhappiness is from spy mission
 					happyIdx = happyIdx/3.0
 
@@ -1399,7 +1399,7 @@ class Revolution:
 			numUnhealthy = (pCity.badHealth(False) - pCity.goodHealth())
 			if numUnhealthy > 0:
 				healthIdx = int(int(2*pow(numUnhealthy, .6) + .5) * self.happinessModifier)
-				if pCity.getEspionageHealthCounter() > 0 or pPlayer.isRebel():
+				if pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_ESPIONAGE_HEALTH] > 0 or pPlayer.isRebel():
 					healthIdx = healthIdx/3
 				if bIsRevWatch:
 					negList.append( (healthIdx, TRNSLTR.getText("TXT_KEY_REV_WATCH_UNHEALTHY",())) )
@@ -1460,7 +1460,7 @@ class Revolution:
 				else :
 					starvingIdx = min([4*abs(pCity.foodDifference(True)),20])
 
-				if( pCity.getEspionageHealthCounter() > 0 or pPlayer.isRebel() ) :
+				if( pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_ESPIONAGE_HEALTH] > 0 or pPlayer.isRebel() ) :
 					starvingIdx = max([starvingIdx/5,min([starvingIdx,10])])
 
 				localRevIdx += starvingIdx
@@ -1469,7 +1469,7 @@ class Revolution:
 
 			# Disorder
 			disorderIdx = 0
-			if pCity.getOccupationTimer() > 0:
+			if pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_OCCUPATION] > 0:
 				if recentlyAcquired or pPlayer.isRebel():
 					# Give recently acquired cities a break
 					disorderIdx = 10
@@ -1520,7 +1520,7 @@ class Revolution:
 			if pPlayer.isHuman():
 				localRevIdx = int(self.humanIdxModifier*localRevIdx + self.humanIdxOffset + .5)
 
-			revIdx = pCity.getRevolutionIndex()
+			revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 
 			# Feedback on Rev Index
 			if( localRevIdx < 0 and revIdx > self.alwaysViolentThreshold ) :
@@ -1553,13 +1553,13 @@ class Revolution:
 				pCity.updateRevIndexAverage()
 				RevData.updateCityVal(pCity, 'RevIdxHistory', revIdxHist )
 
-			if( pCity.getRevolutionIndex() < 0 ) :
+			if( pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX] < 0 ) :
 				pCity.setRevolutionIndex( 0 )
-			elif( pCity.getRevolutionIndex() > (2*self.alwaysViolentThreshold) ) :
+			elif( pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX] > (2*self.alwaysViolentThreshold) ) :
 				pCity.setRevolutionIndex( (2*self.alwaysViolentThreshold) )
 
-			revIdx = pCity.getRevolutionIndex()
-			revIdxAvg = pCity.getRevIndexAverage()
+			revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
+			revIdxAvg = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_AVERAGE]
 
 			if self.LOG_DEBUG and not (iGameTurn%25):
 				print "[REV] Revolt: %s:   Hap %d,   Loc %d,   Rel %d,   Nat %d,   Cult %d,   Gar %d" % (pCity.getName(), happyIdx, locationRevIdx, relIdx, natIdx, cultIdx, garIdx)
@@ -1963,7 +1963,7 @@ class Revolution:
 			if iSmall > iGold:
 				continue
 
-			revIdx = cityX.getRevolutionIndex()
+			revIdx = cityX.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 			localRevIdx = cityX.getLocalRevIndex()
 
 			if localRevIdx > 2*self.badLocalThreshold:
@@ -2017,7 +2017,7 @@ class Revolution:
 
 		for pCity in pPlayer.cities():
 
-			revIdx = pCity.getRevolutionIndex()
+			revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 			prevRevIdx = RevData.getCityVal(pCity, 'PrevRevIndex')
 			localRevIdx = pCity.getLocalRevIndex()
 
@@ -2052,7 +2052,7 @@ class Revolution:
 		# TODO: turn this and instigator bit above into a function, when revolt odds > 0 then is an instigator
 		if( len(revInstigatorCities) > 0 ) :
 			for pCity in revInstigatorCities :
-				revIdx = pCity.getRevolutionIndex()
+				revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 				localRevIdx = pCity.getLocalRevIndex()
 				revIdxHist = RevData.getCityVal(pCity,'RevIdxHistory')
 
@@ -2199,7 +2199,7 @@ class Revolution:
 ##--- Game turn functions  ---------------------------------------------------
 
 	def revIndexAdjusted(self, pCity):
-		return pCity.getRevolutionIndex() - pCity.isCapital() * self.revInstigatorThreshold
+		return pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX] - pCity.isCapital() * self.revInstigatorThreshold
 
 
 	def pickRevolutionStyle(self, pPlayer, instigator, revReadyCities):
@@ -2230,7 +2230,7 @@ class Revolution:
 
 		# Peaceful or violent?
 		bPeaceful = True
-		instRevIdx = instigator.getRevolutionIndex()
+		instRevIdx = instigator.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 		instLocalIdx = instigator.getLocalRevIndex()
 
 		if instRevIdx > self.alwaysViolentThreshold:
@@ -2349,7 +2349,7 @@ class Revolution:
 								if( RevData.getCityVal(pCity, 'RevolutionCiv') == revCivType ) :
 									joinRevCities.append(pCity)
 									if self.LOG_DEBUG: print "[REV] Revolt: %s has same rev type" % pCity.getName()
-								elif( pCity.getRevolutionIndex() > self.revInstigatorThreshold and cityDist <= 0.8*self.closeRadius ) :
+								elif( pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX] > self.revInstigatorThreshold and cityDist <= 0.8*self.closeRadius ) :
 									joinRevCities.append(pCity)
 									if self.LOG_DEBUG: print "[REV] Revolt: %s is close and over threshold, joining" % pCity.getName()
 
@@ -2358,7 +2358,7 @@ class Revolution:
 							handoverCities = []
 							toSort = []
 							for pCity in citiesInRevolt :
-								revIdx = pCity.getRevolutionIndex()
+								revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 								if( pCity.isCapital() ) :
 									if( revIdx > self.alwaysViolentThreshold and pCity.getLocalRevIndex() > 0 ) :
 										if self.LOG_DEBUG: print "[REV] Revolt: %s (capital), %d qualifies as revolting city" % (pCity.getName(), revIdx)
@@ -2377,7 +2377,7 @@ class Revolution:
 										break
 
 								if not bInList:
-									revIdx = pCity.getRevolutionIndex()
+									revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 									if pCity.isCapital():
 										if( revIdx > self.alwaysViolentThreshold and pCity.getLocalRevIndex() > 0 ) :
 											if self.LOG_DEBUG: print "[REV] Revolt: %s (capital), %d qualifies as joining city" % (pCity.getName(), revIdx)
@@ -2721,7 +2721,7 @@ class Revolution:
 						if self.LOG_DEBUG: print "[REV] Revolt: Asking change in state religion, %d practice new, %d practice state" % (revRelCount, stateRelCount)
 						totalRevIdx = 0
 						for pCity in relCities :
-							totalRevIdx += pCity.getRevolutionIndex()
+							totalRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 						iBuyOffCost = totalRevIdx/(17-pPlayer.getCurrentEra()) + GAME.getSorenRandNum(50+10*pPlayer.getCurrentEra(),'Rev')
 						#iBuyOffCost = (60 + 12*pPlayer.getCurrentEra())*len(relCities) + GAME.getSorenRandNum(50+10*pPlayer.getCurrentEra(),'Rev')
 						if( not pPlayer.isHuman() ) : iBuyOffCost = int( iBuyOffCost*.7 )
@@ -2776,7 +2776,7 @@ class Revolution:
 					#iBuyOffCost = (60 + 12*pPlayer.getCurrentEra())*len(indCities) + GAME.getSorenRandNum(50+10*pPlayer.getCurrentEra(),'Rev')
 					totalRevIdx = 0
 					for pCity in indCities :
-						totalRevIdx += pCity.getRevolutionIndex()
+						totalRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 					iBuyOffCost = totalRevIdx/(17-pPlayer.getCurrentEra()) + GAME.getSorenRandNum(50+10*pPlayer.getCurrentEra(),'Rev')
 					if( not pPlayer.isHuman() ) : iBuyOffCost = int( iBuyOffCost*.7 )
 					iBuyOffCost = max( [iBuyOffCost, pPlayer.getGold()/12 + GAME.getSorenRandNum(50,'Rev')] )
@@ -2959,7 +2959,7 @@ class Revolution:
 						#iBuyOffCost = (50 + 10*pPlayer.getCurrentEra())*len(revCities) + GAME.getSorenRandNum(50+10*pPlayer.getCurrentEra(),'Rev')
 						totalRevIdx = 0
 						for pCity in revCities :
-							totalRevIdx += pCity.getRevolutionIndex()
+							totalRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 						iBuyOffCost = totalRevIdx/(20-pPlayer.getCurrentEra()) + GAME.getSorenRandNum(50+10*pPlayer.getCurrentEra(),'Rev')
 						if( not pPlayer.isHuman() ) : iBuyOffCost = int( iBuyOffCost*.7 )
 						iBuyOffCost = max( [iBuyOffCost, pPlayer.getGold()/10 + GAME.getSorenRandNum(50,'Rev')] )
@@ -3049,7 +3049,7 @@ class Revolution:
 						#iBuyOffCost = (50 + 10*pPlayer.getCurrentEra())*len(revCities) + GAME.getSorenRandNum(50+10*pPlayer.getCurrentEra(),'Rev')
 						totalRevIdx = 0
 						for pCity in revCities :
-							totalRevIdx += pCity.getRevolutionIndex()
+							totalRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 						iBuyOffCost = totalRevIdx/(20-pPlayer.getCurrentEra()) + GAME.getSorenRandNum(50+10*pPlayer.getCurrentEra(),'Rev')
 						if( not pPlayer.isHuman() ) : iBuyOffCost = int( iBuyOffCost*.7 )
 						iBuyOffCost = max( [iBuyOffCost, pPlayer.getGold()/10 + GAME.getSorenRandNum(50,'Rev')] )
@@ -3109,7 +3109,7 @@ class Revolution:
 						#iBuyOffCost = (75 + 12*pPlayer.getCurrentEra())*len(foreignCities) + GAME.getSorenRandNum(100+10*pPlayer.getCurrentEra(),'Rev')
 						totalRevIdx = 0
 						for pCity in foreignCities :
-							totalRevIdx += pCity.getRevolutionIndex()
+							totalRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 						iBuyOffCost = totalRevIdx/(15-pPlayer.getCurrentEra()) + GAME.getSorenRandNum(80+10*pPlayer.getCurrentEra(),'Rev')
 						if( not pPlayer.isHuman() ) : iBuyOffCost = int( iBuyOffCost*.7 )
 						iBuyOffCost = max( [iBuyOffCost, pPlayer.getGold()/8 + GAME.getSorenRandNum(50,'Rev')] )
@@ -3158,7 +3158,7 @@ class Revolution:
 						#iBuyOffCost = (50 + 12*pPlayer.getCurrentEra())*len(revCities) + GAME.getSorenRandNum(50+10*pPlayer.getCurrentEra(),'Rev')
 						totalRevIdx = 0
 						for pCity in revCities :
-							totalRevIdx += pCity.getRevolutionIndex()
+							totalRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 						iBuyOffCost = totalRevIdx/(20-pPlayer.getCurrentEra()) + GAME.getSorenRandNum(50+10*pPlayer.getCurrentEra(),'Rev')
 						if( not pPlayer.isHuman() ) : iBuyOffCost = int( iBuyOffCost*.7 )
 						iBuyOffCost = max( [iBuyOffCost, pPlayer.getGold()/10 + GAME.getSorenRandNum(50,'Rev')] )
@@ -3225,7 +3225,7 @@ class Revolution:
 							#iBuyOffCost = (50 + 15*pPlayer.getCurrentEra())*len(revCities) + GAME.getSorenRandNum(150+15*pPlayer.getCurrentEra(),'Rev')
 							totalRevIdx = 0
 							for pCity in revCities :
-								totalRevIdx += pCity.getRevolutionIndex()
+								totalRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 							iBuyOffCost = totalRevIdx/(20-pPlayer.getCurrentEra()) + GAME.getSorenRandNum(100+10*pPlayer.getCurrentEra(),'Rev')
 							if( not pPlayer.isHuman() ) : iBuyOffCost = int( iBuyOffCost*.7 )
 							iBuyOffCost = max( [iBuyOffCost, pPlayer.getGold()/8 + GAME.getSorenRandNum(50,'Rev')] )
@@ -3260,7 +3260,7 @@ class Revolution:
 							#iBuyOffCost = (50 + 10*pPlayer.getCurrentEra())*len(revCities) + GAME.getSorenRandNum(50+10*pPlayer.getCurrentEra(),'Rev')
 							totalRevIdx = 0
 							for pCity in revCities :
-								totalRevIdx += pCity.getRevolutionIndex()
+								totalRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 							iBuyOffCost = totalRevIdx/(20-pPlayer.getCurrentEra()) + GAME.getSorenRandNum(50+12*pPlayer.getCurrentEra(),'Rev')
 							if( not pPlayer.isHuman() ) : iBuyOffCost = int( iBuyOffCost*.7 )
 							iBuyOffCost = max( [iBuyOffCost, pPlayer.getGold()/10 + GAME.getSorenRandNum(50,'Rev')] )
@@ -3301,7 +3301,7 @@ class Revolution:
 								#iBuyOffCost = (50 + 15*pPlayer.getCurrentEra())*len(revCities) + GAME.getSorenRandNum(100+10*pPlayer.getCurrentEra(),'Rev')
 								totalRevIdx = 0
 								for pCity in revCities :
-									totalRevIdx += pCity.getRevolutionIndex()
+									totalRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 								iBuyOffCost = totalRevIdx/(20-pPlayer.getCurrentEra()) + GAME.getSorenRandNum(80+10*pPlayer.getCurrentEra(),'Rev')
 								if( not pPlayer.isHuman() ) : iBuyOffCost = int( iBuyOffCost*.7 )
 								iBuyOffCost = max( [iBuyOffCost, pPlayer.getGold()/10 + GAME.getSorenRandNum(50,'Rev')] )
@@ -3334,7 +3334,7 @@ class Revolution:
 							#iBuyOffCost = (30 + 10*pPlayer.getCurrentEra())*len(revCities) + GAME.getSorenRandNum(100+10*pPlayer.getCurrentEra(),'Rev')
 							totalRevIdx = 0
 							for pCity in revCities :
-								totalRevIdx += pCity.getRevolutionIndex()
+								totalRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 							iBuyOffCost = totalRevIdx/(25-pPlayer.getCurrentEra()) + GAME.getSorenRandNum(90+10*pPlayer.getCurrentEra(),'Rev')
 							if( not pPlayer.isHuman() ) : iBuyOffCost = int( iBuyOffCost*.7 )
 							iBuyOffCost = max( [iBuyOffCost, pPlayer.getGold()/12 + GAME.getSorenRandNum(50,'Rev')] )
@@ -3386,7 +3386,7 @@ class Revolution:
 							#iBuyOffCost = (50 + 12*pPlayer.getCurrentEra())*len(revCities) + GAME.getSorenRandNum(100+10*pPlayer.getCurrentEra(),'Rev')
 							totalRevIdx = 0
 							for pCity in revCities:
-								totalRevIdx += pCity.getRevolutionIndex()
+								totalRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 							iBuyOffCost = totalRevIdx/(22-pPlayer.getCurrentEra()) + GAME.getSorenRandNum(80+10*pPlayer.getCurrentEra(),'Rev')
 							if not pPlayer.isHuman(): iBuyOffCost = iBuyOffCost * 7 / 10
 							iBuyOffCost = max( [iBuyOffCost, pPlayer.getGold()/8 + GAME.getSorenRandNum(50,'Rev')] )
@@ -3465,7 +3465,7 @@ class Revolution:
 			totalRevIdx = 0
 			totalPop = 0
 			for pCity in indCities :
-				totalRevIdx += pCity.getRevolutionIndex()
+				totalRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 				totalPop += pCity.getPopulation()
 			iBuyOffCost = totalRevIdx/(17-pPlayer.getCurrentEra()) + GAME.getSorenRandNum(50+10*pPlayer.getCurrentEra(),'Rev')
 			if( not pPlayer.isHuman() ) : iBuyOffCost = int( iBuyOffCost*.7 )
@@ -3635,7 +3635,7 @@ class Revolution:
 
 						if playerI.getCitiesLost() < 3 and playerI.getNumCities() < 4:
 							pCapital = playerI.getCapitalCity()
-							if pCapital is not None and GAME.getGameTurn() - pCapital.getGameTurnAcquired() < 30 \
+							if pCapital is not None and GAME.getGameTurn() - pCapital.getCounts()[CityCountRead.CITY_COUNT_GAME_TURN_ACQUIRED] < 30 \
 							and not GC.getPlayer(pCapital.getPreviousOwner()).isNPC():
 
 								if (playerI.getCivilizationType() == RevData.getCityVal(pCity, 'RevolutionCiv')):
@@ -4750,7 +4750,7 @@ class Revolution:
 			for pCity in cityList:
 				if self.LOG_DEBUG:
 					print "[REV] Revolt: Buying off revolutionaries in " + pCity.getName()
-				revIdx = pCity.getRevolutionIndex()
+				revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 				pCity.setRevolutionIndex(min([self.revInstigatorThreshold * self.revReadyDividend / self.revReadyDivisor, revIdx - 200]))
 				pCity.setRevolutionCounter(self.buyoffTurns)
 				pCity.setReinforcementCounter(0)
@@ -4776,7 +4776,7 @@ class Revolution:
 
 				# Make those cities happier
 				for pCity in cityList :
-					revIdx = pCity.getRevolutionIndex()
+					revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 					pCity.setRevolutionIndex( min([revIdx/2,int(.6*self.revInstigatorThreshold)]) )
 					pCity.setRevolutionCounter( self.acceptedTurns )
 					pCity.setReinforcementCounter(0)
@@ -4810,7 +4810,7 @@ class Revolution:
 				pPlayer.convert(iNewReligion)
 				# Make those cities happier
 				for pCity in cityList :
-					revIdx = pCity.getRevolutionIndex()
+					revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 					pCity.setRevolutionIndex( min([revIdx/2,int(.6*self.revInstigatorThreshold)]) )
 					pCity.setRevolutionCounter( self.acceptedTurns )
 					pCity.setReinforcementCounter(0)
@@ -4840,7 +4840,7 @@ class Revolution:
 
 				# Lower indices
 				for pCity in cityList :
-					revIdx = pCity.getRevolutionIndex()
+					revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 					pCity.setRevolutionIndex( min([revIdx/2,int(.6*self.revInstigatorThreshold)]) )
 					pCity.setRevolutionCounter( self.acceptedTurns )
 					pCity.setReinforcementCounter(0)
@@ -4961,7 +4961,7 @@ class Revolution:
 				pRevPlayer = GC.getPlayer( revData.dict['iRevPlayer'] )
 
 				for pCity in cityList :
-					revIdx = pCity.getRevolutionIndex()
+					revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 					pCity.setRevolutionIndex( min([revIdx/2,int(.5*self.revInstigatorThreshold)]) )
 					pCity.setRevolutionCounter( self.acceptedTurns )
 					pCity.setReinforcementCounter(0)
@@ -5051,7 +5051,7 @@ class Revolution:
 					# Special case where pPlayer turns over control of handover cities instead of having cityList revolt
 
 					for pCity in handoverCities :
-						revIdx = pCity.getRevolutionIndex()
+						revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 						pCity.setRevolutionIndex(min([revIdx / 2, self.revInstigatorThreshold * 4 * self.revReadyDividend / (5 * self.revReadyDivisor)]))
 						# Other changes handled by acquired city logic
 						if pCity.getNumRevolts(pPlayer.getID()) > 1:
@@ -5062,7 +5062,7 @@ class Revolution:
 					for pCity in cityList :
 						if( not pCity.getID() in revData.dict.get('HandoverCities', []) ) :
 							if self.LOG_DEBUG: print "[REV] Revolt: Turning down rebelliousness in non-handed over city " + pCity.getName()
-							revIdx = pCity.getRevolutionIndex()
+							revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 							pCity.setRevolutionIndex( min([(3*revIdx)/4,int(self.revInstigatorThreshold)]) )
 							if( pCity.getNumRevolts(pPlayer.getID()) > 2 ) :
 								pCity.changeNumRevolts( pPlayer.getID(), -2 )
@@ -5071,7 +5071,7 @@ class Revolution:
 
 					pCity = pPlayer.getCapitalCity()
 					if( not pCity.getID() in revData.dict.get('HandoverCities', []) ) :
-						revIdx = pCity.getRevolutionIndex()
+						revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 						if( not pCity.getID() in revData.dict.get('cityList', []) and (revIdx > self.revInstigatorThreshold and RevData.getCityVal(pCity,'RevolutionCiv') == pRevPlayer.getCivilizationType()) ) :
 							if self.LOG_DEBUG: print "[REV] Revolt: Also turning down rebelliousness in capital " + pCity.getName()
 							pCity.setRevolutionIndex( min([(7*revIdx)/8,int(self.revInstigatorThreshold)]) )
@@ -5086,7 +5086,7 @@ class Revolution:
 
 				else:
 					for pCity in cityList:
-						revIdx = pCity.getRevolutionIndex()
+						revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 						pCity.setRevolutionIndex(min([revIdx/2, self.revInstigatorThreshold * 4 * self.revReadyDividend / (5 * self.revReadyDivisor)]))
 						# Other changes handled by acquired city logic
 						if pCity.getNumRevolts(pPlayer.getID()) > 1:
@@ -5560,7 +5560,7 @@ class Revolution:
 								if( not pCity.getID() in revData.dict.get('cityList', []) ) :
 									if self.LOG_DEBUG: print "[REV] Revolt: Bolstering rebellious spirit in %s (handover city only)" % pCity.getName()
 
-									revIdx = pCity.getRevolutionIndex()
+									revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 									localRevIdx = pCity.getLocalRevIndex()
 									reinfTurns = pCity.getReinforcementCounter()
 
@@ -5921,10 +5921,10 @@ class Revolution:
 		if len(cityList) > 2:
 			revIdxCityList = []
 			for pCity in cityList[1:]:
-				revIdx = pCity.getRevolutionIndex()
+				revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 				revIdxCityList.append(pCity)
 
-			revIdxCityList.sort(key=lambda i: (i.getRevolutionIndex(), i.getName()))
+			revIdxCityList.sort(key=lambda i: (i.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX], i.getName()))
 			revIdxCityList.reverse()
 
 			newCityList = []
@@ -6111,7 +6111,7 @@ class Revolution:
 
 		for [cityIdx, pCity] in enumerate(cityList):
 
-			revIdx = pCity.getRevolutionIndex()
+			revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 			localRevIdx = pCity.getLocalRevIndex()
 			ix = pCity.getX()
 			iy = pCity.getY()
@@ -6473,7 +6473,7 @@ class Revolution:
 
 				pCity.setOccupationTimer( max([iTurns,1]) )
 				if self.LOG_DEBUG:
-					print "[REV] Revolt: City occupation timer set to " + str(pCity.getOccupationTimer())
+					print "[REV] Revolt: City occupation timer set to " + str(pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_OCCUPATION])
 
 				if pCity.getRevRequestAngerTimer() < 3*self.turnsBetweenRevs:
 					pCity.changeRevRequestAngerTimer( min([2*self.turnsBetweenRevs, 3*self.turnsBetweenRevs - pCity.getRevRequestAngerTimer()]) )

--- a/Assets/Python/Revolution/Gameready/Revolution.py
+++ b/Assets/Python/Revolution/Gameready/Revolution.py
@@ -1396,7 +1396,8 @@ class Revolution:
 
 			# Health
 			healthIdx = 0
-			numUnhealthy = (pCity.badHealth(False) - pCity.goodHealth())
+			aWellbeing = pCity.getRealizedWellbeing(0)
+			numUnhealthy = (aWellbeing[WellbeingChannel.WELLBEING_UNHEALTH] - aWellbeing[WellbeingChannel.WELLBEING_HEALTH])
 			if numUnhealthy > 0:
 				healthIdx = int(int(2*pow(numUnhealthy, .6) + .5) * self.happinessModifier)
 				if pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_ESPIONAGE_HEALTH] > 0 or pPlayer.isRebel():
@@ -6243,7 +6244,8 @@ class Revolution:
 			else:
 				# Compare strength of revolution and garrison
 				iRevStrength = iNumUnits
-				if pCity.unhappyLevel(0) - pCity.happyLevel() > 0:
+				aWellbeing = pCity.getRealizedWellbeing(0)
+				if aWellbeing[WellbeingChannel.WELLBEING_ANGER] - aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS] > 0:
 					iRevStrength += 2
 				if bIsJoinWar:
 					iRevStrength -= 2

--- a/Assets/Python/Revolution/RevEvents.py
+++ b/Assets/Python/Revolution/RevEvents.py
@@ -442,7 +442,8 @@ def checkRebelBonuses(argsList):
 	elif newOwnerCiv == RevData.getCityVal(pCity, 'RevolutionCiv'):
 
 		# TODO: Check whether revolt is active in RevoltData
-		if pCity.getReinforcementCounter() > 0 or (pCity.unhappyLevel(0) - pCity.happyLevel()) > 0:
+		aWellbeing = pCity.getRealizedWellbeing(0)
+		if pCity.getReinforcementCounter() > 0 or (aWellbeing[WellbeingChannel.WELLBEING_ANGER] - aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS]) > 0:
 			print "[REV] Rebellious pCity %s is captured by rebel identity %s (%d)!!!" %(pCity.getName(), newOwner.getCivilizationDescription(0), newOwnerCiv)
 
 			newOwnerTeam = GC.getTeam(newOwner.getTeam())

--- a/Assets/Python/Revolution/RevEvents.py
+++ b/Assets/Python/Revolution/RevEvents.py
@@ -132,11 +132,11 @@ def onEndGameTurn(argsList):
 				playerI.setIsRebel(False)
 				if LOG_DEBUG:
 					print "[REV] %s (Player %d) is no longer a rebel due to no rebel against"%(playerI.getCivilizationDescription(0), i)
-			elif playerI.getNumCities() > 3 and GAME.getGameTurn() - playerI.getCapitalCity().getGameTurnAcquired() > 15:
+			elif playerI.getNumCities() > 3 and GAME.getGameTurn() - playerI.getCapitalCity().getCounts()[CityCountRead.CITY_COUNT_GAME_TURN_ACQUIRED] > 15:
 				playerI.setIsRebel(False)
 				if LOG_DEBUG:
 					print "[REV] %s (Player %d) is no longer a rebel by cities and capital ownership turns"%(playerI.getCivilizationDescription(0), i)
-			elif playerI.getNumCities() > 0 and GAME.getGameTurn() - playerI.getCapitalCity().getGameTurnAcquired() > 30:
+			elif playerI.getNumCities() > 0 and GAME.getGameTurn() - playerI.getCapitalCity().getCounts()[CityCountRead.CITY_COUNT_GAME_TURN_ACQUIRED] > 30:
 				playerI.setIsRebel( False )
 				if LOG_DEBUG:
 					print "[REV] %s (Player %d) is no longer a rebel by capital ownership turns"%(playerI.getCivilizationDescription(0), i)
@@ -200,7 +200,7 @@ def onSetPlayerAlive(argsList):
 					print "[REV] The dying %s are the rebel type for %s"%(pPlayer.getCivilizationDescription(0), pCity.getName())
 
 				if GC.getTeam(pPlayer.getTeam()).isAtWarWith(pCity.getTeam()):
-					revIdx = pCity.getRevolutionIndex()
+					revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 					localIdx = pCity.getLocalRevIndex()
 					revCnt = pCity.getNumRevolts(iPlayerX)
 					if pCity.getReinforcementCounter() > 0:
@@ -217,14 +217,14 @@ def onSetPlayerAlive(argsList):
 						changeRevIdx = -revIdx * iDividend // 100
 						pCity.changeRevolutionIndex(changeRevIdx)
 						pCity.changeRevRequestAngerTimer(-pCity.getRevRequestAngerTimer())
-						pCity.setRevolutionIndex(min([pCity.getRevolutionIndex(), RevOpt.getAlwaysViolentThreshold()]))
+						pCity.setRevolutionIndex(min([pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX], RevOpt.getAlwaysViolentThreshold()]))
 						revIdxHist = RevData.getCityVal(pCity,'RevIdxHistory')
 						revIdxHist['Events'][0] += changeRevIdx
 						RevData.updateCityVal(pCity, 'RevIdxHistory', revIdxHist)
 						pCity.setReinforcementCounter(0)
 						pCity.setOccupationTimer(0)
 						if LOG_DEBUG:
-							print "[REV] Rev index in %s decreased to %d (from %d)"%(pCity.getName(), pCity.getRevolutionIndex(), revIdx)
+							print "[REV] Rev index in %s decreased to %d (from %d)"%(pCity.getName(), pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX], revIdx)
 
 					elif GAME.getGameTurn() - revTurn < 30:
 						# Put down after a while
@@ -241,13 +241,13 @@ def onSetPlayerAlive(argsList):
 						changeRevIdx = -revIdx * iDividend // 100
 						pCity.changeRevolutionIndex(changeRevIdx)
 						pCity.changeRevRequestAngerTimer(-pCity.getRevRequestAngerTimer())
-						pCity.setRevolutionIndex(min([pCity.getRevolutionIndex(),RevOpt.getAlwaysViolentThreshold()]))
+						pCity.setRevolutionIndex(min([pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX],RevOpt.getAlwaysViolentThreshold()]))
 						revIdxHist = RevData.getCityVal(pCity,'RevIdxHistory')
 						revIdxHist['Events'][0] += changeRevIdx
 						RevData.updateCityVal(pCity, 'RevIdxHistory', revIdxHist)
 						pCity.setOccupationTimer(0)
 						if LOG_DEBUG:
-							print "[REV] Rev index in %s decreased to %d (from %d)"%(pCity.getName(), pCity.getRevolutionIndex(), revIdx)
+							print "[REV] Rev index in %s decreased to %d (from %d)"%(pCity.getName(), pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX], revIdx)
 
 
 	if not pPlayer.isFoundedFirstCity():
@@ -315,7 +315,7 @@ def onChangeWar(argsList):
 			):
 				# City recently rebelled for civ now at peace
 				localIdx = pCity.getLocalRevIndex()
-				revIdx = pCity.getRevolutionIndex()
+				revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 				revCnt = pCity.getNumRevolts(pCity.getOwner())
 				if LOG_DEBUG:
 					print "[REV] Rebels in %s have agreed to peace (%d, %d, %d)"%(pCity.getName(), revIdx, localIdx, revCnt)
@@ -329,13 +329,13 @@ def onChangeWar(argsList):
 
 				changeRevIdx = -revIdx * iDividend / 100
 				pCity.changeRevolutionIndex(changeRevIdx)
-				pCity.setRevolutionIndex(min([pCity.getRevolutionIndex(),RevOpt.getAlwaysViolentThreshold()]))
+				pCity.setRevolutionIndex(min([pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX],RevOpt.getAlwaysViolentThreshold()]))
 				revIdxHist = RevData.getCityVal(pCity,'RevIdxHistory')
 				revIdxHist['Events'][0] += changeRevIdx
 				RevData.updateCityVal(pCity, 'RevIdxHistory', revIdxHist)
 				pCity.setOccupationTimer(0)
 				if LOG_DEBUG:
-					print "[REV] Rev index in %s decreased to %d (from %d)"%(pCity.getName(), pCity.getRevolutionIndex(), revIdx)
+					print "[REV] Rev index in %s decreased to %d (from %d)"%(pCity.getName(), pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX], revIdx)
 
 		GC.getTeam(pPlayer.getTeam()).setRebelAgainst(iRivalTeam, False)
 
@@ -349,7 +349,7 @@ def onChangeWar(argsList):
 			):
 				# City recently rebelled for civ now at peace
 				localIdx = pCity.getLocalRevIndex()
-				revIdx = pCity.getRevolutionIndex()
+				revIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 				revCnt = pCity.getNumRevolts(pCity.getOwner())
 				if LOG_DEBUG:
 					print "[REV] Rebels in %s have sued for peace" % pCity.getName()
@@ -363,13 +363,13 @@ def onChangeWar(argsList):
 
 				changeRevIdx = -revIdx * iDividend / 100
 				pCity.changeRevolutionIndex( changeRevIdx )
-				pCity.setRevolutionIndex(min([pCity.getRevolutionIndex(), RevOpt.getAlwaysViolentThreshold()]))
+				pCity.setRevolutionIndex(min([pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX], RevOpt.getAlwaysViolentThreshold()]))
 				revIdxHist = RevData.getCityVal(pCity,'RevIdxHistory')
 				revIdxHist['Events'][0] += changeRevIdx
 				RevData.updateCityVal(pCity, 'RevIdxHistory', revIdxHist)
 				pCity.setOccupationTimer(0)
 				if LOG_DEBUG:
-					print "[REV] Rev index in %s decreased to %d (from %d)"%(pCity.getName(), pCity.getRevolutionIndex(), revIdx)
+					print "[REV] Rev index in %s decreased to %d (from %d)"%(pCity.getName(), pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX], revIdx)
 
 		GC.getTeam(pPlayer.getTeam()).setRebelAgainst(iTeam, False)
 
@@ -385,14 +385,14 @@ def onCityBuilt( argsList ):
 
 	if( pPlayer.isNPC() ) :
 		city.setRevolutionIndex( int(.4*RevOpt.getAlwaysViolentThreshold()) )
-		city.setRevIndexAverage(city.getRevolutionIndex())
+		city.setRevIndexAverage(city.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX])
 		return
 
 	if( not city.area().getID() == pPlayer.getCapitalCity().area().getID() ) :
 		city.setRevolutionIndex( int(.35*RevOpt.getInstigateRevolutionThreshold()) )
 	else :
 		city.setRevolutionIndex( int(.25*RevOpt.getInstigateRevolutionThreshold()) )
-	city.setRevIndexAverage(city.getRevolutionIndex())
+	city.setRevIndexAverage(city.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX])
 
 	revTurn = RevData.revObjectGetVal( pPlayer, 'RevolutionTurn' )
 	if revTurn != None and pPlayer.getNumCities() < 4 and GAME.getGameTurn() - revTurn < 25:
@@ -414,7 +414,7 @@ def onCityAcquired(argsList):
 	RevData.initCity(city)
 	RevData.setCityVal(city, 'RevolutionCiv', iRevCiv)
 
-	iTurns = city.getOccupationTimer()
+	iTurns = city.getCountdowns()[CityCountdownKind.COUNTDOWN_OCCUPATION]
 	city.setRevolutionCounter( max([int(1.5*iTurns),3]) )
 
 
@@ -525,7 +525,7 @@ def checkRebelBonuses(argsList):
 						print "Rev - Rebels get a %s to raid motherland" % bestUnit.getDescription()
 
 				# Change city disorder timer to favor new player
-				iTurns = pCity.getOccupationTimer()
+				iTurns = pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_OCCUPATION]
 				iTurns = iTurns/4 + 1
 				pCity.setOccupationTimer(iTurns)
 
@@ -549,7 +549,7 @@ def checkRebelBonuses(argsList):
 				RevUtils.giveCityCulture(pCity, iOwnerNew, newCulVal, newPlotVal)
 
 				# Change city disorder timer to favor new player
-				iTurns = pCity.getOccupationTimer()
+				iTurns = pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_OCCUPATION]
 				iTurns = min([iTurns, iTurns/3 + 1])
 				pCity.setOccupationTimer(iTurns)
 
@@ -569,7 +569,7 @@ def checkRebelBonuses(argsList):
 			newPlotVal = int( revCultureModifier*max([pCity.plot().getCulture(iOwnerOld)/2,pCity.plot().countTotalCulture()/4]) )
 			RevUtils.giveCityCulture( pCity, iOwnerNew, newCulVal, newPlotVal)
 
-			iTurns = pCity.getOccupationTimer()
+			iTurns = pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_OCCUPATION]
 			iTurns = iTurns/2 + 1
 			pCity.setOccupationTimer(iTurns)
 
@@ -586,7 +586,7 @@ def updateRevolutionIndices(argsList):
 
 	if bConquest:
 		# Occupied cities also rack up rev points each turn
-		newRevIdx += pCity.getRevolutionIndex()/4
+		newRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]/4
 		newRevIdx = min( [newRevIdx, 600] )
 
 		if pCity.plot().calculateCulturePercent( iOwnerNew ) > 90:
@@ -599,7 +599,7 @@ def updateRevolutionIndices(argsList):
 			changeRevIdx -= 30
 
 	elif bTrade:
-		newRevIdx += pCity.getRevolutionIndex()/3
+		newRevIdx += pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]/3
 		newRevIdx = min( [newRevIdx, 650] )
 
 		if pCity.plot().calculateCulturePercent( iOwnerNew ) > 90:
@@ -670,7 +670,7 @@ def playerCityLost(CyPlayer, CyCity, bConquest = True):
 	if CyPlayer.isNPC() or CyPlayer.getNumCities() < 1:
 		return
 
-	revIdxChange = (GAME.getGameTurn() - CyCity.getGameTurnAcquired()) * 100.0 / GAME.getSpeedPercent()
+	revIdxChange = (GAME.getGameTurn() - CyCity.getCounts()[CityCountRead.CITY_COUNT_GAME_TURN_ACQUIRED]) * 100.0 / GAME.getSpeedPercent()
 	revIdxChange += CyCity.getHighestPopulation()
 	revIdxChange *= CyCity.plot().calculateCulturePercent(CyPlayer.getID()) / 100.0
 
@@ -705,11 +705,11 @@ def onBuildingBuilt(argsList):
 	if buildingInfo.getMaxGlobalInstances() == 1 and buildingInfo.getPrereqReligion() < 0 and buildingInfo.getProductionCost() > 10:
 		if LOG_DEBUG:
 			print"[REV] World wonder %s build in %s"%(buildingInfo.getDescription(), pCity.getName())
-		curRevIdx = pCity.getRevolutionIndex()
+		curRevIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 		pCity.changeRevolutionIndex(-max([150, curRevIdx / 4]))
 
 		for cityX in GC.getPlayer(pCity.getOwner()).cities():
-			curRevIdx = cityX.getRevolutionIndex()
+			curRevIdx = cityX.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 			iRevIdxChange = -max([75, curRevIdx * 12/100])
 			cityX.changeRevolutionIndex(iRevIdxChange)
 			revIdxHist = RevData.getCityVal(cityX,'RevIdxHistory')
@@ -719,11 +719,11 @@ def onBuildingBuilt(argsList):
 	elif buildingInfo.getMaxPlayerInstances() == 1 and buildingInfo.getPrereqReligion() < 0 and buildingInfo.getProductionCost() > 10:
 		if LOG_DEBUG:
 			print "[REV] National wonder %s build in %s"%(buildingInfo.getDescription(), pCity.getName())
-		curRevIdx = pCity.getRevolutionIndex()
+		curRevIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 		pCity.changeRevolutionIndex(-max([80, curRevIdx * 12/100]))
 
 		for cityX in GC.getPlayer(pCity.getOwner()).cities():
-			curRevIdx = cityX.getRevolutionIndex()
+			curRevIdx = cityX.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 			iRevIdxChange = -max([50, curRevIdx * 7/100])
 			cityX.changeRevolutionIndex(iRevIdxChange)
 			revIdxHist = RevData.getCityVal(cityX,'RevIdxHistory')
@@ -743,10 +743,10 @@ def onReligionFounded(argsList):
 			if iStateReligion > -1 and iStateReligion != iReligion:
 				pCity = GC.getGame().getHolyCity(iReligion)
 				if pCity.getOwner() == argsList[1]:
-					curRevIdx = pCity.getRevolutionIndex()
+					curRevIdx = pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 					pCity.setRevolutionIndex(max([int(.35*RevDefs.revInstigatorThreshold),curRevIdx+100]))
 					if LOG_DEBUG:
-						print "[REV] %s founded non-state religion, index of %s now %d ... state %d, new %d"%(pCity.getName(),pCity.getName(),pCity.getRevolutionIndex(),player.getStateReligion(),iReligion)
+						print "[REV] %s founded non-state religion, index of %s now %d ... state %d, new %d"%(pCity.getName(),pCity.getName(),pCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX],player.getStateReligion(),iReligion)
 
 
 
@@ -849,7 +849,7 @@ def checkForAssimilation():
 		CyTeamX = GC.getTeam(CyPlayerX.getTeam())
 		CyCity0 = CyPlayerX.getCapitalCity()
 		if CyCity0 is None: continue
-		iTurnAcquiredCity0 = CyCity0.getGameTurnAcquired()
+		iTurnAcquiredCity0 = CyCity0.getCounts()[CityCountRead.CITY_COUNT_GAME_TURN_ACQUIRED]
 		CyPlot0 = None
 		szCiv = CyPlayerX.getCivilizationDescription(0)
 
@@ -900,10 +900,10 @@ def checkForAssimilation():
 
 				iOdds = 2*(minNumPlots - iTotalLand) + (4 + 4*iMaxEra)/CyCity0.getPopulation()
 
-				if CyCity0.getOccupationTimer() > 0:
+				if CyCity0.getCountdowns()[CityCountdownKind.COUNTDOWN_OCCUPATION] > 0:
 					iOdds *= 3
 
-				iOdds += CyCity0.getRevolutionIndex()/100
+				iOdds += CyCity0.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]/100
 
 				CyPlot0 = CyCity0.plot()
 				### Special cases
@@ -1076,12 +1076,12 @@ def doSmallRevolts(iPlayer, CyPlayer):
 
 	for city in CyPlayer.cities():
 
-		revIdx = city.getRevolutionIndex()
+		revIdx = city.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 
 		if revIdx <= 5 * RevDefs.revReadyDividend * RevDefs.revInstigatorThreshold / (4 * RevDefs.revReadyDivisor):
 			continue
 
-		if city.getOccupationTimer() > 0 or city.getRevolutionCounter() > 0 or RevData.getCityVal(city, 'SmallRevoltCounter') > 0:
+		if city.getCountdowns()[CityCountdownKind.COUNTDOWN_OCCUPATION] > 0 or city.getRevolutionCounter() > 0 or RevData.getCityVal(city, 'SmallRevoltCounter') > 0:
 			continue # Already in a revolt
 
 		localRevIdx = city.getLocalRevIndex()

--- a/Assets/Python/Revolution/RevUtils.py
+++ b/Assets/Python/Revolution/RevUtils.py
@@ -555,7 +555,7 @@ def giveCityCulture(CyCity, iPlayer, newCityVal, newPlotVal):
 
 def isCanBribeCity(CyCity):
 
-	iRevIdx = CyCity.getRevolutionIndex()
+	iRevIdx = CyCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 
 	if iRevIdx > 1700:
 		return [False, 'Violent']
@@ -577,7 +577,7 @@ def computeBribeCosts(CyCity):
 	iPlayer = CyCity.getOwner()
 	CyPlayer = GC.getPlayer(iPlayer)
 
-	iRevIdx = CyCity.getRevolutionIndex()
+	iRevIdx = CyCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX]
 	localRevIdx = CyCity.getLocalRevIndex()
 
 	iPop = CyCity.getPopulation()
@@ -601,19 +601,19 @@ def bribeCity(CyCity, bribeSize):
 
 	if bribeSize == 'Small':
 		# Small reduction in rev index, mostly just for buyoffturns
-		newRevIdx = int( 0.9*CyCity.getRevolutionIndex() - 10 )
+		newRevIdx = int( 0.9*CyCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX] - 10 )
 		if newRevIdx < 0:
 			newRevIdx = 0
 		CyCity.changeRevolutionCounter(5)
 	elif bribeSize == 'Med':
 		# Med reduction in rev index
-		newRevIdx = int(0.8*CyCity.getRevolutionIndex() - 25)
+		newRevIdx = int(0.8*CyCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX] - 25)
 		if newRevIdx < 0:
 			newRevIdx = 0
 		CyCity.changeRevolutionCounter(7)
 	elif bribeSize == 'Large':
 		# Large reduction in rev index, longer time till next revolt too
-		newRevIdx = int( 0.7*CyCity.getRevolutionIndex() - 50 )
+		newRevIdx = int( 0.7*CyCity.getCounts()[CityCountRead.CITY_COUNT_REVOLUTION_INDEX] - 50 )
 		if newRevIdx < 0:
 			newRevIdx = 0
 		CyCity.changeRevolutionCounter(10)
@@ -631,7 +631,7 @@ def getModNumUnhappy(CyCity, fWarWearinessMod):
 
 	iMod = int(fWarWearinessMod*iPop*CyCity.getWarWearinessPercentAnger()/1000)
 
-	iNumUnhappy = CyCity.angryPopulation(0) - iMod - 1
+	iNumUnhappy = CyCity.getAngryPopulation(0) - iMod - 1
 
 	if iNumUnhappy < 1:
 		return CyCity.unhappyLevel(0) - CyCity.happyLevel()

--- a/Assets/Python/Revolution/RevUtils.py
+++ b/Assets/Python/Revolution/RevUtils.py
@@ -634,7 +634,8 @@ def getModNumUnhappy(CyCity, fWarWearinessMod):
 	iNumUnhappy = CyCity.getAngryPopulation(0) - iMod - 1
 
 	if iNumUnhappy < 1:
-		return CyCity.unhappyLevel(0) - CyCity.happyLevel()
+		aWellbeing = CyCity.getRealizedWellbeing(0)
+		return aWellbeing[WellbeingChannel.WELLBEING_ANGER] - aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS]
 	return iNumUnhappy
 
 def doRevRequestDeniedPenalty(CyCity, iHomeArea, iRevIdxInc=100, bExtraHomeland=False, bExtraColony=False):

--- a/Assets/Python/Screens/Advisors/CvDomesticAdvisor.py
+++ b/Assets/Python/Screens/Advisors/CvDomesticAdvisor.py
@@ -523,7 +523,7 @@ class CvDomesticAdvisor:
 		if CyCity.isDisorder():
 			if CyCity.isOccupation():
 				szOccu = unichr(8871)
-				szReturn += szOccu +":"+unicode(CyCity.getOccupationTimer())
+				szReturn += szOccu +":"+unicode(CyCity.getCountdowns()[CityCountdownKind.COUNTDOWN_OCCUPATION])
 			else:
 				szReturn += unichr(8867)
 

--- a/Assets/Python/Screens/CvMainInterface.py
+++ b/Assets/Python/Screens/CvMainInterface.py
@@ -2636,8 +2636,8 @@ class CvMainInterface:
 			aCityFlags  = GC.getPlayer(iCityOwner).getCity(iCityID).getFlags()
 			aCountdowns = GC.getPlayer(iCityOwner).getCity(iCityID).getCountdowns()
 			aWellbeing  = GC.getPlayer(iCityOwner).getCity(iCityID).getRealizedWellbeing(0)
-			iHappy = aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS] / 100
-			iAnger = aWellbeing[WellbeingChannel.WELLBEING_ANGER] / 100
+			iHappy = aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS]
+			iAnger = aWellbeing[WellbeingChannel.WELLBEING_ANGER]
 
 			# Liberate Button Show
 			if -1 != GC.getPlayer(iCityOwner).getCity(iCityID).getLiberationPlayer():
@@ -2665,8 +2665,8 @@ class CvMainInterface:
 
 			screen.setText("CityNameText", "", szTxt, 1<<2, halfX, 32, 0, eFontGame, WidgetTypes.WIDGET_CITY_NAME, 0, 1)
 
-			iHealthGood = aWellbeing[WellbeingChannel.WELLBEING_HEALTH] / 100
-			iHealthBad = aWellbeing[WellbeingChannel.WELLBEING_UNHEALTH] / 100
+			iHealthGood = aWellbeing[WellbeingChannel.WELLBEING_HEALTH]
+			iHealthBad = aWellbeing[WellbeingChannel.WELLBEING_UNHEALTH]
 			if iHealthBad > 0 or iHealthGood >= 0:
 				if iHealthGood < iHealthBad:
 					# BUG - Negative Health Rate is Positive Eaten Food
@@ -5047,7 +5047,7 @@ class CvMainInterface:
 		screen.setStyle(panel, "ScrollPanel_Min_Style")
 
 		aWellbeing = GC.getPlayer(iCityOwner).getCity(iCityID).getRealizedWellbeing(0)
-		iAngryPop = max(0, min((aWellbeing[WellbeingChannel.WELLBEING_ANGER] - aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS]) / 100, GC.getPlayer(iCityOwner).getCity(iCityID).getPopulation()))
+		iAngryPop = max(0, min(int(aWellbeing[WellbeingChannel.WELLBEING_ANGER] - aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS]), GC.getPlayer(iCityOwner).getCity(iCityID).getPopulation()))
 		x = 0
 		if iAngryPop:
 

--- a/Assets/Python/Screens/Worldbuilder/WBCityDataScreen.py
+++ b/Assets/Python/Screens/Worldbuilder/WBCityDataScreen.py
@@ -213,12 +213,14 @@ class WBCityDataScreen:
 				sText += u"%d%s" %(iVal, CyTranslator().getText("[ICON_HEALTHY]", ()))
 			elif iVal < 0:
 				sText += u"%d%s" %(-iVal, CyTranslator().getText("[ICON_UNHEALTHY]", ()))
+			aGrantedYields = pCity.getBuildingGrantedYields(item[1])
 			for j in xrange(YieldTypes.NUM_YIELD_TYPES):
-				iVal = pCity.getBuildingYieldChange(item[1], j)
+				iVal = aGrantedYields[j]
 				if iVal != 0:
 					sText += u"%d%c" %(iVal, TEXT.getSymbolChar("YIELD_", j))
+			aGrantedCommerces = pCity.getBuildingGrantedCommerces(item[1])
 			for j in xrange(CommerceTypes.NUM_COMMERCE_TYPES):
-				iVal = pCity.getBuildingCommerceChange(item[1], j)
+				iVal = aGrantedCommerces[j]
 				if iVal != 0:
 					sText += u"%d%c" %(iVal, TEXT.getSymbolChar("COMMERCE_", j))
 			screen.setTableInt("WBModifyBuilding", 1, iRow, "<font=3>" + sText + "</font>", "", WidgetTypes.WIDGET_HELP_BUILDING, item[1], -1, 1<<0)
@@ -434,11 +436,11 @@ class WBCityDataScreen:
 		if bRemove:
 			iCount = -iCount
 		if iType < YieldTypes.NUM_YIELD_TYPES:
-			pCity.setBuildingYieldChange(iBuilding, iType, pCity.getBuildingYieldChange(iBuilding, iType) + iCount)
+			pCity.setBuildingYieldChange(iBuilding, iType, pCity.getBuildingGrantedYields(iBuilding)[iType] + iCount)
 		else:
 			iType -= YieldTypes.NUM_YIELD_TYPES
 			if iType < CommerceTypes.NUM_COMMERCE_TYPES:
-				pCity.setBuildingCommerceChange(iBuilding, iType, pCity.getBuildingCommerceChange(iBuilding, iType) + iCount)
+				pCity.setBuildingCommerceChange(iBuilding, iType, pCity.getBuildingGrantedCommerces(iBuilding)[iType] + iCount)
 			else:
 				iType -= CommerceTypes.NUM_COMMERCE_TYPES
 				if iType == 0:

--- a/Assets/Python/Screens/Worldbuilder/WBCityEditScreen.py
+++ b/Assets/Python/Screens/Worldbuilder/WBCityEditScreen.py
@@ -207,13 +207,15 @@ class WBCityEditScreen:
 		iY += 30
 		screen.setButtonGFC("CityChangeHappyPlus", "", "", iX, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1030, -1, ButtonStyles.BUTTON_STYLE_CITY_PLUS)
 		screen.setButtonGFC("CityChangeHappyMinus", "", "", iX + 25, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1031, -1, ButtonStyles.BUTTON_STYLE_CITY_MINUS)
-		sText = "<font=3>%s: %d%s, %d%s</font>" %(CyTranslator().getText("TXT_KEY_CONCEPT_HAPPINESS",()), pCity.happyLevel(), CyTranslator().getText("[ICON_HAPPY]",()), pCity.unhappyLevel(0), CyTranslator().getText("[ICON_UNHAPPY]",()))
+		aWellbeing = pCity.getRealizedWellbeing(0)
+		sText = "<font=3>%s: %d%s, %d%s</font>" %(CyTranslator().getText("TXT_KEY_CONCEPT_HAPPINESS",()), aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS], CyTranslator().getText("[ICON_HAPPY]",()), aWellbeing[WellbeingChannel.WELLBEING_ANGER], CyTranslator().getText("[ICON_UNHAPPY]",()))
 		screen.setLabel("CityChangeHappyText", "Background", sText, 1<<0, iX + 50, iY + 1, -0.1, FontTypes.TITLE_FONT, WidgetTypes.WIDGET_GENERAL, -1, -1)
 
 		iY += 30
 		screen.setButtonGFC("CityChangeHealthPlus", "", "", iX, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1030, -1, ButtonStyles.BUTTON_STYLE_CITY_PLUS)
 		screen.setButtonGFC("CityChangeHealthMinus", "", "", iX + 25, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1031, -1, ButtonStyles.BUTTON_STYLE_CITY_MINUS)
-		sText = "<font=3>%s: %d%s, %d%s</font>" %(CyTranslator().getText("TXT_KEY_CONCEPT_HEALTH",()), pCity.goodHealth(), CyTranslator().getText("[ICON_HEALTHY]",()), pCity.badHealth(False), CyTranslator().getText("[ICON_UNHEALTHY]",()))
+		aWellbeing = pCity.getRealizedWellbeing(0)
+		sText = "<font=3>%s: %d%s, %d%s</font>" %(CyTranslator().getText("TXT_KEY_CONCEPT_HEALTH",()), aWellbeing[WellbeingChannel.WELLBEING_HEALTH], CyTranslator().getText("[ICON_HEALTHY]",()), aWellbeing[WellbeingChannel.WELLBEING_UNHEALTH], CyTranslator().getText("[ICON_UNHEALTHY]",()))
 		screen.setLabel("CityChangeHealthText", "Background", sText, 1<<0, iX + 50, iY + 1, -0.1, FontTypes.TITLE_FONT, WidgetTypes.WIDGET_GENERAL, -1, -1)
 
 		iY += 30

--- a/Assets/Python/Screens/Worldbuilder/WBCityEditScreen.py
+++ b/Assets/Python/Screens/Worldbuilder/WBCityEditScreen.py
@@ -195,7 +195,7 @@ class WBCityEditScreen:
 		iY += 30
 		screen.setButtonGFC("CityDefensePlus", "", "", iX, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1030, -1, ButtonStyles.BUTTON_STYLE_CITY_PLUS)
 		screen.setButtonGFC("CityDefenseMinus", "", "", iX + 25, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1031, -1, ButtonStyles.BUTTON_STYLE_CITY_MINUS)
-		sText = "<font=3>" + CyTranslator().getText("TXT_KEY_WB_DAMAGE",()) + ": " + str(pCity.getDefenseDamage()) + "</font>"
+		sText = "<font=3>" + CyTranslator().getText("TXT_KEY_WB_DAMAGE",()) + ": " + str(pCity.getCounts()[CityCountRead.CITY_COUNT_DEFENSE_DAMAGE]) + "</font>"
 		screen.setLabel("CityDefenseDamageText", "Background", sText, 1<<0, iX + 50, iY + 1, -0.1, FontTypes.TITLE_FONT, WidgetTypes.WIDGET_GENERAL, -1, -1)
 
 		iY += 30
@@ -219,7 +219,7 @@ class WBCityEditScreen:
 		iY += 30
 		screen.setButtonGFC("CityOccupationTurnPlus", "", "", iX, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1030, -1, ButtonStyles.BUTTON_STYLE_CITY_PLUS)
 		screen.setButtonGFC("CityOccupationTurnMinus", "", "", iX + 25, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1031, -1, ButtonStyles.BUTTON_STYLE_CITY_MINUS)
-		sText = "<font=3>" + CyTranslator().getText("TXT_KEY_CONCEPT_RESISTANCE",()) + ": " + str(pCity.getOccupationTimer()) + CyTranslator().getText("[ICON_OCCUPATION]", ()) + "</font>"
+		sText = "<font=3>" + CyTranslator().getText("TXT_KEY_CONCEPT_RESISTANCE",()) + ": " + str(pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_OCCUPATION]) + CyTranslator().getText("[ICON_OCCUPATION]", ()) + "</font>"
 		screen.setLabel("CityOccupationTurnText", "Background", sText, 1<<0, iX + 50, iY + 1, -0.1, FontTypes.TITLE_FONT, WidgetTypes.WIDGET_GENERAL, -1, -1)
 
 		iY += 30
@@ -237,25 +237,25 @@ class WBCityEditScreen:
 		iY += 30
 		screen.setButtonGFC("CityDefyResolutionPlus", "", "", iX, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1030, -1, ButtonStyles.BUTTON_STYLE_CITY_PLUS)
 		screen.setButtonGFC("CityDefyResolutionMinus", "", "", iX + 25, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1031, -1, ButtonStyles.BUTTON_STYLE_CITY_MINUS)
-		sText = "<font=3>" + CyTranslator().getText("TXT_KEY_WB_DEFY_RESOLUTION",(pCity.getDefyResolutionAngerTimer(),)) + "</font>"
+		sText = "<font=3>" + CyTranslator().getText("TXT_KEY_WB_DEFY_RESOLUTION",(pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_DEFY_RESOLUTION_ANGER],)) + "</font>"
 		screen.setLabel("CityDefyResolutionText", "Background", sText, 1<<0, iX + 50, iY + 1, -0.1, FontTypes.TITLE_FONT, WidgetTypes.WIDGET_GENERAL, -1, -1)
 
 		iY += 30
 		screen.setButtonGFC("CityEspionageHealthPlus", "", "", iX, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1030, -1, ButtonStyles.BUTTON_STYLE_CITY_PLUS)
 		screen.setButtonGFC("CityEspionageHealthMinus", "", "", iX + 25, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1031, -1, ButtonStyles.BUTTON_STYLE_CITY_MINUS)
-		sText = u"<font=3>%s %s: %d</font>" %(CyTranslator().getText("TXT_WORD_ESPIONAGE",()), CyTranslator().getText("[ICON_UNHEALTHY]", ()), pCity.getEspionageHealthCounter())
+		sText = u"<font=3>%s %s: %d</font>" %(CyTranslator().getText("TXT_WORD_ESPIONAGE",()), CyTranslator().getText("[ICON_UNHEALTHY]", ()), pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_ESPIONAGE_HEALTH])
 		screen.setLabel("CityEspionageHealthText", "Background", sText, 1<<0, iX + 50, iY + 1, -0.1, FontTypes.TITLE_FONT, WidgetTypes.WIDGET_GENERAL, -1, -1)
 
 		iY += 30
 		screen.setButtonGFC("CityEspionageHappyPlus", "", "", iX, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1030, -1, ButtonStyles.BUTTON_STYLE_CITY_PLUS)
 		screen.setButtonGFC("CityEspionageHappyMinus", "", "", iX + 25, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1031, -1, ButtonStyles.BUTTON_STYLE_CITY_MINUS)
-		sText = u"<font=3>%s %s: %d</font>" %(CyTranslator().getText("TXT_WORD_ESPIONAGE",()), CyTranslator().getText("[ICON_UNHAPPY]", ()), pCity.getEspionageHappinessCounter())
+		sText = u"<font=3>%s %s: %d</font>" %(CyTranslator().getText("TXT_WORD_ESPIONAGE",()), CyTranslator().getText("[ICON_UNHAPPY]", ()), pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_ESPIONAGE_HAPPINESS])
 		screen.setLabel("CityEspionageHappyText", "Background", sText, 1<<0, iX + 50, iY + 1, -0.1, FontTypes.TITLE_FONT, WidgetTypes.WIDGET_GENERAL, -1, -1)
 
 		iY += 30
 		screen.setButtonGFC("CityTemporaryHappyPlus", "", "", iX, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1030, -1, ButtonStyles.BUTTON_STYLE_CITY_PLUS)
 		screen.setButtonGFC("CityTemporaryHappyMinus", "", "", iX + 25, iY, 24, 24, WidgetTypes.WIDGET_PYTHON, 1031, -1, ButtonStyles.BUTTON_STYLE_CITY_MINUS)
-		sText = "<font=3>" + CyTranslator().getText("TXT_KEY_WB_TEMP_HAPPY",(pCity.getHappinessTimer(),)) + "</font>"
+		sText = "<font=3>" + CyTranslator().getText("TXT_KEY_WB_TEMP_HAPPY",(pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_HAPPINESS],)) + "</font>"
 		screen.setLabel("CityTemporaryHappyText", "Background", sText, 1<<0, iX + 50, iY + 1, -0.1, FontTypes.TITLE_FONT, WidgetTypes.WIDGET_GENERAL, -1, -1)
 
 	def placeScript(self):
@@ -429,9 +429,9 @@ class WBCityEditScreen:
 
 		elif inputClass.getFunctionName() in ("CityDefensePlus", "CityDefenseMinus"):
 			if inputClass.getData1() == 1030:
-				pCity.changeDefenseDamage(min(iChange, GC.getDefineINT("MAX_CITY_DEFENSE_DAMAGE") - pCity.getDefenseDamage()))
+				pCity.changeDefenseDamage(min(iChange, GC.getDefineINT("MAX_CITY_DEFENSE_DAMAGE") - pCity.getCounts()[CityCountRead.CITY_COUNT_DEFENSE_DAMAGE]))
 			elif inputClass.getData1() == 1031:
-				pCity.changeDefenseDamage(- min(iChange, pCity.getDefenseDamage()))
+				pCity.changeDefenseDamage(- min(iChange, pCity.getCounts()[CityCountRead.CITY_COUNT_DEFENSE_DAMAGE]))
 			self.placeStats()
 
 		elif inputClass.getFunctionName() in ("CityTradeRoutePlus", "CityTradeRouteMinus"):
@@ -471,7 +471,7 @@ class WBCityEditScreen:
 			if inputClass.getData1() == 1030:
 				pCity.changeOccupationTimer(iChange)
 			elif inputClass.getData1() == 1031:
-				pCity.changeOccupationTimer(- min(iChange, pCity.getOccupationTimer()))
+				pCity.changeOccupationTimer(- min(iChange, pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_OCCUPATION]))
 			self.placeStats()
 
 		elif inputClass.getFunctionName().find("CityDraftAnger") > -1:
@@ -492,28 +492,28 @@ class WBCityEditScreen:
 			if inputClass.getData1() == 1030:
 				pCity.changeDefyResolutionAngerTimer(iChange)
 			elif inputClass.getData1() == 1031:
-				pCity.changeDefyResolutionAngerTimer(- min(iChange, pCity.getDefyResolutionAngerTimer()))
+				pCity.changeDefyResolutionAngerTimer(- min(iChange, pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_DEFY_RESOLUTION_ANGER]))
 			self.placeStats()
 
 		elif inputClass.getFunctionName() in ("CityEspionageHappyPlus", "CityEspionageHappyMinus"):
 			if inputClass.getData1() == 1030:
 				pCity.changeEspionageHappinessCounter(iChange)
 			elif inputClass.getData1() == 1031:
-				pCity.changeEspionageHappinessCounter(- min(iChange, pCity.getEspionageHappinessCounter()))
+				pCity.changeEspionageHappinessCounter(- min(iChange, pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_ESPIONAGE_HAPPINESS]))
 			self.placeStats()
 
 		elif inputClass.getFunctionName() in ("CityEspionageHealthPlus", "CityEspionageHealthMinus"):
 			if inputClass.getData1() == 1030:
 				pCity.changeEspionageHealthCounter(iChange)
 			elif inputClass.getData1() == 1031:
-				pCity.changeEspionageHealthCounter(- min(iChange, pCity.getEspionageHealthCounter()))
+				pCity.changeEspionageHealthCounter(- min(iChange, pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_ESPIONAGE_HEALTH]))
 			self.placeStats()
 
 		elif inputClass.getFunctionName().find("CityTemporaryHappy") > -1:
 			if inputClass.getData1() == 1030:
 				pCity.changeHappinessTimer(iChange)
 			elif inputClass.getData1() == 1031:
-				pCity.changeHappinessTimer(- min(iChange, pCity.getHappinessTimer()))
+				pCity.changeHappinessTimer(- min(iChange, pCity.getCountdowns()[CityCountdownKind.COUNTDOWN_HAPPINESS]))
 			self.placeStats()
 
 		elif inputClass.getFunctionName() == "WBCityProduction":

--- a/Assets/Python/Screens/Worldbuilder/WBPlayerUnits.py
+++ b/Assets/Python/Screens/Worldbuilder/WBPlayerUnits.py
@@ -274,8 +274,9 @@ class WBPlayerUnits:
 			screen.setTableInt("WBCityList", 2, iRow, "<font=3>" + str(loopCity.getID()) + "</font>", "", WidgetTypes.WIDGET_PYTHON, 7200 + i[0], i[1], 1<<2)
 			screen.setTableInt("WBCityList", 3, iRow, "<font=3>" + self.WB.addComma(loopCity.getCulture(i[0])) + "</font>", "", WidgetTypes.WIDGET_PYTHON, 7200 + i[0], i[1], 1<<2)
 			screen.setTableInt("WBCityList", 4, iRow, "<font=3>" + str(loopCity.getPopulation()) + "</font>", "", WidgetTypes.WIDGET_PYTHON, 7200 + i[0], i[1], 1<<2)
-			screen.setTableInt("WBCityList", 5, iRow, "<font=3>" + str(loopCity.happyLevel() - loopCity.unhappyLevel(0)) + "</font>", "", WidgetTypes.WIDGET_PYTHON, 7200 + i[0], i[1], 1<<2)
-			screen.setTableInt("WBCityList", 6, iRow, "<font=3>" + str(loopCity.goodHealth() - loopCity.badHealth(0)) + "</font>", "", WidgetTypes.WIDGET_PYTHON, 7200 + i[0], i[1], 1<<2)
+			aWellbeing = loopCity.getRealizedWellbeing(0)
+			screen.setTableInt("WBCityList", 5, iRow, "<font=3>%d</font>" % (aWellbeing[WellbeingChannel.WELLBEING_HAPPINESS] - aWellbeing[WellbeingChannel.WELLBEING_ANGER]), "", WidgetTypes.WIDGET_PYTHON, 7200 + i[0], i[1], 1<<2)
+			screen.setTableInt("WBCityList", 6, iRow, "<font=3>%d</font>" % (aWellbeing[WellbeingChannel.WELLBEING_HEALTH] - aWellbeing[WellbeingChannel.WELLBEING_UNHEALTH]), "", WidgetTypes.WIDGET_PYTHON, 7200 + i[0], i[1], 1<<2)
 		self.placeCityMap()
 
 	def placeCityMap(self):

--- a/Assets/Python/Screens/Worldbuilder/WorldBuilder.py
+++ b/Assets/Python/Screens/Worldbuilder/WorldBuilder.py
@@ -1268,11 +1268,13 @@ class WorldBuilder:
 
 			pNewCity.setProgressOnBuilding(iBuilding, pOldCity.getProgressOnBuilding(iBuilding))
 
+			aOldCommerces = pOldCity.getBuildingGrantedCommerces(iBuilding)
 			for iCommerce in xrange(CommerceTypes.NUM_COMMERCE_TYPES):
-				pNewCity.setBuildingCommerceChange(iBuilding, iCommerce, pOldCity.getBuildingCommerceChange(iBuilding, iCommerce))
+				pNewCity.setBuildingCommerceChange(iBuilding, iCommerce, aOldCommerces[iCommerce])
 
+			aOldYields = pOldCity.getBuildingGrantedYields(iBuilding)
 			for iYield in xrange(YieldTypes.NUM_YIELD_TYPES):
-				pNewCity.setBuildingYieldChange(iBuilding, iYield, pOldCity.getBuildingYieldChange(iBuilding, iYield))
+				pNewCity.setBuildingYieldChange(iBuilding, iYield, aOldYields[iYield])
 
 			if GC.getBuildingInfo(iBuilding).isCapital() and not bMove:
 				continue
@@ -1308,15 +1310,15 @@ class WorldBuilder:
 			OrderData = pOldCity.getOrderFromQueue(iOrder)
 			pNewCity.pushOrder(OrderData.eOrderType, OrderData.iData1, OrderData.iData2, OrderData.bSave, False, True, False)
 		pNewCity.changeConscriptAngerTimer(pOldCity.getConscriptAngerTimer() - pNewCity.getConscriptAngerTimer())
-		pNewCity.changeDefenseDamage(pOldCity.getDefenseDamage() - pNewCity.getDefenseDamage())
-		pNewCity.changeDefyResolutionAngerTimer(pOldCity.getDefyResolutionAngerTimer() - pNewCity.getDefyResolutionAngerTimer())
-		pNewCity.changeEspionageHappinessCounter(pOldCity.getEspionageHappinessCounter() - pNewCity.getEspionageHappinessCounter())
-		pNewCity.changeEspionageHealthCounter(pOldCity.getEspionageHealthCounter() - pNewCity.getEspionageHealthCounter())
+		pNewCity.changeDefenseDamage(pOldCity.getCounts()[CityCountRead.CITY_COUNT_DEFENSE_DAMAGE] - pNewCity.getCounts()[CityCountRead.CITY_COUNT_DEFENSE_DAMAGE])
+		pNewCity.changeDefyResolutionAngerTimer(pOldCity.getCountdowns()[CityCountdownKind.COUNTDOWN_DEFY_RESOLUTION_ANGER] - pNewCity.getCountdowns()[CityCountdownKind.COUNTDOWN_DEFY_RESOLUTION_ANGER])
+		pNewCity.changeEspionageHappinessCounter(pOldCity.getCountdowns()[CityCountdownKind.COUNTDOWN_ESPIONAGE_HAPPINESS] - pNewCity.getCountdowns()[CityCountdownKind.COUNTDOWN_ESPIONAGE_HAPPINESS])
+		pNewCity.changeEspionageHealthCounter(pOldCity.getCountdowns()[CityCountdownKind.COUNTDOWN_ESPIONAGE_HEALTH] - pNewCity.getCountdowns()[CityCountdownKind.COUNTDOWN_ESPIONAGE_HEALTH])
 		pNewCity.changeExtraHappiness(pOldCity.getExtraHappiness() - pNewCity.getExtraHappiness())
 		pNewCity.changeExtraHealth(pOldCity.getExtraHealth() - pNewCity.getExtraHealth())
 		pNewCity.changeExtraTradeRoutes(pOldCity.getExtraTradeRoutes() - pNewCity.getExtraTradeRoutes())
 		pNewCity.changeGreatPeopleProgress(pOldCity.getGreatPeopleProgress() - pNewCity.getGreatPeopleProgress())
-		pNewCity.changeHappinessTimer(pOldCity.getHappinessTimer() - pNewCity.getHappinessTimer())
+		pNewCity.changeHappinessTimer(pOldCity.getCountdowns()[CityCountdownKind.COUNTDOWN_HAPPINESS] - pNewCity.getCountdowns()[CityCountdownKind.COUNTDOWN_HAPPINESS])
 		pNewCity.changeHurryAngerTimer(pOldCity.getHurryAngerTimer() - pNewCity.getHurryAngerTimer())
 		pNewCity.setAirliftTargeted(pOldCity.isAirliftTargeted())
 		pNewCity.setBombarded(pOldCity.isBombarded())
@@ -1326,7 +1328,7 @@ class WorldBuilder:
 		pNewCity.setFood(pOldCity.getFood())
 		pNewCity.setHighestPopulation(pOldCity.getHighestPopulation())
 		pNewCity.setNeverLost(pOldCity.isNeverLost())
-		pNewCity.setOccupationTimer(pOldCity.getOccupationTimer())
+		pNewCity.setOccupationTimer(pOldCity.getCountdowns()[CityCountdownKind.COUNTDOWN_OCCUPATION])
 		pNewCity.setOverflowProduction(pOldCity.getOverflowProduction())
 		pNewCity.setPlundered(pOldCity.isPlundered())
 		pNewCity.setProductionProgress(pOldCity.getProductionProgress())

--- a/Sources/Python/CyCity.cpp
+++ b/Sources/Python/CyCity.cpp
@@ -30,11 +30,6 @@ void CyCity::kill()
 	m_pCity->kill(true);
 }
 
-int CyCity::getRevolutionIndex() const
-{
-	return m_pCity->getRevolutionIndex();
-}
-
 void CyCity::setRevolutionIndex(int iNewValue)
 {
 	m_pCity->setRevolutionIndex(iNewValue);
@@ -53,11 +48,6 @@ int CyCity::getLocalRevIndex() const
 void CyCity::setLocalRevIndex(int iNewValue)
 {
 	m_pCity->setLocalRevIndex(iNewValue);
-}
-
-int CyCity::getRevIndexAverage() const
-{
-	return m_pCity->getRevIndexAverage();
 }
 
 void CyCity::setRevIndexAverage(int iNewValue)
@@ -425,11 +415,6 @@ int CyCity::happyLevel() const
 	return aWellbeing[WELLBEING_HAPPINESS] / 100;
 }
 
-int CyCity::angryPopulation(int iExtra) const
-{
-	return m_pCity->angryPopulation(iExtra);
-}
-
 int CyCity::totalFreeSpecialists() const
 {
 	return m_pCity->totalFreeSpecialists();
@@ -571,11 +556,6 @@ int CyCity::getGameDateFounded() const
 	return m_pCity->getGameDateFounded(bHistoricalCalendar);
 }
 
-int CyCity::getGameTurnAcquired() const
-{
-	return m_pCity->getGameTurnAcquired();
-}
-
 int CyCity::getPopulation() const
 {
 	return m_pCity->getPopulation();
@@ -683,19 +663,9 @@ int CyCity::getMaintenanceTimes100() const
 	return (int)m_pCity->getMaintenanceTimes100();
 }
 
-int CyCity::getEspionageHealthCounter() const
-{
-	return m_pCity->getEspionageHealthCounter();
-}
-
 void CyCity::changeEspionageHealthCounter(int iChange)
 {
 	m_pCity->changeEspionageHealthCounter(iChange);
-}
-
-int CyCity::getEspionageHappinessCounter() const
-{
-	return m_pCity->getEspionageHappinessCounter();
 }
 
 void CyCity::changeEspionageHappinessCounter(int iChange)
@@ -773,11 +743,6 @@ void CyCity::changeConscriptAngerTimer(int iChange)
 	m_pCity->changeConscriptAngerTimer(iChange);
 }
 
-int CyCity::getDefyResolutionAngerTimer() const
-{
-	return m_pCity->getDefyResolutionAngerTimer();
-}
-
 void CyCity::changeDefyResolutionAngerTimer(int iChange)
 {
 	m_pCity->changeDefyResolutionAngerTimer(iChange);
@@ -786,11 +751,6 @@ void CyCity::changeDefyResolutionAngerTimer(int iChange)
 int CyCity::flatDefyResolutionAngerLength() const
 {
 	return m_pCity->flatDefyResolutionAngerLength();
-}
-
-int CyCity::getHappinessTimer() const
-{
-	return m_pCity->getHappinessTimer();
 }
 
 void CyCity::changeHappinessTimer(int iChange)
@@ -874,11 +834,6 @@ bool CyCity::isPowered() const
 	return m_pCity->isPowered();
 }
 
-int CyCity::getDefenseDamage() const
-{
-	return m_pCity->getDefenseDamage();
-}
-
 void CyCity::changeDefenseDamage(int iChange)
 {
 	m_pCity->changeDefenseDamage(iChange);
@@ -892,11 +847,6 @@ int CyCity::getTotalDefense(bool bIgnoreBuilding) const
 int CyCity::getDefenseModifier(bool bIgnoreBuilding) const
 {
 	return m_pCity->getDefenseModifier(bIgnoreBuilding);
-}
-
-int CyCity::getOccupationTimer() const
-{
-	return m_pCity->getOccupationTimer();
 }
 
 bool CyCity::isOccupation() const
@@ -1365,19 +1315,9 @@ void CyCity::setScriptData(std::string szNewValue)
 	m_pCity->setScriptData(szNewValue);
 }
 
-int CyCity::getBuildingYieldChange(int /*BuildingTypes*/ eBuilding, int /*YieldTypes*/ eYield) const
-{
-	return m_pCity->getBuildingYieldChange((BuildingTypes)eBuilding, (YieldTypes)eYield);
-}
-
 void CyCity::setBuildingYieldChange(int /*BuildingTypes*/ eBuilding, int /*YieldTypes*/ eYield, int iChange)
 {
 	m_pCity->setBuildingYieldChange((BuildingTypes)eBuilding, (YieldTypes)eYield, iChange);
-}
-
-int CyCity::getBuildingCommerceChange(int /*BuildingTypes*/ eBuilding, int /*CommerceTypes*/ eCommerce) const
-{
-	return m_pCity->getBuildingCommerceChange((BuildingTypes)eBuilding, (CommerceTypes)eCommerce);
 }
 
 void CyCity::setBuildingCommerceChange(int /*BuildingTypes*/ eBuilding, int /*CommerceTypes*/ eCommerce, int iChange)

--- a/Sources/Python/CyCity.cpp
+++ b/Sources/Python/CyCity.cpp
@@ -401,37 +401,9 @@ int CyCity::getRevIndexPercentAnger() const
 }
 
 // The wellbeing reads index the realized channel array; ÷100 here because this is the reader boundary.
-int CyCity::unhappyLevel(int iExtra) const
-{
-	int aWellbeing[NUM_WELLBEING_CHANNELS];
-	m_pCity->realizedWellbeing(iExtra, aWellbeing);
-	return aWellbeing[WELLBEING_ANGER] / 100;
-}
-
-int CyCity::happyLevel() const
-{
-	int aWellbeing[NUM_WELLBEING_CHANNELS];
-	m_pCity->realizedWellbeing(0, aWellbeing);
-	return aWellbeing[WELLBEING_HAPPINESS] / 100;
-}
-
 int CyCity::totalFreeSpecialists() const
 {
 	return m_pCity->totalFreeSpecialists();
-}
-
-int CyCity::goodHealth() const
-{
-	int aWellbeing[NUM_WELLBEING_CHANNELS];
-	m_pCity->realizedWellbeing(0, aWellbeing);
-	return aWellbeing[WELLBEING_HEALTH] / 100;
-}
-
-int CyCity::badHealth() const
-{
-	int aWellbeing[NUM_WELLBEING_CHANNELS];
-	m_pCity->realizedWellbeing(0, aWellbeing);
-	return aWellbeing[WELLBEING_UNHEALTH] / 100;
 }
 
 int CyCity::healthRate(int iExtra) const
@@ -1493,6 +1465,8 @@ namespace
 {
 	//	The whole group out, in one call. N is deduced from the array the group read filled, so a family that
 	//	grows a channel needs no edit here.
+	//	⚠ RAW relay -- for a group whose members are NOT ×100 amounts (counts, timers, percents, enum ids).
+	//	An AMOUNT group uses cyc_toHuman below.
 	template <int N>
 	python::list cyc_toList(const int (&values)[N])
 	{
@@ -1500,6 +1474,24 @@ namespace
 		for (int i = 0; i < N; ++i)
 		{
 			list.append(values[i]);
+		}
+		return list;
+	}
+
+	//	⛔ THE READER BOUNDARY -- an AMOUNT converts HERE, once, and Python does no scale math.
+	//	The Cy layer is the CONTROLLER (patterns.md § the Cy* layer is the controller): thin means no LOGIC, and
+	//	representation is not logic -- turning the engine's internal ×100 fixed point into the external form is
+	//	precisely this layer's job, and the only place it should happen. Push it outward and every consumer has
+	//	to know the engine's internal scale, and they then disagree about it -- which is the state this replaces.
+	//	⚖ FLOAT, not a truncating int: nothing downstream of the controller does deterministic math, so the two
+	//	decimals the fixed point exists to carry survive the boundary instead of being thrown away at it.
+	template <int N>
+	python::list cyc_toHuman(const int (&values)[N])
+	{
+		python::list list = python::list();
+		for (int i = 0; i < N; ++i)
+		{
+			list.append(values[i] / 100.0);
 		}
 		return list;
 	}
@@ -1531,7 +1523,7 @@ python::list CyCity::getWellbeing() const
 {
 	int values[NUM_WELLBEING_CHANNELS] = { 0 };
 	if (m_pCity) m_pCity->getWellbeing(values);
-	return cyc_toList(values);
+	return cyc_toHuman(values);
 }
 
 python::list CyCity::getDefenseKinds() const
@@ -1616,7 +1608,7 @@ python::list CyCity::getRealizedWellbeing(int iExtraPopulation) const
 	PERF_SCOPE("CyCity::getRealizedWellbeing", -1);
 	int values[NUM_WELLBEING_CHANNELS] = { 0 };
 	if (m_pCity) m_pCity->realizedWellbeing(iExtraPopulation, values);
-	return cyc_toList(values);
+	return cyc_toHuman(values);
 }
 
 int CyCity::getHealthRate(int iExtraPopulation) const
@@ -2319,8 +2311,6 @@ void CyCity::pythonPublish()
 		.def("getNameKey",            &CyCity::getNameKey)
 		.def("getFood",               &CyCity::getFood)
 		.def("growthThreshold",       &CyCity::growthThreshold)
-		.def("goodHealth",            &CyCity::goodHealth)
-		.def("badHealth",             &CyCity::badHealth)
 		.def("getCultureThreshold",   &CyCity::getCultureThreshold)
 		.def("getMaintenanceTimes100", &CyCity::getMaintenanceTimes100)
 		.def("getDefenseModifier",    &CyCity::getDefenseModifier)

--- a/Sources/Python/CyCity.h
+++ b/Sources/Python/CyCity.h
@@ -144,14 +144,12 @@ public:
 
 	void kill();
 
-	int getRevolutionIndex() const;
 	void setRevolutionIndex(int iNewValue);
 	void changeRevolutionIndex(int iChange);
 
 	int getLocalRevIndex() const;
 	void setLocalRevIndex(int iNewValue);
 
-	int getRevIndexAverage() const;
 	void setRevIndexAverage(int iNewValue);
 	void updateRevIndexAverage();
 
@@ -239,7 +237,6 @@ public:
 
 	int unhappyLevel(int iExtra) const;
 	int happyLevel() const;
-	int angryPopulation(int iExtra) const;
 	int totalFreeSpecialists() const;
 	int goodHealth() const;
 	int badHealth() const;
@@ -267,7 +264,6 @@ public:
 
 	int getGameTurnFounded() const;
 	int getGameDateFounded() const;
-	int getGameTurnAcquired() const;
 	int getPopulation() const;
 	void setPopulation(int iNewValue);
 	void changePopulation(int iChange);
@@ -290,9 +286,7 @@ public:
 	int getMaintenance() const;
 	int getMaintenanceTimes100() const;
 
-	int getEspionageHealthCounter() const;
 	void changeEspionageHealthCounter(int iChange);
-	int getEspionageHappinessCounter() const;
 	void changeEspionageHappinessCounter(int iChange);
 
 	int getBuildingHealth(int iBuilding) const;
@@ -312,10 +306,8 @@ public:
 
 	int getConscriptAngerTimer() const;
 	void changeConscriptAngerTimer(int iChange);
-	int getDefyResolutionAngerTimer() const;
 	void changeDefyResolutionAngerTimer(int iChange);
 	int flatDefyResolutionAngerLength() const;
-	int getHappinessTimer() const;
 	void changeHappinessTimer(int iChange);
 	bool isNoUnhappiness() const;
 
@@ -333,12 +325,10 @@ public:
 	int getBuildingDefense() const;
 	int getMaxAirlift() const;
 	bool isPowered() const;
-	int getDefenseDamage() const;
 	void changeDefenseDamage(int iChange);
 	int getTotalDefense(bool bIgnoreBuilding) const;
 	int getDefenseModifier(bool bIgnoreBuilding) const;
 
-	int getOccupationTimer() const;
 	bool isOccupation() const;
 	void setOccupationTimer(int iNewValue);
 	void changeOccupationTimer(int iChange);
@@ -466,9 +456,7 @@ public:
 	int getOrderQueueLength() const;
 	OrderData getOrderFromQueue(int iIndex) const;
 
-	int getBuildingYieldChange(int /*BuildingTypes*/ eBuilding, int /*YieldTypes*/ eYield) const;
 	void setBuildingYieldChange(int /*BuildingTypes*/ eBuilding, int /*YieldTypes*/ eYield, int iChange);
-	int getBuildingCommerceChange(int /*BuildingTypes*/ eBuilding, int /*CommerceTypes*/ eCommerce) const;
 	void setBuildingCommerceChange(int /*BuildingTypes*/ eBuilding, int /*CommerceTypes*/ eCommerce, int iChange);
 	int getBuildingHappyChange(int /*BuildingTypes*/ eBuilding) const;
 	void setBuildingHappyChange(int /*BuildingTypes*/ eBuilding, int iChange);

--- a/Sources/Python/CyCity.h
+++ b/Sources/Python/CyCity.h
@@ -235,11 +235,7 @@ public:
 
 	int getRevIndexPercentAnger() const;
 
-	int unhappyLevel(int iExtra) const;
-	int happyLevel() const;
 	int totalFreeSpecialists() const;
-	int goodHealth() const;
-	int badHealth() const;
 	int healthRate(int iExtra) const;
 	int foodConsumption(bool bNoAngry, int iExtra) const;
 	int foodDifference(bool bBottom) const;


### PR DESCRIPTION
Clears the Cy collisions, and builds the reader boundary the last of them needed.

**Burndown: 174 → 160 methods, 704 → 584 call sites.**

---

# 1. The collisions (#493) — 12 names, 108 sites

A **collision** is a legacy per-field declaration whose coherent read is already published on the same type. Nothing needed building: the endpoint existed, the legacy name had not died yet.

| group read | re-pointed | sites |
|---|---|--:|
| `getCounts()` | `CITY_COUNT_REVOLUTION_INDEX` (61), `_REVOLUTION_AVERAGE`, `_DEFENSE_DAMAGE`, `_GAME_TURN_ACQUIRED` | 71 |
| `getCountdowns()` | `COUNTDOWN_OCCUPATION` (11), `_ESPIONAGE_HEALTH`, `_ESPIONAGE_HAPPINESS`, `_HAPPINESS`, `_DEFY_RESOLUTION_ANGER` | 30 |
| `getBuildingGrantedYields/Commerces()` | indexed by yield / commerce | 6 |
| `getAngryPopulation()` | direct rename, same argument | 1 |

**Every mapping was verified against the engine, not matched by name** — the mapping is conceptual (`getOccupationTimer` → `COUNTDOWN_OCCUPATION` shares no substring). What makes each provably value-identical: `getCityCounts` and `getCountdowns` **call the very legacy getters being removed**, and `getBuildingGrantedYields(b)[y]` is literally `getBuildingYieldChange(b, y)`.

⚠ **Two families in #493 turned out NOT to be collisions**, caught by that verification:
- `getBuildingDefense` sums `DEFENSE_AMOUNT` over *active buildings only*; `getDefenseKinds()[DEFENSE_AMOUNT]` is the full cascade total from **all** sources. Different values.
- `getOrderFromQueue(i)` is the *i-th queued* order; `getOrder()` is the **current** order. Different questions.

---

# 2. The reader boundary (#489) — the mechanism, not a patch

The wellbeing family was "blocked" on the group read serving ×100. That is a fix, not a blocker.

**The boundary had no mechanism.** `cyc_toList` relayed 35 group reads raw while eight scalar reads hand-rolled their own `/100` — which is exactly why the layer was inconsistent and why six Python consumers invented six different rules for the same call.

There is now one primitive, `cyc_toHuman`, carrying the reasoning: the `Cy*` layer is the **controller**; thin means no *logic*, and **representation is not logic**. Converting the engine's internal ×100 into the external form is this layer's job and the only place it should happen — push it outward and every consumer must know the engine's internal scale, then disagree about it.

It returns **float**, not a truncating int: nothing downstream does deterministic math, so the two decimals the fixed point exists to carry survive the boundary.

`getWellbeing` / `getRealizedWellbeing` now convert — which makes `happyLevel`, `unhappyLevel`, `goodHealth`, `badHealth` pure collisions (each was the group read indexed by one channel with a `/100` stapled on). All four deleted, their 11 call sites read the group.

## Two live defects fall out of it

- **`CvDomesticAdvisor.calculateNetHappiness` / `calculateNetHealth`** returned the raw ×100 difference straight into a display column — those columns showed **hundredfold values**.
- **`badHealth` was registered taking NO argument** while five Python sites call `badHealth(True/False/0)` — a Boost.Python `ArgumentError` every time. The wrapper is gone, so the mismatch goes with it. ⚠ `verify-python-bindings` does **not** catch this class — it checks registration, not **arity**. Worth closing separately.

## Consumer corrections in the same pass

Hand-rolled `/100`s dropped, and two ×100 magic thresholds in the event predicates changed (`< 100` → `< 1`) — those would otherwise have inverted silently.

⚠ **`PediaBuilding.py` is deliberately untouched**: it reads `CyInfo.getWellbeing`, a *different provider* that still returns ×100, so its `/100` must stay. Same enum, different surface.

---

## Verification

`Assert` build clean. `verify-python-bindings` 174 → 160 (ratchet fell twice). `verify-python24` and `verify-docs` pass.

**Not observed in a running game.** For a tester: the revolution index reads through the new path (61 sites), the city bar's happy/angry/health icons and the Domestic Advisor's net happiness/health columns are where a scale mistake would show, and the WorldBuilder city-data screen covers the building grant reads.

Closes #493. Advances #489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
