### PR TITLE
fix(#496, #497): a process may only stand alone, idle behaves as no order, and water plots derive HAS_COAST

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 > # ⛔ STOP — READ THIS BEFORE YOU TOUCH ANYTHING ⛔
 >
-> ## HOURS WASTED ON ROLLERSKATING: **195** &nbsp;·&nbsp; *and counting*
+> ## HOURS WASTED ON ROLLERSKATING: **207** &nbsp;·&nbsp; *and counting*
 >
 > *(Increment this every time an agent ships an ungrounded fix / design / edit — one the docs already answered — that the owner has to rein in. It is a real number, not a joke.)*
 >
@@ -12,17 +12,27 @@
 >
 > **You are not the exception. Assume you are about to add to that number unless you deliberately do the opposite:**
 >
-> - **⚑ READ THE CONCEPT DOC FOR WHAT YOU TOUCH — IN FULL, BEFORE YOU ACT.** `docs/` is ONE FILE PER CONCEPT
->   (cascade · enabler · json · spine · triggers · save · vision · tally · …); [`docs/README.md`](docs/README.md)
->   is the index. Read the one that owns your subsystem end to end — not a grep of it, not the section you think
->   is relevant. **Your judgment of what is "necessary" is systematically biased toward reading too little.**
+> - **⚑ READ EVERY DOC THAT TOUCHES WHAT YOU TOUCH — IN FULL, BEFORE YOU ACT.** [`docs/README.md`](docs/README.md)
+>   is the index, and `docs/` is roughly one file per concept — but **the count of relevant files is something you
+>   FIND, never something you DECIDE.** Before the first edit, **grep the whole of `docs/` for the subsystem, the
+>   symbols and the mechanism you are about to touch, and read every file that hits, end to end** — not a grep of
+>   it, not the section you think is relevant. **Your judgment of what is "necessary" is systematically biased
+>   toward reading too little.**
+>   ⛔ **THERE IS NO CLAUSE HERE THAT LETS YOU READ ONE FILE AND STOP, AND ANY WORDING THAT READS LIKE ONE IS A
+>   DEFECT TO DELETE ON SIGHT (owner).** A rule that lets an agent SELECT its reading is not a reading rule; it is
+>   a permission slip, and it is *"a gigantic failure mechanism"*. ⚠ **Measured: a full day burned on a bug that
+>   should have taken twenty minutes** — the agent picked the one doc it judged to own the subsystem, never
+>   searched for the others, and shipped ~10 ungrounded edits into a system whose behaviour two unread docs
+>   already described.
+>   ⚑ **What was actually retired is re-reading the WHOLE CORPUS at session start** — front-loading a lagging
+>   corpus manufactured confidence rather than knowledge. That is not licence to read one file when you touch a
+>   subsystem: it moves the reading from session-start to WORK-START, and it makes it *exhaustive for that
+>   subsystem* rather than exhaustive for the repo.
 >   ⛔ **THE TREE OUTRANKS THE DOC.** The engine has been rebuilt and the docs lag it, so a doc line is a
 >   HYPOTHESIS you confirm against `Sources/` — never the other way round. Where the two disagree the code wins,
->   and **fixing the doc is part of the same work item** (Conventions § Docs, below).
->   ⚑ **The blanket read-everything protocol is RETIRED, deliberately** (owner). It was made for the engine
->   switch, when the docs were the only account of a system in flux. It now does the opposite: it front-loads a
->   corpus that lags the tree, and — being far too large to actually re-read — it manufactures the confidence
->   that makes a stale line dangerous. One concept, one file, read properly, verified against the code.
+>   and **fixing the doc is part of the same work item** (Conventions § Docs, below). ⚠ This is NOT a reason to
+>   skip the doc and go straight to the code: the doc is what tells you which behaviour is DESIGNED and which is
+>   accidental, and the code alone cannot.
 >   **⛔ ALL docs live in the repo — a plan or design note kept only in a local/private notes folder
 >   (`.claude/plans/`, assistant memory) is a core-rule VIOLATION to fix by moving it into `docs/`, not a doc you
 >   may skip.**
@@ -523,35 +533,27 @@ not findings to re-discover.
   signature points to a graphics path running pre-init, not a logic bug. Established
   guard sites: `CvPlot.cpp` `setPlotType` graphics block, `setLayoutDirty`,
   `shouldHaveGraphics`; `CvMap::setupGraphical`.
-- **⛔ THE UNIT'S IN-FLIGHT ANIMATION LIVES ON ITS SCENE ENTITY, so DESTROYING THE ENTITY DISCARDS THE QUEUED
-  MOVE.** `QueueMove` pushes onto the entity and `ExecuteMove` plays it; `CvUnit::reloadEntity`'s own
-  `RemoveUnitFromBattle` call — *"remove this unit from any active mission"* — is the admission, and the entity
-  interface is pointer-keyed throughout, with no re-bind and no queue transfer.
-  ⚠ **"MISSION" IS TWO DIFFERENT THINGS HERE AND CONFLATING THEM IS THE TRAP.** The entity holds the EXE's
-  VISUAL mission definition (`addMission(CvMissionDefinition…)` — the walk, the combat sequence). The ORDER is
-  DLL-side and untouched: `CvSelectionGroup::m_missionQueue`, with `isBusy()` = `getMissionTimer() > 0 ||
-  isCombat()`, both plain members. ⇒ Losing an entity loses the PICTURE, never the instruction — so this class
-  presents as a purely visual orphan while game state advances correctly, which is exactly why it survives.
-  ⛔ **It is NOT caused by graphics paging.** Paging only makes `isGraphicsVisible(UNIT)` false, and that path
-  EARLY-RETURNS before any reload. ⚑ **The window that makes this bite is `CvSelectionGroup::groupMove`:** it inhibits centre-unit
-  recalc on both plots, `setXY` **queues** the move onto the current entity, the inhibit **nulls
-  `m_pCenterUnit`** as a dangling-pointer guard, and lifting it therefore makes `newCenterUnit != m_pCenterUnit`
-  unconditionally true — so `updateCenterUnit` reloads the entity **between `QueueMove` and `ExecuteMove`**.
-  ⇒ **An entity that is already the kind the unit wants is KEPT**; only a genuine MODEL change (a warlord
-  attaching) rebuilds one, through `rebuildEntityArt()`. ⚠ The signature to recognise, because none of it looks
-  like a graphics bug: the walk animation plays **in place on the tile the unit left**, animations never end,
-  units render **stacked** (`setupGraphical`'s `ExecuteMove(0, false)` is what separates a stack, and it is
-  spent on the empty queue), and **re-selecting the unit fixes it** — `reloadEntity` skips a selected unit.
-  ⛔ **AND AN ENTITY MAY BE CREATED BEFORE GRAPHICS INIT, SO THE SETUP LATCH IS OWNED BY `setupGraphical` AND
-  SET ONLY WHEN ITS GATE PASSES.** A NEW game forms the starting units' groups during `CvGame::init` — before
-  `SetGraphicsInitialized` — and the head-unit swap in `CvSelectionGroup::addUnit` calls `reloadEntity` right
-  there, creating a REAL entity with no landscape to set it up against (a LOAD never hits this: deserialization
-  writes coordinates raw, so no pre-graphics reload fires — which is why the defect class is invisible on every
-  save-based test). Creating pre-graphics is fine (the non-dynamic ctor path always has); what must survive is
-  the RETRY: `bGraphicsSetup` latched on the *attempt* left the entity model-less forever, and the EXE dies at
-  `faultAddr=0x24` the first time that unit is selected or moved. The keep-the-entity rule above is what removed
-  the accidental repair (the old churn recreated the entity post-init, resetting the latch), so the two rules
-  only compose because the latch is honest.
+- **⛔ THE UNIT RENDERING PIPELINE IS DOCUMENTED IN FULL, CITED, IN
+  [`docs/reference/unit-rendering.md`](docs/reference/unit-rendering.md) — READ IT BEFORE TOUCHING ANY GRAPHICS
+  OR ENTITY PATH.** The entity lifecycle (create · setup · place · destroy), how a plot chooses the one unit it
+  draws (`m_pCenterUnit`), graphics paging ON vs OFF, and the load / new-game timelines all live there against
+  `Sources/` line cites. What stays here is only the HARD RULES; the knowledge is the reference's.
+- **⛔ NEVER DESTROY A REAL SCENE NODE OUT FROM UNDER A SELECTED UNIT.** The engine's move queue lives ON the
+  scene node, so a needless destroy between a `QueueMove` and its `ExecuteMove` strands the walk animation.
+  `reloadEntity` therefore KEEPS an entity already of the wanted kind; only a genuine MODEL change (a warlord
+  attaching) rebuilds one, through `rebuildEntityArt()`.
+- **⛔ EVERY EXE ENTITY CALL GUARDS ON `isRealEntity(getEntity())`, NEVER ON `!isUsingDummyEntities()`.** The
+  latter answers FALSE for a NULL entity, so it hands NULL to an EXE that does not null-check; `isRealEntity` is
+  the only test that excludes both the shared dummy and NULL (`CvDLLEntity` — every member that passes an entity
+  over).
+- **⛔ GRAPHICS PAGING OFF IS A LIVE LOOP — "PAGE EVERYTHING IN, PAGE NOTHING OUT" — NEVER A ONE-SHOT.**
+  `CvPlotPaging::UpdatePaging` runs every `CvGame::update`; ON it requires plots by camera distance, OFF it
+  requires ALL on every plot every frame (a NONE no-op once a plot is fully shown). The inherited code ran a
+  one-shot disable sweep that latched dead, so a plot that could not render at that instant — the whole map, if
+  the sweep landed pre-landscape — stayed blank forever and unit nodes were built later against plots whose
+  `updateGraphics` never ran. ⚑ Its partner: `CvPlot::showRequiredGraphics` must not mark a bit visible before
+  `IsGraphicsInitialized()`, or a pre-init pass poisons the visible mask (`required ^ visible` = NONE forever)
+  and nothing retries. This asymmetry is what made *"works with paging on, broken with it off"* the signature.
 
 ### ⛔ THE NO-GUESSING RULE — map everything, always
 

--- a/Sources/AI/CvCityAI.cpp
+++ b/Sources/AI/CvCityAI.cpp
@@ -1186,6 +1186,19 @@ void CvCityAI::AI_chooseProduction()
 		return;
 	}
 
+	// A PROCESS IS NEVER A COMMITMENT (owner): it never completes, so one that survives a decision blocks the
+	// queue forever. Strip every ORDER_MAINTAIN before deciding -- the end-of-cascade fallback re-adds one only
+	// when there is still nothing better to do this turn.
+	for (int iOrder = getOrderQueueLength() - 1; iOrder >= 0; iOrder--)
+	{
+		if (getOrderAt(iOrder).eOrderType == ORDER_MAINTAIN)
+		{
+			logCityAI(2, "[CIT/dropProcess] city=%S owner=%d slot=%d",
+				getName().GetCString(), (int)getOwner(), iOrder);
+			popOrder(iOrder);
+		}
+	}
+
 	//#0 : Establish all needed Values that will be used for multple prio/conditions
 	const bool bDanger = AI_isDanger();
 	const int iDangerValue = GET_PLAYER(getOwner()).AI_getPlotDanger(plot(), 2, false);
@@ -9289,9 +9302,13 @@ bool CvCityAI::AI_chooseProcess(CommerceTypes eCommerceType, int64_t* commerceWe
 		eventSpine().emit(CvSpineEvent(EVENTKIND_DIAGNOSTIC, SD_CITY, CIT_ORDER_PROCESS, 1)
 			.addI(CITF_city, getID()).addI(CITF_owner, (int)getOwner())
 			.addI(CITF_process, (int)eBestProcess).addI(CITF_commerce, (int)eCommerceType));
+		// Whether the order LANDED is read off the queue length, never assumed from having asked: a process
+		// is refused outright when the AI queue already holds a real order, and a caller that returns on a
+		// bare true would end its decision cascade having set nothing.
+		const int iQueueLengthBefore = getOrderQueueLength();
 		pushOrder(ORDER_MAINTAIN, eBestProcess, -1, false, false, !bforce);
 
-		return true;
+		return getOrderQueueLength() > iQueueLengthBefore;
 	}
 
 	return false;

--- a/Sources/AI/CvUnitAI.cpp
+++ b/Sources/AI/CvUnitAI.cpp
@@ -21645,7 +21645,9 @@ bool CvUnitAI::processContracts(int iMinPriority)
 				//GC.getUnitAIInfo(AI_getUnitAIType())->getType();
 				
 			}
-			logContractBroker(1, "	Unit %S (%d) for player %d (%S) at (%d,%d) found work (%S) at (%d,%d) %S\n",
+			// MissionInfos/JoinInfos are NARROW CvStrings: %s, never %S -- a %S here makes the CRT scan the narrow
+			// buffer as wchar_t* for a two-byte terminator it may never find (the paging-toggle end-turn AV).
+			logContractBroker(1, "	Unit %S (%d) for player %d (%S) at (%d,%d) found work (%s) at (%d,%d) %s\n",
 					getUnitInfo().getDescription(),
 					getID(),
 					getOwner(),

--- a/Sources/Engine/CvCity.cpp
+++ b/Sources/Engine/CvCity.cpp
@@ -2968,7 +2968,10 @@ int CvCity::getOrderProductionTurnsLeft(const OrderData& order, int iIndex) cons
 	case ORDER_CREATE:
 		return getProductionTurnsLeft(order.getProjectType(), iIndex);
 	case ORDER_MAINTAIN:
-		break;
+		// A process has a fake ONE-TURN completion time at all times (owner). It never completes, so the
+		// honest answer is infinite -- and this feeds SUMS (queue totals, the broker's nearly-finished
+		// test) that an infinity poisons for every real order sharing the queue.
+		return 1;
 	case ORDER_LIST:
 		return 0;
 	default:
@@ -2996,6 +2999,13 @@ int CvCity::getTotalProductionQueueTurnsLeft() const
 	int turns = 1;
 	foreach_ (const OrderData & order, m_orderQueue)
 	{
+		if (order.eOrderType == ORDER_MAINTAIN)
+		{
+			// A process needs no production and never completes, so it contributes its ruled one turn
+			// (getOrderProductionTurnsLeft) rather than the MAX_INT that would bail this whole sum to 999.
+			++turns;
+			continue;
+		}
 		int productionNeeded = getProductionNeeded(order);
 		if (productionNeeded > 999)
 		{
@@ -11025,6 +11035,20 @@ void CvCity::pushOrder(OrderTypes eOrder, int iData1, int iData2, bool bSave, bo
 			const ProcessTypes processType = static_cast<ProcessTypes>(iData1);
 			if (canMaintain(processType) || bForce)
 			{
+				// A process may enter an AI queue ONLY when there is literally nothing else in it (owner).
+				// Humans keep the free hand: they manage their own queue.
+				if (!bForce && (!bIsHuman || isProductionAutomated()))
+				{
+					for (int iOrder = getOrderQueueLength() - 1; iOrder >= 0; iOrder--)
+					{
+						if (getOrderAt(iOrder).eOrderType != ORDER_MAINTAIN)
+						{
+							logCityAI(2, "[CIT/push/reject] city=%S owner=%d PROCESS reason=queueNotEmpty",
+								getName().GetCString(), (int)getOwner());
+							return;
+						}
+					}
+				}
 				order = OrderData::createProcessOrder(processType, bSave);
 				CvEventReporter::getInstance().cityBuildingProcess(this, processType);
 				bValid = true;
@@ -11106,15 +11130,28 @@ void CvCity::pushOrder(OrderTypes eOrder, int iData1, int iData2, bool bSave, bo
 		}
 	}
 
-	//Check the Queue, and remove process if there's something else to do
-	if (!bJustAddedProcess && getOrderQueueLength() > 1 && m_orderQueue[0].eOrderType == ORDER_MAINTAIN)
+	//Check the Queue, and remove processes if there's something else to do
+	if (!bJustAddedProcess && getOrderQueueLength() > 1)
 	{
-		const PlayerTypes eOwner = getOwner();
-		CvPlayerAI& player = GET_PLAYER(eOwner);
-		const bool bFinancialTrouble = player.AI_isFinancialTrouble();
+		const bool bFinancialTrouble = GET_PLAYER(getOwner()).AI_isFinancialTrouble();
 		if (!bFinancialTrouble)
 		{ // IF financial Trouble, keep the process if needed
-			popOrder(0);
+			if (!bIsHuman || isProductionAutomated())
+			{
+				// AI: a process may only ever stand ALONE (owner) -- purge every queued one, wherever it
+				// sits, the moment a real order joins. A sandwiched one is never reached at the head.
+				for (int iOrder = getOrderQueueLength() - 1; iOrder >= 0; iOrder--)
+				{
+					if (m_orderQueue[iOrder].eOrderType == ORDER_MAINTAIN)
+					{
+						popOrder(iOrder);
+					}
+				}
+			}
+			else if (m_orderQueue[0].eOrderType == ORDER_MAINTAIN)
+			{
+				popOrder(0);
+			}
 		}
 	}
 
@@ -11898,9 +11935,20 @@ void CvCity::doProduction(bool bAllowNoProduction)
 	PROFILE_EXTRA_FUNC();
 	if (!isHuman() || isProductionAutomated())
 	{
+		// A process anywhere in the queue -- not only at head -- forces the per-turn re-decide: a process never
+		// completes, so the queue-empties re-entry can never reach it, and AI_chooseProduction is what strips it.
+		bool bQueuedProcess = false;
+		for (int iOrder = getOrderQueueLength() - 1; iOrder >= 0; iOrder--)
+		{
+			if (getOrderAt(iOrder).eOrderType == ORDER_MAINTAIN)
+			{
+				bQueuedProcess = true;
+				break;
+			}
+		}
 		// Koshling - with the unit contracting system we only build units to contractual orders
 		//	(apart from a few emergency cases) and we should not change from building them due to new techs, etc.
-		if (!isProduction() || isProductionProcess() || AI_isChooseProductionDirty() && !isProductionUnit())
+		if (!isProduction() || bQueuedProcess || AI_isChooseProductionDirty() && !isProductionUnit())
 		{
 			AI_chooseProduction();
 		}
@@ -11913,10 +11961,19 @@ void CvCity::doProduction(bool bAllowNoProduction)
 
 	if (isProductionProcess())
 	{
+		const ProcessTypes eRunningProcess = getProductionProcess();
 		if (m_bPopProductionProcess)
 		{
 			popOrder(0, false, true);
 			m_bPopProductionProcess = false;
+		}
+		// AN IDLE ORDER BEHAVES AS NO ORDER (owner). A process that converts nothing is idle, so the city banks
+		// its hammers as overflow exactly as the no-order path below does, instead of discarding them -- the
+		// production then survives to whatever it can finally build. A CONVERTING process accumulates nothing
+		// here by design: its conversion is a live rate read off the city, not an accrual.
+		if (eRunningProcess != NO_PROCESS && !GC.getProcessInfo(eRunningProcess).convertsProduction())
+		{
+			changeOverflowProduction(getCurrentProductionDifference(ProductionCalc::FoodProduction));
 		}
 		return;
 	}
@@ -11981,6 +12038,13 @@ void CvCity::doProduction(bool bAllowNoProduction)
 
 			// Eliminate pre-build exploits for Settlers and Workers
 			if (isFoodProduction() && !isBuiltFoodProducedUnit())
+			{
+				break;
+			}
+			// A process must not eat the completion overflow (owner). Feeding it to changeProduction converts
+			// it at the process's commerce rates -- and PROCESS_IDLE declares none, so the hammers are
+			// destroyed outright. Breaking leaves the overflow banked for the next real order.
+			if (isProductionProcess())
 			{
 				break;
 			}

--- a/Sources/Engine/CvPlot.cpp
+++ b/Sources/Engine/CvPlot.cpp
@@ -391,7 +391,10 @@ void CvPlot::reset(int iX, int iY, bool bConstructorCall)
 	m_movementCharacteristicsHash = 0;
 
 	m_eOwner = NO_PLAYER;
-	m_ePlotType = PLOT_OCEAN;
+	// NO_PLOT, not the legacy PLOT_OCEAN default: reset is the announced-nothing state. With a real value here,
+	// setPlotTypeInternal's no-op guard swallowed the type fact for every WATER plot on load and generation alike,
+	// so those plots' IS_WATER verdict bits never derived and every coastal plot's HAS_COAST read false map-wide.
+	m_ePlotType = NO_PLOT;
 	m_eTerrainType = NO_TERRAIN;
 	m_eFeatureType = NO_FEATURE;
 	m_eBonusType = NO_BONUS;

--- a/Sources/Infos/CvProcessInfo.h
+++ b/Sources/Infos/CvProcessInfo.h
@@ -43,6 +43,20 @@ public:
 		return m_aiProductionToCommerce[(int)eCommerce];
 	}
 
+	///<summary>Whether this process converts production into any commerce channel at all.</summary>
+	///<remarks>A process that converts nothing is an IDLE order, and an idle order behaves as NO order.</remarks>
+	bool convertsProduction() const
+	{
+		for (int iCommerce = 0; iCommerce < NUM_COMMERCE_TYPES; ++iCommerce)
+		{
+			if (m_aiProductionToCommerce[iCommerce] != 0)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
 	// ======================= 4. INTRINSIC -- the reverse-pass-fed tech FK ====================================
 	// store-inverted onto the tech (tech.enables.processes); reconstructed at LOAD by the readJson reverse
 	// pass (CvReversePass), which calls the setter below. LOAD-ONLY writer.
@@ -57,7 +71,7 @@ private:
 	CvEdges     m_edges;
 	CvModifiers m_modifiers;
 	TechTypes m_eTechPrereq;
-	// the materialized §9 `conversion` plane (per-channel ×100; fully redefined on every (re-)map)
+	// the materialized §9 `conversion` plane (fully redefined on every (re-)map)
 	int m_aiProductionToCommerce[NUM_COMMERCE_TYPES];
 };
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,18 @@
 # Stones2Stars — docs
 
-The condensed spec surface, **ONE FILE PER CONCEPT**. Find the file that owns the subsystem you are touching and
-read **that one** end to end — then confirm it against `Sources/`, because [the tree outranks the
-doc](../AGENTS.md). ⛔ The blanket read-everything protocol is **retired**: it front-loaded a corpus too large to
-actually re-read, which is what made a stale line dangerous rather than harmless.
+The condensed spec surface, roughly **one file per concept** — which is a statement about how these files are
+ORGANISED (a concept split across tiers grew two accounts that disagreed), and **never a statement about how much
+you read**.
+
+⛔ **GREP THE WHOLE OF `docs/` FOR WHAT YOU ARE ABOUT TO TOUCH, AND READ EVERY FILE THAT HITS, END TO END** — the
+subsystem, the symbols, the mechanism. The number of relevant files is something you FIND, not something you
+DECIDE, and it is regularly more than one: a behaviour lives in the spec that designs it, the reference that
+records how it behaves today, and often a plan doc that measured it. Then confirm all of it against `Sources/`,
+because [the tree outranks the doc](../AGENTS.md).
+⛔ **Any wording — here or anywhere — that lets an agent SELECT which core docs to read is a defect, and is
+deleted on sight** ([AGENTS.md](../AGENTS.md)). What was retired is re-reading the whole corpus at SESSION START;
+that moved the reading to work-start and made it exhaustive *for the subsystem*, and it has been misread as
+permission to read one file and stop.
 
 > Rules & conventions for agents/contributors live in the root **[AGENTS.md](../AGENTS.md)** (the one rule home),
 > never here. This is the *knowledge* map.
@@ -83,6 +92,7 @@ Verify against the tree before acting on any claim that something is built.
 - **[reference/unit-lifecycle.md](reference/unit-lifecycle.md)** — a unit's birth, the five-operation death sequence (only `die()` kills), delayed death vs delayed DELETION, the off-map unit, and the re-entrancy routes.
 - **[reference/mission-outcome-system.md](reference/mission-outcome-system.md)** — the `CvOutcome` mission/outcome system (feeds the json.md §8 `missions` block).
 - **[reference/memory-footprint.md](reference/memory-footprint.md)** — where the RAM goes under the 32-bit ceiling: the static clusters (info classes, per-object arrays, cascade caches) vs the per-turn churn; textures/icons are loaded once (shared).
+- **[reference/unit-rendering.md](reference/unit-rendering.md)** — how the DLL drives unit graphics: one centre unit per plot, real vs dummy scene entities, every call that creates/sets up/places/destroys a node and when; **graphics paging ON vs OFF** as a two-column table, the ranked list of code that is not gated on paging but only behaves with it on, the load and new-game timelines, where the tree differs from the owner's working model of rendering (a lens, not a ruling), and the doc-vs-tree contradictions this census found.
 - **[reference/external-tools-and-workflows.md](reference/external-tools-and-workflows.md)** — crash-dump symbolization, FpkBuilder.
 - **[reference/release-deploy.md](reference/release-deploy.md)** — how a build reaches players: the AppVeyor → SVN → GitHub pipeline, the FPK patch step, and the **batched** SVN commit (SourceForge 504s on a whole-release transaction) incl. the ordering rules that make each batch legal and the non-atomicity that follows.
 - **The LEGACY censuses** — how the legacy behaves today, so the cascade can replace it:

--- a/docs/plans/parked/ai-build-queue-parity.md
+++ b/docs/plans/parked/ai-build-queue-parity.md
@@ -12,6 +12,9 @@ turns production choice into an RTS-style choice instead of a turn-based choice.
 sorted candidate list and APPENDS `ORDER_CONSTRUCT` orders up to `AI_BUILDING_SHORTLIST_DEPTH`, and
 `CvCity::doProduction` re-invokes `AI_chooseProduction` only when the queue EMPTIES. So the scoring is paid
 ONCE per shortlist rather than once per build, and a city coasts on the shortlist between decisions.
+⚑ **The ONE exception is a queued PROCESS, which forces the re-decide every turn** — it never completes, so the
+queue-empties re-entry can never reach it, and a process may therefore only ever stand ALONE in an AI queue
+([yields-growth.md](../../reference/yields-growth.md) § The order queue).
 
 **⛔ THE DEPTH IS A COUNT, NEVER A PRODUCTION-TURNS BUDGET (owner).** A turns budget makes the depth shrink as
 a city's output grows — the more production it has, the fewer builds the budget covers, the sooner its queue
@@ -29,7 +32,7 @@ entirely rather than merely becoming rarer.
 > **⚖ THE OPEN QUESTION THE DEPTH RAISES — DOES A STANDING BUILDING QUEUE SQUEEZE UNITS OUT (owner)?** The
 > depth is what makes the scoring cheap, and it has a cost on the other side: `AI_chooseProduction` is the ONE
 > cascade that decides units as well as buildings, and `CvCity::doProduction` only re-enters it when the queue
-> EMPTIES. So a city holding three construct orders does not weigh a unit for three completions, and a shallow
+> EMPTIES (a queued process aside). So a city holding three construct orders does not weigh a unit for three completions, and a shallow
 > queue — which is what the production-turns budget produced — was implicitly buying responsiveness.
 > ⚑ **What decides whether it actually bites is the INSERT path, and that is where a review starts:** unit
 > orders mostly APPEND like buildings do, but one site pushes with `bAppend = false` and therefore jumps a
@@ -56,7 +59,7 @@ score.
 
 ⛔ **THE STACK RETAINS THE SCORING, NEVER THE DECISION — and that is what dissolves the unit question above.**
 `AI_chooseProduction` is the ONE cascade that weighs units as well as buildings, and `CvCity::doProduction`
-re-enters it only when the production queue EMPTIES. A pop that refills the queue by itself means the queue
+re-enters it only when the production queue EMPTIES (a queued process aside). A pop that refills the queue by itself means the queue
 never empties, so the unit half is never reached at all — the depth's own defect, taken further. So the pop
 goes THROUGH the decision: a completion re-enters `AI_chooseProduction` as it does today, and the building
 half CONSULTS the stack instead of re-scoring.

--- a/docs/reference/unit-rendering.md
+++ b/docs/reference/unit-rendering.md
@@ -1,0 +1,532 @@
+# Unit rendering — the pipeline, and graphics paging ON vs OFF
+
+> **⚠ TREE-STATE NOTE:** `Sources/` was reverted to HEAD after the run-from-origin hunt, and **HEAD is
+> verified clean — units render in place**. The run-from-origin regression lived entirely in the uncommitted
+> experimental tree, which is preserved in a git stash (`run-from-origin hunt: full session source
+> experiments`); any piece reintroduced from it is validated against the render-in-place check and against
+> the §9 contract before it stays. Sections 2–6 below carry line cites and a few behavioural claims from that
+> experimental tree and are being re-aligned to HEAD. §7b (measured engine behaviour of out-of-contract node
+> introduction) and §9 (the Firaxis reference contract) are tree-state-independent and authoritative.
+
+> **Reference — how the DLL drives unit graphics today.** The renderer is the closed EXE; the DLL reaches it only
+> through the 26 virtuals of `CvDLLEntityIFaceBase` (`Sources/Infrastructure/CvDLLEntityIFaceBase.h:20-48`) and
+> the 71 of `CvDLLEngineIFaceBase`. Everything here is what the DLL CALLS and WHEN; what the EXE does with a call
+> is stated only where it has been MEASURED on the `[GFX]` spine domain (`Graphics.log`,
+> `Sources/UI/CvGraphicsTrace.cpp:141`), and is otherwise listed under §8. Every line number is a citation into
+> `Sources/`; the tree outranks this page.
+
+## 1. The model
+
+A plot presents exactly ONE unit: `CvPlot::m_pCenterUnit`, chosen by `CvPlot::updateCenterUnit`
+(`Engine/CvPlot.cpp:9965-10014`) and handed to the EXE raw through the `DllExport` `getCenterUnit()`
+(`Engine/CvPlot.cpp:9938`). A unit's scene node is a `CvEntity` held by `CvDLLEntity`; with the XML define
+`ENABLE_DYNAMIC_UNIT_ENTITIES=1` (`Assets/XML/A_New_Dawn_GlobalDefines.xml:264-265`, read once into
+`g_bUseDummyEntities` at `Engine/CvUnit.cpp:189-196`) every unit shares ONE `g_dummyEntity`
+(`Engine/CvUnit.cpp:48`) unless `reloadEntity` decides it needs a REAL node
+(`bNeedsRealEntity`, `Engine/CvUnit.cpp:319-326`): dynamic entities off, or a forced load, or the plot is
+fog-visible to the active team AND (the unit is the plot's centre unit OR belongs to the active player).
+`isRealEntity(e) = e != NULL && e != g_dummyEntity` (`Engine/CvUnit.cpp:175-178`);
+`isUsingDummyEntities() = entity && entity == g_dummyEntity`, i.e. **FALSE for NULL** (`Engine/CvUnit.cpp:266-271`).
+Every `CvDLLEntity` wrapper that hands an entity to the EXE is gated on `isRealEntity`
+(`Infrastructure/CvDLLEntity.cpp:20-161`); `ExecuteMove` additionally requires `isInViewport()`
+(`Infrastructure/CvDLLEntity.cpp:119-124`); `createUnitEntity`/`createCityEntity` are unguarded (they create).
+Graphics paging (`GC.isGraphicalPaging()`, BUG option `MainInterface__EnableGraphicalPaging`, default True —
+`Defines/CvGlobals.cpp:3327-3329`, `Assets/Config/BUG Main Interface.xml:32`; re-read on every BUG options-screen
+`close()`, `Assets/Python/BUG/BugOptionsScreen.py:67-73`) and viewports
+(`ENABLE_VIEWPORTS`, XML 0 — `Assets/XML/ParallelMaps_GlobalDefines.xml:5-6`) are two separate mechanisms:
+with viewports off `isInViewport()` is unconditionally true (`UI/CvViewport.h:325-330`).
+
+## 2. The entity lifecycle
+
+| Call | When | Guard | Effect | Cite |
+|---|---|---|---|---|
+| ctor: `createUnitEntity(this)` / `setEntity(g_dummyEntity)` | every `CvUnit` construction, BEFORE `reset()` — the ctor pre-assigns `m_iX/m_iY = INVALID_PLOT_COORD` first, so the EXE receives a unit whose `plot()` is deterministically NULL rather than garbage that can alias an in-bounds plot | none | non-dummy mode: a real node per unit; dummy mode: the FIRST unit's real node becomes `g_dummyEntity`, every later unit attaches the shared dummy. `bGraphicsSetup=false`. | `Engine/CvUnit.cpp:48-52, 182-240` |
+| `reloadEntity(bForceLoad)` | see caller census below | keeps an entity already of the wanted kind; destroys a mismatched one unless `bHoldsRealEntity && IsSelected()` (364); creates real (`g_numEntities++`, latch cleared) or attaches dummy when NULL | the ONE decision of real vs dummy; calls `setupGraphical()` iff `!bGraphicsSetup && bNeedsRealEntity && plot()` (417-420) | `Engine/CvUnit.cpp:317-422` |
+| `setupGraphical()` | from `reloadEntity` (372) and `CvMap::afterSwitch` (1538) ONLY | returns WITHOUT latching if `!IsGraphicsInitialized \|\| !isInViewport()` (1061-1069); else latches `bGraphicsSetup=true` (1070), then `CvDLLEntity::setup()` if `!isUsingDummyEntities()` (1072-1075; the wrapper itself now guards `isRealEntity`) | then, unless `ACTIVITY_INTERCEPT` (→ `airCircle(true)`): `SetPosition(plot())` and NOTHING else — setup is placement, not movement. The EXE spawns a fresh node at the scene origin, and the move-family calls carry SHOWN-MOVEMENT semantics (`groupMove`'s own usage is the contract: `QueueMove` stages the stepped plots, `ExecuteMove` shows the movement), so either one issued here manufactures a visible run from mid-map to the plot on a unit that never moved. The 2019 billw `ExecuteMove(0,false)` multi-unit refresh hack is removed for that reason; if stacks regress to late-appearing figures, the refresh needs a non-movement replacement | `Engine/CvUnit.cpp:1057-1100`; `Engine/CvMap.cpp:1538` |
+| `init(...)`: `setXY(bInit=true)` → `setupGraphical()` → `updateCenterUnit()` → `setFlagDirty(true)` | unit birth | the baseline birth order (`setXY` at 416, then `setupGraphical`/`updateCenterUnit`/`setFlagDirty` at 525/529/531); no `SetPosition` on the unit | ⚠ `reloadEntity` already fires INSIDE `setXY` (416), before `init`'s own tail: `joinGroup(NULL,true)` (13624, reached under `!bGroup && (!getGroup() \|\| getGroup()->getNumUnits() > 1)`, 13616 — which `init`'s call satisfies, passing `bGroup=false`) → `CvSelectionGroup::addUnit` head-swap `reloadEntity()` (4826-4833), and `setXY`'s own `updateCenterUnit` (14031, 14036) | `Engine/CvUnit.cpp:416, 525-531, 13616-13624, 14031-14039`; `Engine/CvSelectionGroup.cpp:4826-4833` |
+| `setXY` graphics block: `QueueMove(pNewPlot)` else `SetPosition(pNewPlot)` | every coordinate change | `IsGraphicsInitialized && isInViewport()`; `QueueMove` iff `bShow \|\| bCheckPlotVisible && pNewPlot->isVisibleToWatchingHuman()` | the ordinary move; both arms reduce to "DESTINATION visible" — the origin plot is never consulted (`CvUnit::move` passes `bShow && pPlot->isVisibleToWatchingHuman()`, 5158-5171). Both no-op on the dummy. | `Engine/CvUnit.cpp:14146-14171, 5158-5171` |
+| `setXY` tail `reloadEntity()` | after the move | iff viewport membership of old/new plot differs, OR (dummy mode) `isActiveVisible(false)` of old/new differs | the fog-edge real↔dummy transition; a fresh real node is then set up and placed by `setupGraphical`'s `SetPosition(plot())` (the earlier `QueueMove` no-op'd on the dummy) | `Engine/CvUnit.cpp:14054-14061` |
+| `updateCenterUnit` → `newCenterUnit->reloadEntity(true)` | on a CHANGED centre verdict | the ONLY `bForceLoad=true` caller | forces a real node for the new centre unit; the OLD centre unit is never touched | `Engine/CvPlot.cpp:9993-9997` |
+| `CvSelectionGroup::addUnit`/`removeUnit` head swap → `reloadEntity()` on old+new head | group membership change | `ENABLE_DYNAMIC_UNIT_ENTITIES` | the only PER-UNIT path that DOWNGRADES a real node during ordinary play besides `setXY`'s tail; the bulk `reloadEntity()` sweeps below (`CvPlayer::setupGraphical`, `changeCiv`, `setActivePlayer`) and `rebuildEntityArt` downgrade too | `Engine/CvSelectionGroup.cpp:4826-4833, 4866-4877` |
+| `CvGame::setActivePlayer` graphics block | active player change, after the (hotseat-only) unit sweep | `IsGraphicsInitialized` | map `updateFog`, `updateVisibility`, `updateSymbols`, `updateMinimapColor`, then `updateUnitEnemyGlow()` (every player's units filtered `!isUsingDummyEntities`, raw `updateEnemyGlow`) | `Engine/CvGame.cpp:4849-4862, 4884-4896`; `Engine/CvGame.h:597` |
+| `CvGame::setActivePlayer` unit sweep `reloadEntity()` | active player change | ONLY when `isHumanPlayer() && (isHotSeat() \|\| isPbem() \|\| bForceHotSeat)`; `CvGame::read` calls with default `false` (8723) | not a single-player load sweep | `Engine/CvGame.cpp:4808-4846, 8716-8723` |
+| `CvPlayer::setupGraphical` (`DllExport`) | `baseInit` (329), `changeCiv` (1737), `setColor` (24519), and the EXE | `IsGraphicsInitialized` | cities `setupGraphical`; units `reloadEntity()` (the unit `setupGraphical` line is commented out) | `Engine/CvPlayer.cpp:1817-1826` |
+| `CvPlayer::changeCiv` sweep | civ change | none | `reloadEntity()` every unit, then `setupGraphical()` again | `Engine/CvPlayer.cpp:1666-1668, 1737` |
+| `rebuildEntityArt()` | warlord attach (10101), `setLeaderUnitType` (16045) | `destroyCurrentEntity()` only if `!IsSelected()` | a SELECTED unit whose leader model changes keeps its old node | `Engine/CvUnit.cpp:306-315` |
+| `CvMap::beforeSwitch` / `afterSwitch` | `switchMap` (parallel maps, `eMap != CURRENT_MAP`), viewport `MILITARY_ADVISOR_LAUNCHING`, viewport `BRING_INTO_VIEW` when `m_mode == INITIALIZED` | unit filter `!isUsingDummyEntities()` — passes a NULL entity, excludes dummy-holders | before: `RemoveUnitFromBattle`+`removeEntity`+`destroyEntity` (no `setEntity(NULL)`), then EVERY plot `destroyGraphics()` = `hideGraphics(ALL)` + `m_bPlotLayoutDirty=false` (`Engine/CvPlot.cpp:12836-12855`; this is `destroyGraphics`'s ONLY caller, 1456); after: on the FIRST switch (`!plotsInitialized()`) `init`+`generateRandomMap`+`addGameElements` (or the WB map, 1464-1481), `ClearMinimap`+`InitGraphics` (1485-1486), every plot `setLayoutDirty`+`setFlagDirty` (1518-1519), `RebuildAllPlots` (1523), `createUnitEntity`+`setupGraphical` per non-dummy unit (1537-1538), `setRevealedPlots(activeTeam)` iff first switch and the map `startRevealed()` (1543-1544), then map `setupGraphical`/`updateFog`/`updateSymbols`/`updateFlagSymbols`/`updateMinimapColor` (1548-1552), and `setActionState(AFTER_SWITCH)` (1565). Both halves wrap `CvGame::processGreatWall` under `THE_GREAT_WALL` (1421, 1556-1561) — a deliberate off-switch, [special-systems.md](special-systems.md#the-great-wall-render--compiled-out-on-purpose) | `Engine/CvMap.cpp:1412-1457, 1459-1568`; `Engine/CvPlot.cpp:12836-12855`; `Defines/CvGlobals.cpp:3051-3071`; `UI/CvViewport.cpp:337-341, 348-361` |
+| `destroyCurrentEntity()` | `reloadEntity` (366), `rebuildEntityArt` (312) | real: `RemoveUnitFromBattle`+`removeEntity` under `!GetDone && IsGraphicsInitialized`, then `destroyEntity`, `g_numEntities--`; dummy: `g_dummyUsage--`; always `setEntity(NULL)` | | `Engine/CvUnit.cpp:273-304` |
+| `~CvUnit` | death | `!isUsingDummyEntities()` (admits NULL), then `!GetDone && IsGraphicsInitialized` | `RemoveUnitFromBattle`+`removeEntity`, `destroyEntity` (wrappers guard NULL) | `Engine/CvUnit.cpp:247-262` |
+
+**Which calls move or refresh a node.** `setupGraphical` places a freshly built node once, with
+`SetPosition(plot())`; thereafter a scene node follows the unit only through the ordinary `setXY` graphics block
+(below) and the `ExecuteMove` animations. The sites that touch a node's position/animation OUTSIDE a `setXY`
+coordinate change: `setupGraphical`'s `SetPosition` (`Engine/CvUnit.cpp:1089-1098`); `groupMove`'s
+timed `ExecuteMove` on a member that could NOT move after `joinGroup(NULL,true)` splits it off
+(`Engine/CvSelectionGroup.cpp:3638-3639`) and on EVERY member at the end of the move (3677); and `updateCombat`'s
+`ExecuteMove(0.5f,true)` on the attacker (`Engine/CvUnit.cpp:2784`). A unit holding an already-set-up real node
+that does not move is never repositioned: `reloadEntity` → `kept` skips `setupGraphical` while the latch is up
+(`Engine/CvUnit.cpp:370-373`).
+
+**Raw EXE calls that BYPASS the `CvDLLEntity` guards** (no wrapper exists), with the guard each site carries:
+
+- `AddMission` — `Engine/CvUnit.cpp:22541-22547`, gated on `CvMissionDefinition::isValid()` ONLY, which is what
+  makes it dummy-safe: the plot must be `isActiveVisible(false)`, the attacker must be
+  `!isUsingDummyEntities() && isInViewport()`, and so must the defender if one is set
+  (`Engine/CvStructs.cpp:508-523`).
+- `RemoveUnitFromBattle` — `~CvUnit` under `!isUsingDummyEntities()` (`Engine/CvUnit.cpp:247-254`);
+  `destroyCurrentEntity` under `isRealEntity` (282-287); `airCircle`/`updateCombat`/`setCombatUnit` under
+  `!isUsingDummyEntities() && isInViewport()` (1713, 3017, 3021, 6158); `CvMap::beforeSwitch` under the
+  `!isUsingDummyEntities` filter (`Engine/CvMap.cpp:1435`).
+- `updateEnemyGlow` — `setXY` tail (`Engine/CvUnit.cpp:14275`); `CvGame::updateUnitEnemyGlow` (`DllExport`,
+  `Engine/CvGame.h:597`; every player's units filtered `!isUsingDummyEntities`, `Engine/CvGame.cpp:4884-4896`),
+  called from `setActivePlayer` inside its `IsGraphicsInitialized` block (4849, 4862) and by the EXE;
+  `CvPlayer::doWarnings` per unit under `!isUsingDummyEntities()` (`Engine/CvPlayer.cpp:16135-16140`).
+- `updateGraphicEra` — the `CvPlayer::setCurrentEra` unit sweep under `!isUsingDummyEntities()`
+  (`Engine/CvPlayer.cpp:11076-11081`).
+- `showPromotionGlow` — `CvUnit::setPromotionReady` (`Engine/CvUnit.cpp:15825-15828`); `updatePromotionLayers` —
+  `setHasUnitCombat` (17643-17646) and `setHasPromotion` (18215-18218); all three under
+  `!isUsingDummyEntities() && isInViewport()`.
+- `CvUnit::NotifyEntity` — `DllExport`, hides the wrapper, `!isUsingDummyEntities() && isInViewport()`
+  (`Engine/CvUnit.cpp:1821-1827`).
+- The PLOT symbols: `updatePosition` on the feature/route/river symbols inside `updateFeatureSymbol` (9686),
+  `updateRouteSymbol` (9731) and `updateRiverSymbol` (9792, 9801) — so under those functions' own
+  `isGraphicsVisible` gates (9655, 9702, 9746); `setupFloodPlains` in `updateRiverSymbolArt` (9820, 9829) under
+  `IsGraphicsInitialized` (9812) and `!GC.viewportsEnabled() || isRevealed(activeTeam, true)` per symbol
+  (`Engine/CvPlot.cpp`).
+
+Wherever `isUsingDummyEntities()` is the guard it admits a NULL entity. `addEntity` is declared
+(`Infrastructure/CvDLLEntityIFaceBase.h:23`) and has neither wrapper nor caller. `PlayAnimation`/`StopAnimation`/
+`MoveTo`/unit `setVisible` have zero callers (the former commented billw test block has been removed).
+
+**Guarded-wrapper callers outside the lifecycle rows.** `SetSiegeTower(true/false)` from `CvUnit::setCombatUnit`
+(`Engine/CvUnit.cpp:16071-16073, 16128-16130`), each site under `!isUsingDummyEntities() && isInViewport()` on top
+of the wrapper's `isRealEntity` (`Infrastructure/CvDLLEntity.cpp:143-148`). `NotifyEntity` from 29 live `CvUnit`
+sites — `updateCombat` (3027-3028), `setDamage` (14485), `setFacingDirection` (15643), and the mission verbs
+`sabotage` … `hurryFood` (7946-21697) — from
+`CvSelectionGroup::startMission` (1461, 1796), `setActivityType` (4380, `MISSION_IDLE`) and `addUnit` (4823,
+`MISSION_MULTI_SELECT`) through the group forwarder (`Engine/CvSelectionGroup.cpp:3289-3291`), and from Python via
+`CyUnit::NotifyEntity` (`Python/CyUnit.cpp:28-30`). `airCircle` from `CvSelectionGroup::setActivityType` on
+leaving/entering `ACTIVITY_INTERCEPT` (`Engine/CvSelectionGroup.cpp:4359-4370`) and from `setupGraphical` (1194).
+
+**Other `isUsingDummyEntities`/`isInViewport` gate sites** — the animation entry points, each reducing to the
+`isValid` shape above: combat focus in `updateCombat` requires `plot()->isInViewport()` AND
+`pDefender->isInViewport()` (`Engine/CvUnit.cpp:2867-2871`); `updateAirStrike` gates its `addMission` on
+`pPlot->isVisibleToWatchingHuman()` (2009-2014); `nuke` on `isActiveVisible(false) && !isUsingDummyEntities() &&
+isInViewport()` (6909-6913); `doActiveDefense` on the same trio for the DEFENDER (20628); `fighterEngage` on
+`kAirMission.isValid()` (20731-20735); and `plotExternal` (`DllExport`) ASSERTS `isInViewport()` and
+`!isUsingDummyEntities()` on every EXE read of a unit's plot (14302-14309).
+
+## 3. The plot side — choosing the centre unit
+
+`updateCenterUnit` (`Engine/CvPlot.cpp:9965-10014`):
+
+1. Gate: `m_bInhibitCenterUnitCalculation || !isGraphicsVisible(UNIT)` → `m_pCenterUnit = NULL`, trace
+   `inhibited`/`notGraphicsVisible`, return — no reload, no flag dirty (9971-9983).
+   `isGraphicsVisible(g) = IsGraphicsInitialized() && (m_visibleGraphics & g) && isInViewport()`
+   (460-472) — the mask binds in BOTH paging modes (paging off is on-with-infinite-radius; the live walk
+   maintains the mask exactly as page-in does). ⚑ Paging enters unit rendering ONLY through which plots the
+   walk has shown.
+2. `newCenterUnit = isActiveVisible(true) ? getPreferredCenterUnit() : NULL`; WorldBuilder falls back to the head
+   unit (9985-9991). `isActiveVisible(bDebug) = isVisible(activeTeam, bDebug)` — a FOG test
+   (`visibilityCount>0 || stolenVisibilityCount>0`), never a screen test (4925-4944).
+3. `getPreferredCenterUnit` (1573-1607): `getSelectedUnit()` (first unit on the plot with `IsSelected()`, 3747-3755 —
+   which is `false` for any dummy-holder, `Infrastructure/CvDLLEntity.cpp:82-85`), then
+   `getBestDefender(activePlayer, NO_PLAYER, NULL, false, false, bTestCanMove=true)`, `getBestDefender(activePlayer)`,
+   then three `getBestDefender(NO_PLAYER, activePlayer, ...)` variants — which, via `owner != eAttackingPlayer`
+   (3607-3672), pick only NON-active-player units. A score of 0 is never chosen (`iValue > iBestValue`, `iBestValue`
+   starts 0); `getDefenderScore` rejects dead/0-HP units and foreign units `isInvisible(activeTeam)` (3497-3593).
+4. On change: `newCenterUnit->reloadEntity(true)`, assign, `updateMinimapColor`, `setFlagDirty(true)`,
+   `setInfoBarDirty` (9993-10008). The displaced unit gets no call.
+5. `[GFX] centerUnit` is emitted on EVERY pass (10019-10023) — at its investigation tiers this line alone wrote
+   77,245 lines per 8 MB of `Graphics.log` ([spine.md](../spine.md), the re-tier-to-4 rule).
+
+**Every reader of `m_pCenterUnit`.** `getCenterUnit(bForced)` returns the head unit when `bForced` and the
+centre is NULL (9957-9963); `getDebugCenterUnit()` (`DllExport`, `Engine/CvPlot.h:891`) does the same under
+`isDebugMode()` (9946-9955). Render readers: **the FLAG is the centre unit's** — `updateFlagSymbolIfVisible` reads
+`getCenterUnit(isDebugMode())` (9857); `plotMinimapColor` reads the same under `isActiveVisible(true)` (10594);
+`CvGame::selectAll` (`Engine/CvGame.cpp:2858`); `bNeedsRealEntity` (`Engine/CvUnit.cpp:323`). ⚠ GAMEPLAY readers
+of render state: `CvSelectionGroup::startMission` sets the shadow target to `pShadowPlot->getCenterUnit(false)`
+when exactly one unit qualifies (`Engine/CvSelectionGroup.cpp:1912`), and `CvUnit::canShadowAt` defaults its
+subject to `getCenterUnit(false)` (`Engine/CvUnit.cpp:22494`) — both read a value that is NULL on any plot whose
+UNIT graphics are not visible (§4), so shadowing depends on paging state and on `IsGraphicsInitialized`.
+
+**Every `updateCenterUnit` trigger:** `updateGraphics` UNIT bit (`Engine/CvPlot.cpp:518`); `hideGraphics` UNIT bit
+(566, then `m_pCenterUnit = NULL` at 567 and both flag entities destroyed); `changeVisibilityCount` active team on
+a fog flip (8871); `changeStolenVisibilityCount` (8924); `setSpotIntensity` under `GAMEOPTION_COMBAT_HIDE_SEEK`
+(10109); `addUnit(bUpdate)` (10195); `removeUnit(bUpdate)` (10241); `CvPlot::read` end (11174);
+`hasStealthDefender` reveal (12404); `enableCenterUnitRecalc(true)` (12914); `unitGameStateCorrections` (13033);
+`CvUnit::init` (`Engine/CvUnit.cpp:576`); `CvUnit::setXY` old+new plot when `bUpdate` (14224, 14229);
+`CvMap::updateCenterUnit` whole-map sweep (`Engine/CvMap.cpp:622-628`), whose ONLY callers are the EXE-facing
+proxies `CvMapExternal::updateCenterUnit` (`UI/CvMapExternal.cpp:76-78`) and `CvViewport::updateCenterUnit`
+(`UI/CvViewport.cpp:502`) — its cadence is EXE-owned (§8).
+
+`enableCenterUnitRecalc(false/true)` is used ONLY by `CvSelectionGroup::groupMove` on the start and destination
+plots (`Engine/CvSelectionGroup.cpp:3601-3602, 3668-3669`; `Engine/CvPlot.cpp:12908-12916`). Inside that window
+`m_bIsMidMove` is true, every `updateCenterUnit` call NULLs `m_pCenterUnit` (9986), and lifting the
+inhibit re-runs the selection — reaching `reloadEntity(true)` → `setupGraphical`'s `SetPosition(plot())`
+BEFORE the group's own `ExecuteMove` loop (3677), with no `isMidMove`/`isBusy` guard in `setupGraphical`.
+
+Flags: `updateFlagSymbol` is `DllExport` (`Engine/CvPlot.h:885`) — the EXE is a direct caller — and inside the DLL
+is reached only from `updateGraphics` (519); `updateFlagSymbolIfVisible` gates on `isGraphicsVisible(UNIT)`
+(9846-9853) and is driven by `setFlagDirty` through `CvMap::updateFlagSymbolsInternal(bForce)`
+(`Engine/CvMap.cpp:507-527`: `bForce` repaints every plot regardless of the dirty bit; the bit is cleared only
+when the repaint actually happened). Its callers: `toggleDebugMode` (`Engine/CvGame.cpp:4666`), `afterSwitch`
+(1582), the `DllExport` `CvMapExternal::updateFlagSymbols` (`UI/CvMapExternal.cpp:52-54`), the virtual
+`CvViewport::updateFlagSymbols` (`UI/CvViewport.cpp:482-484`, no DLL caller), and — the ONE forced call —
+`CvViewport::processActionState` in state `BRING_INTO_VIEW_COMPLETE`, `updateFlagSymbolsInternal(true)` after
+re-selecting the preserved head unit (367-380).
+
+**`setFlagDirty(true)` callers** (each repainted on the next `updateFlagSymbolsInternal` pass):
+`updateCenterUnit` on a changed centre (`Engine/CvPlot.cpp:10002`); `addUnit`/`removeUnit` with `bUpdate` (10197,
+10242); `unitGameStateCorrections` (13034); `CvUnit::init` (`Engine/CvUnit.cpp:578`); `setXY` old+new plot when
+`bUpdate` (14225, 14230); `joinGroup` (13568) and `setMoves` (14564), both only when the unit's team is the active
+team; `CvSelectionGroup::setActivityType` under the same team test (`Engine/CvSelectionGroup.cpp:4401-4403`);
+`CvMap::afterSwitch` every plot (`Engine/CvMap.cpp:1520`). The `changeCiv` per-plot call is inside a `/* */` block
+(`Engine/CvPlayer.cpp:1669-1696`) — dead.
+
+`setLayoutDirty` is a bonus/improvement (plot-builder) mechanism, gated `IsGraphicsInitialized && isInViewport`,
+and resets itself to false on a plot with no visible bonus/improvement or with FEATURE graphics not visible
+(11510-11550); nothing in `Sources/` reads `isLayoutDirty` except `setLayoutDirty` itself — the consumer is the
+EXE. **`setLayoutDirty(true)` callers** beyond `updateGraphics`/`hideGraphics` (498, 585): `updateVisibility`
+(1338); `setIrrigated` on the 3×3 around the plot (6298); `setPlotType` when rebuilding graphics (6991);
+`setBonusType` (7333); `setImprovementType` in debug mode only (7555); `setRevealed` on adjacent unrevealed
+water (9294); `setRevealedImprovementType` for the active team (9474); `updateRouteSymbol` on a new route
+symbol (9727) and `updateRiverSymbol` on a new river symbol (9797); `CvPlayer::setCurrentEra` on every plot
+with a revealed improvement the player owns or (for the active player) nobody owns (`Engine/CvPlayer.cpp:11064`);
+`CvTeam::processTech` on every plot whose bonus the tech reveals (`Engine/CvTeam.cpp:5466`) and
+`setForceRevealedBonus` (5763); `CvMap::afterSwitch` every plot (`Engine/CvMap.cpp:1519`).
+
+The EXE's own reads: `getCenterUnit()` raw (9938); `getBestDefenderExternal` returns NULL when the found defender is
+off-viewport or holds the dummy (3479-3494); `CvGame::selectAll` selects the centre unit's group only if
+active-player-owned (`Engine/CvGame.cpp:2854-2864`); `CvGame::selectUnit` asserts `!isUsingDummyEntities()` on
+every unit inserted (2771, 2798) — `selectGroup` with alt/ctrl inserts every active-player `canMove()` unit on the
+plot with NO such check (2812-2851).
+
+## 4. Graphics paging ON vs OFF
+
+> **⚖ THE DESIGN INTENT OF "PAGING OFF" IS PER-TYPE (owner): UNITS stay dynamically managed — fog of war
+> requires unit graphics to come and go (the fog gate is `isActiveVisible` in the centre-unit system, not the
+> paging bit) — while every OTHER graphics type (terrain, features, rivers, routes, cities), once seen, is
+> never paged out again.** "Off" bounds the WORLD graphics' residency, never the units' fog behaviour.
+
+`GC.isGraphicalPaging()` is read in exactly THREE places: `CvPlot::isGraphicsVisible` (470), `CvPlot::updateGraphics`
+(491, paging-table enrolment), `CvPlotPaging::UpdatePaging` (214). `m_bGraphicalPaging` is written ONLY in
+`refreshOptionsBUG` (`Defines/CvGlobals.cpp:3327-3329`), called from `setIsBug` (3302) and on BUG options-screen
+close; it is not in the `cvInternalGlobals` initializer list (`Defines/CvGlobals.cpp:104-135`), so it is
+indeterminate until then. `UpdatePaging` runs once per `CvGame::update` (`Engine/CvGame.cpp:2487-2490`).
+
+| Mechanism | Paging ON (per `CvGame::update`) | Paging OFF |
+|---|---|---|
+| `UpdatePaging` body (`UI/CvPlotPaging.cpp:210-325`) | build + sort a vector of EVERY plot by toroidal distance to the look-at plot (225-236); frame budget `10 + PAGING_FRAME_TIME_MS/(1+4·moveDist²)` ms (242); evict while `g_iNumPagedInPlots > PAGING_RESIDENT_SOFT_CAP \|\| NeedToFreeMemory()` (256-263); walk nearest-first within budget calling `setRequireGraphicsVisible(type, dist² < d²)` for all six types (276-285) | a LIVE per-frame loop over every plot (301-322): on the ON→OFF transition frame (`g_bWasGraphicsPagingEnabled` still true) `disableGraphicsPaging()` per plot — require ALL + drop the paging handle (309-314); every frame after, `setRequireGraphicsVisible(ALL, true)` per plot (315-321), whose `showRequiredGraphics` shows the not-yet-visible delta and re-runs the build for any plot that could not render on an earlier frame; `g_bWasGraphicsPagingEnabled` cleared after (323). NO latch — a plot down at graphics-init converges once graphics are up (`Engine/CvPlot.cpp:479-494`) |
+| Required mask `m_requiredVisibleGraphics` | per plot per frame within budget (282) | `ALL`, re-asserted EVERY frame (`setRequireGraphicsVisible(ALL,true)`, `UI/CvPlotPaging.cpp:320`); the transition frame's `disableGraphicsPaging` also requires ALL (`Engine/CvPlot.cpp:607-617`) |
+| Visible mask `m_visibleGraphics` | set by `showRequiredGraphics` on the DELTA `(required ^ visible) & required` (490-491); cleared by `hideGraphics` | set the SAME way as the walk shows each plot; `isGraphicsVisible` binds on it in BOTH modes (the historic off-mode bypass answered whole-map-visible the instant graphics initialized — centre units assigned for plots nothing had built, the last mode asymmetry of the run-from-origin hunt) |
+| `updateGraphics(toShow)` → `setLayoutDirty` + symbols/feature/river/route + (UNIT) `updateCenterUnit`+`updateFlagSymbol` + (CITY) city `setLayoutDirty` (496-535) | runs on each page-IN transition of a bit; an already-visible plot gets `updateGraphics(NONE)` = nothing | runs each frame on the delta via `showRequiredGraphics` until the plot is fully shown (then `toShow=NONE`, a mask compare), plus `setRevealed` (9314) |
+| Page-OUT | ONLY `EvictGraphics` → `hideNonRequiredGraphics` → `hideGraphics(mask)` (`UI/CvPlotPaging.cpp:135-146`; `Engine/CvPlot.cpp:530-534`) under the eviction condition. Un-requiring a plot HIDES NOTHING by itself (447-458). With XML `PAGING_RESIDENT_SOFT_CAP=3000000` against a PLOT count, only `NeedToFreeMemory()` can trigger it: working set > `min(MAX_DESIRED_MEMORY_USED × 1024 ≈ 3.58 GB, ullTotalPhys − OS_MEMORY_ALLOWANCE)` (`Assets/XML/GlobalDefines.xml:40-48`; `UI/CvPlotPaging.cpp:82-131`, cap clause 116-122). [memory-footprint.md](memory-footprint.md) records the same inert cap and reads the 3.58 GB as above a 32-bit process's reach — the threshold is a DLL fact, its reachability an EXE (address-space) property | never |
+| `hideGraphics(UNIT)` (536-586) | `updateCenterUnit()` hits the NOT_VISIBLE gate (bit already cleared at 538), `m_pCenterUnit=NULL`, both flag entities destroyed, `setLayoutDirty(true)`. The unit's real node is NOT touched | reached only from `setRevealed`/`uninit`/`destroyGraphics`; the inner `updateCenterUnit` runs a FULL recalc (may `reloadEntity(true)` a unit) whose result line 567 then discards |
+| `updateCenterUnit` gate `isGraphicsVisible(UNIT)` | requires the UNIT bit paged in: plots beyond `PAGE_IN_DIST_UNIT` (XML 20, `Assets/XML/GlobalDefines.xml:88-89`) from the camera have `m_pCenterUnit=NULL` regardless of fog | `IsGraphicsInitialized && isInViewport` = with viewports off, graphics-initialized alone |
+| `setRevealed` active team (9284-9320): `hideGraphics(ALL)` then `updateGraphics(ALL)` | every updater early-returns (visible==NONE); rebuild happens on a LATER frame when `UpdatePaging` re-requires the bits | synchronous rebuild; `updateCenterUnit` runs twice (566, 518) on the same unit; `m_visibleGraphics` left NONE (dead state while OFF) |
+| Fog flip on the active team (`changeVisibilityCount` 8867-8872) | `updateFog`, `updateMinimapColor`, `updateCenterUnit` — the last refused for a plot outside the UNIT radius until paged in | the same trio; centre unit computed immediately |
+| `bNeedsRealEntity` (`Engine/CvUnit.cpp:319-326`) | no paging term; but `plot()->getCenterUnit(false)==this` is FALSE for every unit on a plot whose UNIT bit is not paged in (its `m_pCenterUnit` was nulled at 9979), so only the active-player clause yields real nodes there | the centre clause depends on graphics-init + viewport only |
+| `CvPlot::setupGraphical` = `showRequiredGraphics` + `updateVisibility` (620-627) from `CvMap::setupGraphical` (`Engine/CvMap.cpp:322-337`; callers `regenerateMap` 954, `toggleDebugMode` 4663, `afterSwitch` 1579, `CvMapExternal::setupGraphical` `DllExport`) | shows the delta of already-required bits | after the sweep both masks are `ALL` → `toShow = NONE` → NO component updater runs; `updateVisibility` (1329-1349) gates on `shouldHaveGraphics()`, then `setLayoutDirty(true)`, the symbol/feature-visibility/route updaters and the non-NPC city's `updateVisibility` — never `updateCenterUnit` |
+| Paging table | plots enrolled in `updateGraphics` (491-494) even when `toShow==NONE`; evicted by INSERTION age (`iSeq` assigned at `AddPlot` only, `UI/CvPlotPaging.cpp:165-175`) | no plot ever holds a handle |
+
+### Code that is NOT gated on paging but only behaves with paging ON
+
+Ranked by confidence. "Re-runs ON" = what re-executes it under paging; "Re-runs OFF" = what (if anything) does.
+
+1. **`CvPlot::updateCenterUnit` gets a periodic driver only until a plot converges.** ON: re-run on every UNIT-bit
+   page-in transition (`showRequiredGraphics` delta → `updateGraphics(UNIT)`, `Engine/CvPlot.cpp:490-491, 523-526`).
+   OFF: the live paging loop re-requires ALL each frame, so a plot whose UNIT bit is not yet visible re-runs
+   `updateGraphics(UNIT)` → `updateCenterUnit` EVERY frame until it renders; once the plot is fully shown the delta
+   is NONE and there is NO periodic driver — only the event callers in §3
+   (`setXY`/`addUnit`/`removeUnit`/`enableCenterUnitRecalc`/fog flips/`setRevealed`/`CvPlot::read`) and the
+   EXE-cadence `CvMapExternal::updateCenterUnit`. ⚑ Confidence: HIGH (code).
+2. **The pre-init hole is CLOSED — paging-off is no longer a latched one-shot.** `showRequiredGraphics` now gates on
+   `isInViewport() && GC.IsGraphicsInitialized()` (488), so a pass that runs before `SetGraphicsInitialized` marks
+   NOTHING visible and defers, instead of setting `m_visibleGraphics=ALL` while the updaters early-returned and
+   leaving `(required ^ visible)=NONE` forever. The live per-frame loop (`UI/CvPlotPaging.cpp:301-322`) re-requires
+   ALL every frame, so the build re-runs once graphics come up and the plot renders — no latch, no lost sweep.
+   `SetGraphicsInitialized` still has no DLL caller (`Defines/CvGlobals.cpp:3240`; `Defines/CvGlobals.h:2049-2052`),
+   so its exact timing is EXE ordering (§8), but it no longer decides whether the map ever renders.
+   ⚑ Confidence: HIGH (code).
+3. **`bNeedsRealEntity`'s centre clause reads `m_pCenterUnit`, which paging NULLs.** With paging ON, `updateCenterUnit`'s
+   early return (9979) makes `getCenterUnit(false)==this` false for every unit on an out-of-radius plot, so
+   `reloadEntity` from `setXY`/head swaps/`setActivePlayer` gives such units the dummy unless active-player-owned
+   (`Engine/CvUnit.cpp:323-325`). OFF: the clause tracks graphics-init + viewport only. ⚑ Confidence: HIGH.
+4. **`setRevealed`'s rebuild is deferred ON and synchronous OFF, and leaves `m_visibleGraphics=NONE` on a plot
+   with live scene objects.** OFF→ON toggle hazard: `getNonRequiredGraphicsMask = (required ^ visible) & visible`
+   is NONE for such a plot (588-591), so the evictor can never select it. ⚑ Confidence: HIGH (code-derived, not
+   runtime-observed).
+5. **`updateFeatureSymbol` / `updateRiverSymbol` have NO periodic caller in either mode.** Outside `updateGraphics`
+   they run only from map-edit setters (`setPlotType` 6990-6993, `setFeatureType` 7162, `setNOfRiver` 6136,
+   `setWOfRiver` 6175) and the viewport spoof timer (`UI/CvViewport.cpp:308`). OFF: once at the sweep + each
+   active-team `setRevealed`. ⚑ Confidence: HIGH.
+6. **Flag symbols repaint only when dirty AND `updateFlagSymbolIfVisible` returns true** (`Engine/CvMap.cpp:511-527`;
+   `Engine/CvPlot.cpp:9853-9860`). ON: a paged-out plot keeps its dirty bit until page-in re-runs `updateFlagSymbol`
+   via `updateGraphics` (526). OFF: while a plot's UNIT delta is non-empty the live loop re-runs `updateFlagSymbol`
+   via `updateGraphics(UNIT)` each frame; once the plot has converged, repaint depends on `setFlagDirty` and the EXE
+   calling `CvMapExternal::updateFlagSymbols`, plus the forced whole-map repaint at the end of a `BRING_INTO_VIEW`
+   (`UI/CvViewport.cpp:375`, §3). ⚑ Confidence: HIGH that the DLL has no periodic OFF-mode driver AFTER convergence;
+   EXE cadence unverified.
+7. **`m_bGraphicalPaging` is indeterminate between `new cvInternalGlobals()` and the first `refreshOptionsBUG`**
+   (`Defines/CvGlobals.cpp:104-135, 3295-3302, 3327-3329`). Any `isGraphicsVisible`/`updateGraphics`/`UpdatePaging`
+   read before `BugInit.init` → `setIsBug` reads garbage. Whether such a read occurs is EXE/Python ordering.
+   ⚑ Confidence: MEDIUM (window exists; reachability unverified).
+8. **`setLayoutDirty` silently un-dirties under paging.** `updatePlotBuilder` gates on `isGraphicsVisible(FEATURE)`
+   (11531-11540), so with paging ON a `setLayoutDirty(true)` on a plot whose FEATURE bit is out of
+   `PAGE_IN_DIST_FEATURES` (XML 15) resets `m_bPlotLayoutDirty=false`. The reverse case of this list (works OFF,
+   drops ON). ⚑ Confidence: HIGH.
+9. **No path re-places an already-set-up node in either mode.** `updateCenterUnit` re-runs only on the page-in
+   DELTA under paging (490-491) and each frame until convergence with paging off (items 1-2); either way
+   `reloadEntity(true)` on a unit whose latch is set is a `kept` that positions nothing (`Engine/CvUnit.cpp:370-373`).
+   A node's position is established once at setup (`SetPosition(plot())`) and thereafter by the ordinary
+   move path — never re-placed by paging. ⚑ Confidence: HIGH.
+10. **Define-name mismatch:** the code reads `PAGING_FRAME_TIME_MS` (`UI/CvPlotPaging.cpp:242`); the XML authors
+    `MAX_PAGING_FRAME_TIME_MS` (`Assets/XML/GlobalDefines.xml:67-68`, itself commented "unused"). The code default
+    (100) is what runs. ⚑ Confidence: HIGH.
+11. **`CvPlot::updateSymbols` is paging-dependent the same way as item 5.** It gates on
+    `isGraphicsVisible(SYMBOLS)` (`Engine/CvPlot.cpp:1418-1423`) and, outside `updateGraphics`, runs only from
+    `setOwner` (6677), `setRevealedImprovementType` (9473), `setRevealedRouteType` (9519) and the whole-map
+    `CvMap::updateSymbols` (`Engine/CvMap.cpp:573-581`; callers `toggleDebugMode` `Engine/CvGame.cpp:4665`,
+    `setActivePlayer` 4859, `afterSwitch` `Engine/CvMap.cpp:1581`). `PAGE_IN_DIST_SYMBOLS=999`
+    (`Assets/XML/GlobalDefines.xml:72-73`) makes the ON gate whole-map in practice. ⚑ Confidence: HIGH.
+12. **`bForce` bypasses the FEATURE gate but not the RIVER gate — and nobody uses the bypass.**
+    `updateFeatureSymbol(bForce)` returns unless `isGraphicsVisible(FEATURE) || bForce` (9655); its three callers
+    (506, 6990, 7162) all pass the default `false`. `updateRiverSymbol(bForce=true)` is passed at `setNOfRiver`
+    (6136), `setWOfRiver` (6175) and the viewport spoof timer (`UI/CvViewport.cpp:308`), but the gate at 9746 has no
+    `bForce` term, so those calls are still refused on a paged-out / pre-init plot. ⚑ Confidence: HIGH.
+13. **`CvCity::getVisibleBuildings` answers "no buildings" for a paged-out city.** It returns
+    `iChosenNumGenerics=0` with an empty list unless `plot()->isGraphicsVisible(CITY)` (`Engine/CvCity.cpp:13246-13250`);
+    ON that is the `PAGE_IN_DIST_CITY` radius, OFF it is graphics-init + viewport. ⚑ Confidence: HIGH.
+14. **`pageGraphicsOut` is reached by two different conditions.** `hideGraphics` calls it only when the mask has
+    dropped to NONE (`Engine/CvPlot.cpp:581-584`, the paged-out plot leaves the table); the OFF sweep's
+    `disableGraphicsPaging` calls it unconditionally after requiring ALL (609) — so with paging OFF no plot holds a
+    handle, and a later `hideGraphics` (from `setRevealed`/`uninit`/`destroyGraphics`) releases nothing.
+    ⚑ Confidence: HIGH.
+
+## 5. Timelines
+
+EXE-owned steps are marked `[EXE]`; their order relative to DLL entry points is not visible from the tree.
+
+**Save load.** `[EXE]` `CvGame::read` → `reset` (`ResetPaging` ×2, `m_bFinalInitialized=false`;
+`Engine/CvGame.cpp:8424-8429, 1057, 1288`) → … `[EXE]` `CvMap::read` → `CvPlot::read` per plot (`m_units.Read`
+11048; ends `updateCenterUnit()` 11174 — refused while graphics are down) → `[EXE]` `CvPlayer::read` per player
+(`CvUnit::read` writes `m_iX/m_iY` raw, `Engine/CvUnit.cpp:18359-18360`; NO `setXY`/`reloadEntity`; a corrupt-group
+repair may `addUnit` → head-swap `reloadEntity`, `Engine/CvPlayer.cpp:16900-16926`) → `CvGame::read` tail
+`setActivePlayer(firstHuman)` (8716-8723; no unit sweep in single player, §2) → `[EXE]` `SetGraphicsInitialized(true)`
+at an EXE-chosen point → `[EXE]` `CvPlayer::setupGraphical` per player (`DllExport`; `reloadEntity()` every unit —
+measured as ~9k contiguous `kept` lines grouped by owner) → `[EXE]` `CvMapExternal::read` sets viewport state
+`LOADING` (`UI/CvMapExternal.cpp:193`) → `[EXE]` `CvGame::update` #1: `onFinalInitialized(false)` (2452-2454) →
+`processActionState` (2473): `LOADING` selects a head unit and `bringIntoView(unit, bForceCenter=true)`
+(`UI/CvViewport.cpp:421-437`) → `BRING_INTO_VIEW` runs `beforeSwitch`/`afterSwitch` iff `m_mode == INITIALIZED`
+(348-361) — with viewports off `CvMap::reset` already set INITIALIZED via `setMapOffset(0,0)`
+(`Engine/CvMap.cpp:293-298`; `UI/CvViewport.cpp:44-49`), yet whether `afterSwitch` actually runs on a load is not
+established from the tree (§8) →
+`UpdatePaging` (2489): ON: distance-sorted `setRequireGraphicsVisible` per frame; OFF: the live per-frame loop →
+`showRequiredGraphics` → `updateGraphics(UNIT)` → `updateCenterUnit` → `reloadEntity(true)` on the chosen centre
+unit — the only `bForceLoad=true` caller (§2) → `createUnitEntity` → `setupGraphical` → `setup` +
+`SetPosition(plot())`. Every load-time real node is created through this `updateCenterUnit` path. `CvGame::onFinalInitialized` also clears every plot's
+visibility and re-registers sight via `CvMap::updateSight(true,false)` (551), so every active-team plot that
+becomes visible runs the `updateFog`/`updateMinimapColor`/`updateCenterUnit` trio then
+(`Engine/CvPlot.cpp:8867-8872`).
+
+**New game.** `[EXE]` `CvGame::init` → `reset` (`ResetPaging`) → NPC `addPlayer` → `AI_init` — creates NO units
+(`Engine/CvGame.cpp:126-462`). `[EXE]` `CvPlayer::init` per player → `baseInit` → `setupGraphical` (no-op unless
+graphics already up; `Engine/CvPlayer.cpp:305-329`). `[EXE or afterSwitch firstSwitch]` `CvMap::init` +
+`generateRandomMap` + `addGameElements` (plot-graphics mutation guarded by `IsGraphicsInitialized`,
+`Engine/CvPlot.cpp:6986`). `[EXE]` `CvGame::setInitialItems` (`DllExport`, `Engine/CvGame.cpp:827-884`) →
+`initFreeUnits` → `CvPlayer::initFreeUnits` → `initUnit` → `CvUnit` ctor (dummy) → `CvUnit::init`: `setXY(bUpdate)`
+[`addUnit` → `updateCenterUnit`, refused if graphics down] → `joinGroup` → head-swap `reloadEntity` →
+`updateCenterUnit` → `reloadEntity()` [`bNeedsRealEntity` true via the active-player clause even with
+`m_pCenterUnit` NULL, so `createUnitEntity` runs pre-graphics and `setupGraphical` early-returns without latching
+while graphics are down]. `[EXE]` `SetGraphicsInitialized(true)`. `[EXE]` `CvMapExternal::setupGraphical` →
+`CvViewport::setupGraphical` (mode INITIALIZED, `UI/CvViewport.cpp:218-222`) → `CvMap::setupGraphical` →
+`CvPlot::setupGraphical` (shows nothing: both masks NONE). `[EXE]` `setFinalInitialized` — body only prints
+(`Engine/CvGame.cpp:4741-4747`); the flag is set by `onFinalInitialized` from `CvGame::update` on both paths (472,
+2452-2454). `[EXE]` `CvGame::update` #1 → `onFinalInitialized(true)` → `UpdatePaging` → … →
+`updateCenterUnit` → `reloadEntity(true)` → real node + `setupGraphical` (`SetPosition(plot())`). The DLL-internal `regenerateMap` fixes the
+order units-before-`CvMap::setupGraphical` for the regen case (`Engine/CvGame.cpp:943-957`).
+
+## 6. The working model, and where the tree differs from it
+
+⚠ **This is a MODEL, not a ruling.** It is the owner's stated expectation of how rendering works, offered as a
+lens for reading the tree — not a design the tree is required to satisfy, and not licence to change the code
+toward it. Nothing below is a defect by virtue of appearing here; each item is a place where the tree behaves
+differently from the model, recorded so the difference is known rather than assumed away.
+
+The model, paging OFF (owner, verbatim): *"every unit that is on top of its stack and not in fog of war should
+have its graphics rendered on the plot it stands on; everything else should NOT be rendered until required, and
+then rendered ON the plot, never by moving graphics from the centre plot to that plot."*
+
+Where the tree differs, DLL-side (whether the EXE draws a non-centre real node is §8):
+
+1. **Non-centre active-player units get REAL nodes.** The `|| getOwner() == activePlayer` clause in
+   `bNeedsRealEntity` (`Engine/CvUnit.cpp:310-317`) builds a node for every active-player unit on a fog-visible
+   plot, top of stack or not (on a populated load most units still hold the dummy — only centre + active-player
+   units get real nodes, the split readable off `[GFX] entity`). The reason: the EXE dereferences a
+   SELECTED unit's entity at offset `0x24`, and `selectGroup`(alt/ctrl)/`SELECT_HEALTHY`/`nextPlotUnit`/
+   `cycleSelectionGroups`/`FLYOUT_SELECT_UNIT` insert non-centre units with no entity check
+   (`Engine/CvGame.cpp:2812-2851`; `Engine/CvGameInterface.cpp:1000-1020, 1695-1727`); removing the clause was
+   measured to crash select-all with `faultAddr=0x24`.
+2. **Nodes are built against a laid-out plot, not flown in.** Paging-off now runs `updateGraphics` per plot each
+   frame — the same path as paging-on (§4) — and `showRequiredGraphics` defers any pre-init pass (488), so a
+   unit's scene node is created and set up against a plot the landscape has already built. `setupGraphical`
+   places the node with `SetPosition(plot())` and nothing else (`Engine/CvUnit.cpp:1089-1098`) — never
+   `QueueMove`/`ExecuteMove`, whose shown-movement semantics manufacture the run-from-mid-map-to-plot the model
+   forbids — and ordinary movement is the `setXY` graphics block. `groupMove` additionally issues a timed
+   `ExecuteMove` to a member that could not move (`Engine/CvSelectionGroup.cpp:3638-3639`) and to every member at
+   the end of the move (3677).
+3. **A unit that stops being centre / drops into fog is never un-rendered by the DLL.** `updateCenterUnit`
+   reloads only the NEW centre unit (`Engine/CvPlot.cpp:10000-10015`); a fog-out only NULLs `m_pCenterUnit`; the
+   DLL never calls `setVisible` on a unit entity. A real node is downgraded only by `setXY`'s fog-edge test
+   (14054-14061), a group head swap (`Engine/CvSelectionGroup.cpp:4826-4833, 4866-4877`), or a bulk
+   `reloadEntity()` sweep.
+4. **A required unit that already holds a node is never (re)positioned.** `reloadEntity` → `kept` skips
+   `setupGraphical` when the latch is set (`Engine/CvUnit.cpp:370-373`); a fog→visible flip of such a
+   unit issues no positioning call at all.
+5. **With `ENABLE_DYNAMIC_UNIT_ENTITIES=0` every unit holds a real node unconditionally** — fog, viewport and
+   stack position ignored (`Engine/CvUnit.cpp:208-210, 321`).
+6. **The ctor builds a node before the unit has a plot** — every unit in non-dummy mode, and the two bootstrap
+   entities (`g_dummyUnit`'s own node and the shared `g_dummyEntity`) in dynamic mode. The ctor pre-assigns
+   `m_iX/m_iY = INVALID_PLOT_COORD` before `createUnitEntity`, so the window is deterministic (`plot()` is NULL)
+   rather than garbage — but the node is still created positionless and depends on the later
+   `setupGraphical` `SetPosition` for placement (`Engine/CvUnit.cpp:182-240`).
+7. **`BRING_INTO_VIEW` performs a whole-map rebuild even with viewports off.** `m_mode` is INITIALIZED from
+   `CvMap::reset` (`Engine/CvMap.cpp:293-298`), so alt-numpad pans, ctrl-alt-C and the `LOADING` state
+   (`UI/CvViewport.cpp:126-210, 421-437`) reach `beforeSwitch`/`afterSwitch` (348-361): every real unit node
+   destroyed and recreated, `RebuildAllPlots`, `setLayoutDirty` on every plot, `createUnitEntity`+`setupGraphical`
+   for every non-dummy unit regardless of stack-top or fog (`Engine/CvMap.cpp:1413-1596`).
+8. **A centre-unit change mid-`groupMove` runs `setupGraphical` inside the walk window.**
+   `enableCenterUnitRecalc(true)` (3668-3669) runs `updateCenterUnit` → `reloadEntity(true)` → `setupGraphical`'s
+   `SetPosition(plot())` before the group's `ExecuteMove` loop, and `setupGraphical` has no `isMidMove()`
+   guard (`Engine/CvUnit.cpp:1089-1098`).
+9. **Rendering-when-required is event-driven once a plot has converged** (§4 item 1): after the live paging-off
+   loop has fully shown a plot, a stack change without a `setXY`/`addUnit`/`removeUnit`/fog flip on it — e.g. the
+   centre unit dies via a path that does not `removeUnit(bUpdate)`, or a `toggleDebugMode` that changes
+   `isActiveVisible(true)` without an `updateCenterUnit` sweep (`Engine/CvGame.cpp:4657-4667`) — is re-presented
+   only when the EXE calls `CvMapExternal::updateCenterUnit`.
+
+## 7. Doc contradictions (fix-the-doc items)
+
+| Doc cite | Claim | Code cite | Truth |
+|---|---|---|---|
+| `docs/reference/memory-footprint.md:125-127` | a real entity only for ON-SCREEN units; counted under `[PERF/entity]` | `Engine/CvUnit.cpp:310-317`; `Engine/CvPlot.cpp:4948-4952`; `UI/CvGraphicsTrace.cpp:169` | The criterion is `isActiveVisible(false)` (fog), not screen; the count is the `[GFX] entity` line at level 4; no `[PERF/entity]` tag exists. |
+| `Assets/XML/GlobalDefines.xml:62-69` (comment) | `MAX_PAGING_FRAME_TIME_MS` is unused | `UI/CvPlotPaging.cpp:242` | The mechanism is live under `PAGING_FRAME_TIME_MS`, which is not authored; the XML key is inert. |
+| `docs/plans/parked/multimap-zone-rework.md:14, 49` | proactive eviction shipped via `PAGING_RESIDENT_SOFT_CAP`; zone paging can "reuse the shipped proactive eviction" | `UI/CvPlotPaging.cpp:256-263`; `Assets/XML/GlobalDefines.xml:47-48` | The branch exists but the authored cap (3,000,000) is compared to a PLOT count; it can never trigger (`docs/reference/memory-footprint.md` states the same). Eviction is `NeedToFreeMemory`-only. |
+| `docs/plans/parked/turn-time-optimization.md:612` | `isActiveVisible` is a single count read | `Engine/CvPlot.cpp:4932-4944` | It also ORs `getStolenVisibilityCount`. |
+| `docs/specs/json.md:1122-1125` | `getArtInfo(iIndex, eEra, eStyle)` resolves a civilization art-style override first | `Infos/CvUnitInfo.cpp:207-227` | `eStyle` is unused; the function walks era bands then falls back to the unit's art tag. |
+| `Engine/CvGame.cpp:4741, 2439-2441` (comments) | `setFinalInitialized` fires for a NEW GAME ONLY and marks final init | `Engine/CvGame.cpp:4741-4746, 472, 2452-2454` | Its body only prints; `m_bFinalInitialized` is set by `onFinalInitialized` from the first `CvGame::update` on BOTH paths. |
+| `Tools/CvHttpServer.cpp:8-9`; `AI/BetterBTSAI.cpp:52` (comments) | `/computed/perf` serves the memory gauge | `Tools/CvHttpServer.cpp:409-419` | No such route exists in the route table; `docs/spine.md:949-952` is the correct side. |
+
+## 7b. The run-from-origin reconciliation — MEASURED engine behaviour (owner mechanism, runtime-verified)
+
+**The engine renders a graphics assignment it must reconcile as a VISIBLE MOVE from the world origin (= the
+map centre: `plotXToPointX`'s `-fWidth/2` term) to the unit's plot, at the node's first presentation — and NO
+DLL input prevents it.** Each statement below is runtime-verified on the `[GFX]` scene trace, not inferred:
+
+- The reconciliation fires at the plot's centre-unit assignment: every `notifyEntity` from a stack
+  manipulation is followed within ~30-80ms by a `centerUnit` flip and by engine reads of the new centre's
+  state; a queued walk survives ~23 minutes un-drained until such a flip presents it.
+- The engine resolves `CvUnit::canMove` / `hasMoved` / `isWaiting` by mangled name (present in the EXE image)
+  and reads them at setup and at every centre flip — but the walk is NOT gated on them: a full session
+  answering `canMove=false` for every unit still jogged every fresh centre node in.
+- Position inputs are accepted and ignored for a never-presented node: `SetPosition` / `updatePosition` /
+  `QueueMove`+`ExecuteMove(0)` in every ordering (before and after `setup()`), with coordinates and the plot
+  transform verified live at call time, leave the first presentation walking from origin. A unit's own MOVE
+  path (`setXY` → `QueueMove`/timed `ExecuteMove`) is the one sequence that leaves a node position-synced.
+- Node creation timing does not matter (pre-init ctor births under `ENABLE_DYNAMIC_UNIT_ENTITIES=0`, post-init
+  sweeps, paced or flooded schedules — all jog), churn does not help (C2C's destroy/recreate-per-reload,
+  restored verbatim, MULTIPLIED runners in both paging modes: every fresh node's first presentation walks),
+  and both paging modes exhibit it (`paging=1` sessions traced).
+- Load-time entity creation is a single-frame burst from the `CvPlayer::setupGraphical` sweep (active-player
+  clause), not from the paging walk; `beforeSwitch`/`afterSwitch` does NOT run on a load (zero `destroyEntity`
+  lines across load traces — closes the former open question).
+
+The structural invariant the ctor now honours (no `createUnitEntity` before the unit stands on a plot; lazy
+dummy bootstrap in `reloadEntity`) removes the plotless first assignment but does not remove the jog. The
+un-eliminated remainder is engine-internal: the node's spawn position and the animate-the-delta behaviour.
+
+## 8. Open questions (not decidable from the DLL)
+
+- **Whether `CvMap::afterSwitch` runs on a load.** The `LOADING` → `bringIntoView(force)` → `BRING_INTO_VIEW` →
+  `afterSwitch` chain exists with `m_mode` INITIALIZED (`UI/CvViewport.cpp:421-437, 348-361`; `Engine/CvMap.cpp:293-298`),
+  but whether it fires on a load is not decidable from the tree. Candidates for it NOT firing: `CvMapExternal::read`
+  (virtual, not `DllExport`, no DLL caller) not invoked; no selectable unit at that frame.
+- **Whether the EXE draws a REAL node that is not the plot's `getCenterUnit()`** — the active-player clause builds
+  them; the renderer's use of `getCenterUnit()` is inside the EXE.
+- **Whether the EXE keeps drawing a real node whose plot fell into fog**, and what it does with `isLayoutDirty` /
+  `isLayoutStateDifferent` / `setLayoutStateToCurrent` (all `DllExport`, no DLL reader).
+- **What the EXE reads from a `CvUnit` at `createUnitEntity` time** (the ctor now guarantees
+  `m_iX/m_iY = INVALID_PLOT_COORD` there, so a position read gets a deterministic no-plot, but what the EXE does
+  with the rest of the not-yet-`reset` unit is unknown), and whether `createUnitEntity` re-binds a dangling
+  `m_pEntity` after `beforeSwitch`'s `destroyEntity` (which does not null it).
+- **Cadence of the EXE's calls to `CvMapExternal::updateCenterUnit` / `updateFlagSymbols` / `setupGraphical`** — the
+  only possible periodic re-run sources for centre-unit and flag repaint with paging OFF.
+- **What the EXE dereferences at entity offset `0x24` for a selected unit**, and whether at insert time or later;
+  the only DLL evidence is `CvGame::selectUnit`'s asserts (`Engine/CvGame.cpp:2771, 2798`) and the measured crash.
+- **Whether `getGroup()` can be NULL when `setupGraphical` runs** (`Engine/CvUnit.cpp:1077`, unguarded deref).
+- **The numeric `gDLL->getMillisecsPerTurn()`** (EXE virtual), hence the real duration of `groupMove`'s
+  `ExecuteMove` (`MISSION_MOVE_TO iTime=4`, `Assets/XML/Units/CIV4MissionInfos.xml:7-11`).
+- **Whether the billw multi-unit refresh concern is still real.** `setupGraphical` no longer issues
+  `ExecuteMove(0,false)` (its shown-movement semantics manufactured the run-from-origin; §2, §6 item 2). billw's
+  2019 observation — without it, only one figure of a stack showed and the rest appeared ~10s later — was made
+  against graphics paging ON (verified in the C2C archive: commit `d9e623416`, "fix(Paging V2): multi-unit
+  graphics work correctly"; the pre-billw body was `setup()` only, so under the dummy system no placement call
+  ever existed in this path before the `SetPosition` above), whose page-in churn retries setup continually, and
+  may itself have been a symptom of the then-unplaced nodes. His test block shows `SetPosition(plot())` among
+  the candidates that did NOT cure his refresh symptom under paging ON — refresh and placement are different
+  questions. A late-figures
+  symptom seen now, under paging OFF and `SetPosition` placement, is a NEW observation to diagnose fresh — if a
+  refresh is genuinely needed it must be a non-movement mechanism, never the `ExecuteMove` back. The one
+  remaining possibly-empty-queue caller is `groupMove`'s could-not-move member
+  (`Engine/CvSelectionGroup.cpp:3638-3639`).
+
+## 9. The Firaxis reference contract (vanilla BTS source, `<BTS install>/CvGameCoreDLL/`)
+
+The original Firaxis DLL — the code the closed EXE ships with and renders correctly against — defines the
+contract. Traced in full (call census + verbatim bodies); the invariants, cited to vanilla source:
+
+- **The DLL positions a unit node exactly twice in its life**: once via the `SetPosition` arm of the `setXY`
+  called from `init` (the entity already exists — ctor-created — and `setup()` runs AFTER, `CvUnit.cpp:107-111`),
+  and thereafter only via `QueueMove`+`ExecuteMove` pairs during actual movement. On a LOAD the DLL issues **no
+  position at all**: the EXE calls the DllExport `CvPlayer::setupGraphical` → per-unit `setupGraphical()` →
+  bare `setup()`, and **the engine's `setup()` reads the unit's coordinates itself and places the node**
+  (`CvPlayer.cpp:738-759`; `CvUnit::read` is pure deserialization, `CvUnit.cpp:11254`).
+- **`setupGraphical` is `setup()` + the intercept `airCircle` and NOTHING else** (`CvUnit.cpp:409-422`). No
+  `ExecuteMove`, no position verb. `ExecuteMove` exists at exactly two sites in the whole vanilla tree:
+  `groupMove` (flushing queued moves, `CvSelectionGroup.cpp:3092,3105`) and `updateCombat`
+  (`ExecuteMove(0.5f,true)` before `AddMission`, `CvUnit.cpp:1375`). An empty-queue `ExecuteMove` at setup —
+  the billw C2C refresh — is a call shape the reference does not contain.
+- **A centre-unit change touches no entity, ever**: `setCenterUnit` = pointer + `updateMinimapColor` +
+  `setFlagDirty` + `setInfoBarDirty` (`CvPlot.cpp:7773-7791`). The flag is the centre unit's derivative,
+  rebuilt by destroy/`create(player)`/`setPlot(flag, plot)`/`updateUnitInfo` under the EXE-driven dirty sweep
+  (`CvPlot.cpp:7650-7742`; `CvMap::updateFlagSymbols` has no in-DLL caller).
+- **Never called by vanilla on a unit entity**: `addEntity` (declared, zero callers), `updatePosition` (used
+  ONLY on feature/route/river symbols), `MoveTo`, `PlayAnimation`, `StopAnimation`, `setVisible` (one call,
+  on a city). A fix reaching for any of these is outside the contract.
+- **Selection makes zero entity calls** except `addUnit`'s `NotifyEntity(MISSION_MULTI_SELECT)` fan on the
+  ownerless (NO_PLAYER) UI selection group (`CvSelectionGroup.cpp:3792-3847`); `selectUnit`/`selectGroup`/
+  `cycleSelectionGroups` only mutate the selection list.
+- **Vanilla `reloadEntity` exists** (destroy → create → `setupGraphical`, `CvUnit.cpp:68-82`) and is called
+  ONLY for art rebuilds (warlord attach, `setLeaderUnitType`) — never from centre-unit changes; position
+  survives a rebuild because the engine's `setup()` re-reads the unit's plot.
+- ⚠ **The dummy-entity system (C2C) is structurally outside this contract**: it creates real entities after
+  the two placement moments the contract provides (birth `setXY`; load-time pre-existing entities placed by
+  the engine's init/setup). Every S2S "run in from world origin" observation traces to presentations of nodes
+  introduced outside those two moments — see §7b for the measured behaviour.
+
+## 10. See also
+
+- [superseded-ideas.md #42](../architecture/superseded-ideas.md) — why nothing can be shared or reused across
+  the boundary: the 26 + 71 virtuals carry no instancing primitive, so residency (paging/viewports) and art
+  payload are the only two dials.
+- [memory-footprint.md](memory-footprint.md) — `shouldHaveGraphics() = IsGraphicsInitialized() && isInViewport()`
+  with the `isRevealed` clause commented out (`Engine/CvPlot.cpp:612-615`), the deliberate `PAGE_IN_DIST_* = 999`
+  for the Low-cost components, and the inert soft cap (§4).
+- [special-systems.md](special-systems.md#the-great-wall-render--compiled-out-on-purpose) — the `THE_GREAT_WALL`
+  off-switch on `beforeSwitch`/`afterSwitch` (§2).
+- [spine.md](../spine.md) — the `[GFX]` domain's tiering and the measured volume of the per-pass `centerUnit`
+  line (§3).
+- [multimap-zone-rework.md](../plans/parked/multimap-zone-rework.md) — the parked zone plan keeps `CvViewport` +
+  `CvPlotPaging` and would replace `UpdatePaging`'s distance marking with zone membership; its eviction premise is
+  §7.

--- a/docs/reference/yields-growth.md
+++ b/docs/reference/yields-growth.md
@@ -59,10 +59,59 @@
   project is effectively single-city built. Changing that is a post-migration redesign, not a #430 item.
 - **Hammers/turn** = `max(1, extraYield + overflow(if flag) + foodSurplus(if FoodProduction) + (baseYieldRate +
   specialistYield)·baseYieldRateModifier/100)`. `isDisorder()` → 0. Process-mode converts to gold/science/culture
-  (no overflow).
+  as a live rate (no accrual); a NON-converting process is idle and banks overflow instead (§ The order queue).
 - **Overflow cap** = `getYieldRate(PRODUCTION) × CityScreen__ProductionOverflowLimit` (default **2** — 2× base/turn);
   beyond cap → gold at `MAXED_{UNIT,BUILDING,PROJECT}_GOLD_PERCENT`. Feature production (chop hammers) banks
   alongside; both cleared each turn.
+### The order queue — a PROCESS may only ever stand ALONE
+
+The queue holds `ORDER_TRAIN` / `ORDER_CONSTRUCT` / `ORDER_CREATE` / `ORDER_MAINTAIN` (a process) / `ORDER_LIST`.
+The AI **queues rather than re-deciding per completion**
+([ai-build-queue-parity.md](../plans/parked/ai-build-queue-parity.md)): `AI_chooseBuilding` appends construct
+orders up to `AI_BUILDING_SHORTLIST_DEPTH`, and `doProduction` re-enters `AI_chooseProduction` when the queue
+empties. **A process is the exception at every point below, because it is the one order that NEVER COMPLETES.**
+
+- ⛔ **A PROCESS MAY ONLY EVER STAND ALONE IN AN AI QUEUE (owner): *"idle should not be possible to add unless
+  there is literally nothing else."*** Enforced at both ends of `pushOrder` — the `ORDER_MAINTAIN` case REFUSES
+  the push when an AI/automated queue already holds any non-process order (`[CIT/push/reject]
+  reason=queueNotEmpty`), and the tail purge pops EVERY queued process wherever it sits the moment a real order
+  joins. Humans keep the free hand and manage their own queue.
+  ⚑ **The failure it closes is the SANDWICHED process:** one sitting BETWEEN real orders is never reached at the
+  head, and because the re-decide fires on the queue EMPTYING, nothing ever strips it — the city locks on it
+  permanently, for the rest of the game.
+  ⚠ **Whether the push LANDED is read off the QUEUE LENGTH, never assumed from having asked** —
+  `AI_chooseProcess` returns the queue delta, because a decision-cascade rung that returns on a bare `true` ends
+  the entire decision having set nothing.
+- ⛔ **A PROCESS HAS A FAKE ONE-TURN COMPLETION TIME AT ALL TIMES (owner).** `getOrderProductionTurnsLeft`
+  returns **1** for `ORDER_MAINTAIN`, and `getTotalProductionQueueTurnsLeft` counts it as one turn instead of
+  reading `getProductionNeeded` (`MAX_INT` for a process). ⚑ The reason is that both feed SUMS shared with real
+  orders: the queue total bails to **999** for any order needing >999 hammers, so a single queued process made
+  the contract broker read `turns=1000` for a unit costing six hammers, collapsing that city's bid.
+- ⛔ **A PROCESS NEVER EATS THE COMPLETION OVERFLOW (owner: *"idle eats the remaining production, and then the
+  cycle repeats"*).** `doProduction`'s completion loop breaks before `changeProduction(getOverflowProduction())`
+  when the new head is a process. ⚑ `changeProduction` routes the hammers through the process's
+  `productionToCommerce` rates — and `PROCESS_IDLE` declares NONE — so the overflow was converted at zero and
+  then cleared: destroyed outright. Breaking leaves it BANKED, and a process head returns from `doProduction`
+  before the per-turn overflow clear, so it survives to the next real order.
+- ⛔ **AN IDLE ORDER BEHAVES AS NO ORDER (owner).** A process whose `conversion` block is empty converts
+  nothing (`CvProcessInfo::convertsProduction()` is false), so `doProduction` **banks the city's hammers as
+  overflow** exactly as the no-order path does, rather than discarding them. ⚑ **The rule is about IDLE
+  itself, not about who selected it** — a human parking a city and an AI falling back to it get the same
+  answer, and the production survives to whatever the city can finally build. ⚠ A **converting** process
+  accrues nothing here by design: its conversion is a live rate read off the city, never an accrual.
+  ⚑ **Why this is load-bearing rather than tidiness:** `PROCESS_IDLE` is the only process
+  `TECH_GAME_START` carries, and every real one is unlocked by a tech (`PROCESS_WEALTH_MEAGER` ←
+  `TECH_COOPERATION`, `PROCESS_RESEARCH_MEAGER` ← `TECH_ORAL_TRADITION`, both ← `TECH_LANGUAGE`) — the domain
+  is built purely from `enables` edges, so a low-tech player's ONLY reachable process is idle. Discarding
+  production there is a trap with no exit: no hammers, so no building, so no economy, so no tech.
+- ⚖ **A QUEUED PROCESS IS RE-DECIDED EVERY TURN (owner): *"if PROCESS is being run, recalc has to happen for
+  that city every turn as long as process is run."*** `doProduction` re-enters `AI_chooseProduction` when a
+  process sits ANYWHERE in the queue, and `AI_chooseProduction` strips every `ORDER_MAINTAIN` before deciding
+  (`[CIT/dropProcess]`) — **a process is a fallback, never a commitment.** The end-of-cascade fallback re-adds
+  one only when there is still nothing better this turn. ⚠ The strip pops with `bChoose = false`, so it never
+  re-enters the chooser — derived data must never drive a loop
+  ([ai-architecture-north-star.md](../plans/parked/ai-architecture-north-star.md) §2.4).
+
 - **Hurry:** Buy (gold, `getGoldPerProduction>0`) or Whip (pop + `m_iHurryAngerTimer`, `getProductionPerPopulation>0`);
   `maxHurryPopulation = pop/2`. **Decay** (`doDecay`, human cities only): non-head queued items bleed
   `BUILDING_PRODUCTION_DECAY_PERCENT`% per `BUILDING_PRODUCTION_DECAY_TIME` turns (speed-scaled).

--- a/docs/specs/json.md
+++ b/docs/specs/json.md
@@ -1130,6 +1130,18 @@ Empire-agnostic self-description. Read directly — never summed or cascaded.
   > not degrade to "no art": a max animation speed of **0** is a unit that plays its walk cycle and never
   > translates, and **0** group definitions is a formation with no per-member offsets, so the models stack on
   > one another.
+  > ⛔ **AND THE SIX ANSWER THE AUTHORED MESH-GROUP BLOCK *ALONE* — a value from another system is the same
+  > defect wearing a plausible name.** The EXE reads a figure COUNT and the per-member OFFSETS across these
+  > calls and lays one formation out of them, so the layout is coherent only while all of them come from the one
+  > block. ⚑ The trap is a name collision: Size Matters' `groupRank()` also says "group", and
+  > `CvUnit::getGroupSize` returned it whenever `GAMEOPTION_COMBAT_SIZE_MATTERS` was on — a merge/size rank
+  > summed from the combat classes, whose consumer is `getUnitCountSM`, handed to the renderer as a figure
+  > count the art cannot supply. That is the pivot rule in the `sizeMatters` block below failing on the ART
+  > plane: **one `DllExport` read meaning two different things depending on a player toggle.**
+  > ⚠ It stayed invisible because the whole family answered `0/-1` while the mesh-group data was uncarried —
+  > the formation loop never ran, so the override had no consumer. **Carrying the data is what made it
+  > reachable**, which is the shape to expect from any stub this family is restored from: the bug is not in the
+  > restoration, it is the pre-existing wrong answer the restoration finally delivers to someone.
   > ⛔ It is NOT covered by the ART CARVE-OUT above, which carves out the art DEFINES and asset files — these are
   > the unit's own numbers, authored in the unit XML, that merely reference a define.
   > **⛔ ART IS NOT A DECIMAL (owner) — the animation numbers carry NO fixed-point scale.**

--- a/docs/spine.md
+++ b/docs/spine.md
@@ -889,6 +889,18 @@ events and formats the raw typed payload to text **only when its gate is on** (a
 - **Level semantics:** 1 = headline (`begin`/`best`/`decision`), 2 = per-decision (`score`/`order`/`act`), 3 =
   per-candidate (`cand`/`skip`), 4 = inner-loop (a genuine fire hazard — CTB emits 10k+ lines/turn at 4). Owner plays
   at 3.
+- **⛔ A DIAGNOSTIC BUILT FOR A DEBUGGING SESSION MOVES TO LEVEL 4 WHEN THAT SESSION ENDS (owner): *"we do not
+  need diagnostics like this; 4 is where trace logs belong after we have finished debugging."*** The tiers above
+  describe what a line COSTS; this says what it is FOR. **Because the owner plays at 3, anything at 1–3 is on
+  during ordinary play** — so a trace kept at its investigation-time tier does not merely sit there, it runs
+  forever, in every session, for a question nobody is asking any more.
+  ⚑ **The instrument is KEPT, not deleted** — that is the point of moving it rather than removing it. It cost
+  real effort to build, it is the thing that makes the same class of defect findable next time, and at 4 it is
+  free until someone raises the gate. ⇒ Closing an investigation has a step: **re-tier its diagnostics to 4**.
+  ⚠ The cost of skipping it is measurable, not theoretical: the `[GFX]` domain left at its investigation tiers
+  (2 and 3) wrote a **133 MB** `Graphics.log` in one ordinary session — 77,245 `centerUnit` lines per 8 MB,
+  including a full-map sweep of plots that draw no units at all — which is exactly the legibility loss the
+  own-file rule below exists to prevent, arriving through the level gate instead.
 - `OutputDebugString` is `#define`d to nothing under `FINAL_RELEASE` — it fires only in Release/Assert/Debug (any
   "fires in FinalRelease, CRIT" framing is wrong for the shipped build).
 


### PR DESCRIPTION
Fixes #496. Fixes #497.

## #496 — AI cities were not building anything

A **PROCESS could sit SANDWICHED between real orders** in the production queue. A process never
completes, and `doProduction` only re-entered `AI_chooseProduction` when the queue **emptied**, so a
queued process was unreachable forever and the city locked on it for the rest of the game.

The financial-trouble branch is what preserved it. A broke AI falls through the whole decision cascade to
the end-of-cascade process fallback, and `pushOrder`'s tail purge — which removes a process the moment a
real order joins — is skipped under `AI_isFinancialTrouble`. Broker-pushed unit orders then landed
around it, producing exactly the reported shape: *idle wedged between the first wanderer and the second*.

Closed at every point it could enter or do damage:

- `pushOrder` **refuses** a process when an AI/automated queue already holds any non-process order
  (`[CIT/push/reject] reason=queueNotEmpty`). Humans keep the free hand over their own queue.
- The tail purge walks the **whole queue** instead of testing only the head — head-only is what left a
  sandwiched process standing.
- `AI_chooseProduction` **strips** every queued process before deciding (`[CIT/dropProcess]`); the
  fallback re-adds one only if nothing better exists. The pops pass `bChoose=false`, so stripping never
  re-enters the chooser (advisory data must never drive a loop).
- `doProduction` re-decides when a process sits **anywhere** in the queue, not only at the head.
- `AI_chooseProcess` reports whether the push actually **landed**, read off the queue length. It
  previously returned a bare `true`, so a cascade rung could end the entire decision having set nothing.

**A process now reports a fake one-turn completion time** rather than `MAX_INT`, in both
`getOrderProductionTurnsLeft` and the `getTotalProductionQueueTurnsLeft` walk. Those feed sums shared with
real orders: the queue total bails to **999** for any order needing >999 hammers, so a single queued
process made the contract broker read `turns=1000` for a unit costing **six hammers**, collapsing that
city's bid.

### An idle order now behaves as no order

A process whose `conversion` block is empty converts nothing, so `doProduction` **banks** the city's
hammers as overflow exactly as the no-order path does, instead of discarding them. `changeProduction`
routes hammers through the process's `productionToCommerce` rates and `PROCESS_IDLE` declares none — so
the production was being **destroyed outright**, every turn.

This is a property of idle rather than of who selected it, so a human parking a city gets it too.

It is load-bearing because `PROCESS_IDLE` is the only process `TECH_GAME_START` carries. Every real one is
unlocked by a tech — `PROCESS_WEALTH_MEAGER` via `TECH_COOPERATION`, `PROCESS_RESEARCH_MEAGER` via
`TECH_ORAL_TRADITION`, both behind `TECH_LANGUAGE` — and the processes domain is built purely from
`enables` edges. **A low-tech player's only reachable process is idle**, so discarding production there is
a trap with no exit: no hammers, no building, no economy, no tech.

## #497 — could not build fishing boats

`CvPlot::reset` seeded `m_ePlotType` with the legacy `PLOT_OCEAN` default. `reset` is the
announced-nothing state, so a real value there meant `setPlotTypeInternal`'s no-op guard **swallowed the
type fact for every WATER plot**, on load and on generation alike. Those plots' `IS_WATER` verdict bits
never derived, and every coastal plot read `HAS_COAST` false map-wide. Seeding `NO_PLOT` lets the fact
announce itself.

## Also included

The **unit rendering pipeline reference** (`docs/reference/unit-rendering.md`) and the hard rules it
established in `AGENTS.md`, plus the doc-reading rule that work paid for. Carries one crash fix found by
the same census: `processContracts` logged narrow `CvString`s with `%S`, so the CRT scanned a narrow
buffer as `wchar_t*` for a two-byte terminator it might never find — the paging-toggle end-turn access
violation.

## Verification

`Assert rebuild` green (45.2s). `python Tools/verify-docs.py` clean — 1434 intra-repo links and anchors
resolve.

**Not observed in-game.** The save this was diagnosed on is unrecoverable for the purpose: its AI players
have already bottomed out at 0% research after over-producing units they cannot pay upkeep on, so their
cities are broke whether or not idle burns their hammers. **The idle fix wants a fresh game to show
anything.**

What a tester should watch, none of which appears in the pre-fix logs:

- `[CIT/push/reject] … reason=queueNotEmpty` and `[CIT/dropProcess]` should start appearing in `CityAI.log`.
- `[CIT/order] action=maintainProcess` should collapse. On the diagnosed save it was **163 of 227** — 72%
  of every AI production decision was "run a process".
- AI cities should stop reading `turns=1000` in `ContractBroker.log` bids on six-hammer units.
- Coastal cities should offer work boats again (#497).

## Not fixed here

The disease upstream of all of it: AI empires producing ~2 commerce/turn while paying upkeep on a mountain
of cheap units, so their research target never completes — 7 techs each, +0 across 21 turns, against the
human's +2. Unit production choice has **no cost term at all**, filed as #498 with the shape question
(gate-and-tie-break versus a score term) left for a maintainer ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DHU3jFQG5Ry9YNXyLR8yX
