### PR TITLE
fix(#367): emphasis now decides food vs hammers; wildlife no longer besieges plots

### DIFF
--- a/Sources/AI/CvCityAI.cpp
+++ b/Sources/AI/CvCityAI.cpp
@@ -214,6 +214,9 @@ namespace
 #define BUILDINGFOCUSINDEX_CAPITAL				17
 
 #define NUM_REAL_BUILDINGFOCUS_FLAGS			18
+
+//	How many buildings the city's own frontier must offer before it emphasizes production over growth.
+#define AI_EMPHASIZE_BUILD_FRONTIER				3
 //	Pseudo flags which represent combinations used in the calculation
 //	and are not independent so have to be accumulated separately
 #define BUILDINGFOCUSINDEX_GOLDANDRESEARCH		18
@@ -8788,16 +8791,8 @@ void CvCityAI::AI_doHurry(bool bForce)
 }
 
 
-// Improved use of emphasize by Blake, to go with his whipping strategy - thank you!
 void CvCityAI::AI_doEmphasize()
 {
-	//Note from Blake:
-	//Emphasis proved to be too clumsy to manage AI economies,
-	//as such it's been nearly completely phased out by
-	//the AI_specialYieldMultiplier system which allows arbitary
-	//value-boosts and works very well.
-	//Ideally the AI should never use emphasis.
-
 	PROFILE_FUNC();
 	FAssert(!isHuman());
 
@@ -8812,11 +8807,28 @@ void CvCityAI::AI_doEmphasize()
 	const bool bCultureVictory = GET_PLAYER(getOwner()).AI_isDoVictoryStrategy(AI_VICTORY_CULTURE2);
 	const int iPopulationRank = findPopulationRank();
 
+	std::vector<int> availableBuildings;
+	getAvailableBuildings(availableBuildings);
+	const bool bLotToBuild = (int)availableBuildings.size() >= AI_EMPHASIZE_BUILD_FRONTIER;
+
+	const bool bRoomToGrow =
+		netHappiness(0) > 0
+		&& netHealth(0) > 0
+		&& AI_countGoodTiles(true, true) + AI_countGoodSpecialists(true) > 0;
+
 	for (int iI = 0; iI < GC.getNumEmphasizeInfos(); iI++)
 	{
 		bool bEmphasize = false;
 
-		if (AI_specialYieldMultiplier(YIELD_PRODUCTION) < 50)
+		if (GC.getEmphasizeInfo((EmphasizeTypes)iI).getYieldChange(YIELD_PRODUCTION) > 0)
+		{
+			bEmphasize = bLotToBuild;
+		}
+		else if (GC.getEmphasizeInfo((EmphasizeTypes)iI).getYieldChange(YIELD_FOOD) > 0)
+		{
+			bEmphasize = !bLotToBuild && bRoomToGrow;
+		}
+		else
 		{
 			if (bFirstTech && GC.getEmphasizeInfo((EmphasizeTypes)iI).getYieldChange(YIELD_COMMERCE) > 0)
 			{
@@ -10154,7 +10166,7 @@ int CvCityAI::AI_yieldValueInternal(short* piYields, short* piCommerceYields, bo
 	const int iBaseProductionValue = 15;
 	const int iBaseCommerceValue[NUM_COMMERCE_TYPES] = { 7,10,7,7 };	//	Koshling - boost science a bit
 
-	const int iMaxFoodValue = (3 * iBaseProductionValue) - 1;
+	const int iBaseFoodValue = iBaseProductionValue;
 
 	int aiYields[NUM_YIELD_TYPES];
 	int aiCommerceYieldsTimes100[NUM_COMMERCE_TYPES];
@@ -10215,7 +10227,6 @@ int CvCityAI::AI_yieldValueInternal(short* piYields, short* piCommerceYields, bo
 	int iValue = 0;
 	int iSlaveryValue = 0;
 
-	int iFoodGrowthValue = 0;
 	int iFoodGPPValue = 0;
 
 	if (!bIgnoreFood && aiYields[YIELD_FOOD] != 0)
@@ -10295,178 +10306,6 @@ int CvCityAI::AI_yieldValueInternal(short* piYields, short* piCommerceYields, bo
 		{
 			if (!bAvoidGrowth)
 			{
-				int iPopToGrow = 0;
-				// only do relative checks on food if we want to grow AND we not emph food
-				// the emp food case will just give a big boost to all food under all circumstances
-				if (bWorkerOptimization || (!bIgnoreGrowth))// && !bEmphasizeFood))
-				{
-					// also avail: iFoodLevel, iFoodToGrow
-
-					// adjust iFoodPerTurn assuming that we work plots all equal to iConsumtionPerPop
-					// that way it is our guesstimate of how much excess food we will have
-					iFoodPerTurn += (iExtraPopulationThatCanWork * iConsumptionByPopulation);
-
-					// we have less than 10 extra happy, do some checks to see if we can increase it
-					if (iHappinessLevel < 10)
-					{
-						// if we have anger becase no military, do not count it, on the assumption that it will
-						// be remedied soon, and that we still want to grow
-						if (getMilitaryHappinessUnits() == 0)
-						{
-							if (GET_PLAYER(getOwner()).getNumCities() > 2)
-							{
-								iHappinessLevel += ((GC.getNO_MILITARY_PERCENT_ANGER() * (iPopulation + 1)) / GC.getPERCENT_ANGER_DIVISOR());
-							}
-						}
-
-						// currently we can at most increase happy by 2 in the following checks
-						const int kMaxHappyIncrease = 2;
-
-						// if happy is large enough so that it will be over zero after we do the checks
-						int iNewFoodPerTurn = iFoodPerTurn + aiYields[YIELD_FOOD] - iConsumptionByPopulation;
-						if ((iHappinessLevel + kMaxHappyIncrease) > 0 && iNewFoodPerTurn > 0)
-						{
-							int iApproxTurnsToGrow = (iNewFoodPerTurn > 0) ? ((iFoodToGrow - iFoodLevel) / iNewFoodPerTurn) : MAX_INT;
-
-							// do we have hurry anger?
-							int iHurryAngerTimer = getHurryAngerTimer();
-							if (iHurryAngerTimer > 0)
-							{
-								int iTurnsUntilAngerIsReduced = iHurryAngerTimer % flatHurryAngerLength();
-
-								// angry population is bad but if we'll recover by the time we grow...
-								if (iTurnsUntilAngerIsReduced <= iApproxTurnsToGrow)
-								{
-									iHappinessLevel++;
-								}
-							}
-
-							// do we have conscript anger?
-							int iConscriptAngerTimer = getConscriptAngerTimer();
-							if (iConscriptAngerTimer > 0)
-							{
-								int iTurnsUntilAngerIsReduced = iConscriptAngerTimer % flatConscriptAngerLength();
-
-								// angry population is bad but if we'll recover by the time we grow...
-								if (iTurnsUntilAngerIsReduced <= iApproxTurnsToGrow)
-								{
-									iHappinessLevel++;
-								}
-							}
-
-							// do we have defy resolution anger?
-							int iDefyResolutionAngerTimer = getDefyResolutionAngerTimer();
-							if (iDefyResolutionAngerTimer > 0)
-							{
-								int iTurnsUntilAngerIsReduced = iDefyResolutionAngerTimer % flatDefyResolutionAngerLength();
-
-								// angry population is bad but if we'll recover by the time we grow...
-								if (iTurnsUntilAngerIsReduced <= iApproxTurnsToGrow)
-								{
-									iHappinessLevel++;
-								}
-							}
-						}
-					}
-
-					if (bEmphasizeFood)
-					{
-						//If we are emphasize food, pay less heed to caps.
-						iHealthLevel += 5;
-						iHappinessLevel += 2;
-					}
-
-					bool bBarFull = (iFoodLevel + iFoodPerTurn /*+ aiYields[YIELD_FOOD]*/ > ((90 * iFoodToGrow) / 100));
-
-					iPopToGrow = std::max(0, iHappinessLevel);
-					int iGoodTiles = AI_countGoodTiles(iHealthLevel > 0, true, 50, true);
-					iGoodTiles += AI_countGoodSpecialists(iHealthLevel > 0);
-					iGoodTiles += bBarFull ? 0 : 1;
-
-					if (!bEmphasizeFood)
-					{
-						iPopToGrow = std::min(iPopToGrow, iGoodTiles + ((bRemove) ? 1 : 0));
-					}
-
-					// if we have growth pontential, fill food bar to 85%
-					bool bFillingBar = false;
-					if (iPopToGrow == 0 && iHappinessLevel >= 0 && iGoodTiles >= 0 && iHealthLevel >= 0)
-					{
-						if (!bBarFull)
-						{
-							if (AI_specialYieldMultiplier(YIELD_PRODUCTION) < 50)
-							{
-								bFillingBar = true;
-							}
-						}
-					}
-
-					if (getPopulation() < 3)
-					{
-						iPopToGrow = std::max(iPopToGrow, 3 - getPopulation());
-						iPopToGrow += 2;
-					}
-
-					// if we want to grow
-					if (iPopToGrow > 0 || bFillingBar)
-					{
-
-						// will multiply this by factors
-						iFoodGrowthValue = aiYields[YIELD_FOOD];
-						if (iHealthLevel < (bFillingBar ? 0 : 1))
-						{
-							iFoodGrowthValue--;
-						}
-
-						// (range 1-25) - we want to grow more if we have a lot of growth to do
-						// factor goes up like this: 0:1, 1:8, 2:9, 3:10, 4:11, 5:13, 6:14, 7:15, 8:16, 9:17, ... 17:25
-						int iFactorPopToGrow;
-
-						if (iPopToGrow < 1 || bFillingBar)
-							iFactorPopToGrow = 20 - (10 * (iFoodLevel + iFoodPerTurn + aiYields[YIELD_FOOD])) / iFoodToGrow;
-						else if (iPopToGrow < 7)
-							iFactorPopToGrow = 17 + 3 * iPopToGrow;
-						else
-							iFactorPopToGrow = 41;
-
-						iFoodGrowthValue *= iFactorPopToGrow;
-
-						//If we already grow somewhat fast, devalue further food
-						//Remember growth acceleration is not dependent on food eaten per
-						//pop, 4f twice as fast as 2f twice as fast as 1f...
-						//	⛔ THE THRESHOLD IS A FOOD-PER-TURN RATE, so it LIFTS to meet iFoodPerTurn rather than
-						//	the rate being reduced to meet it. Built from POPULATION counts, it is whole by
-						//	construction, and against a x100 surplus the comparison below is true for any surplus
-						//	above a hundredth of a food -- so the damper saturated at x0.26 on every city that grows
-						//	at all, and the emphasis doubling that exists to hold it off was swamped with it.
-						int iHighGrowthThreshold = 100 * (2 + std::max(std::max(0, 5 - getPopulation()), (iPopToGrow + 1) / 2));
-						if (bEmphasizeFood)
-						{
-							iHighGrowthThreshold *= 2;
-						}
-
-						if (iFoodPerTurn > iHighGrowthThreshold)
-						{
-							iFoodGrowthValue *= 25 + ((75 * iHighGrowthThreshold) / iFoodPerTurn);
-							iFoodGrowthValue /= 100;
-						}
-					}
-				}
-
-				//very high food override
-				if ((isHuman()) && ((iPopToGrow > 0) || bCanPopRush))
-				{
-					//very high food override
-					int iTempValue = std::max(0, 30 * aiYields[YIELD_FOOD] - 15 * iConsumptionByPopulation);
-					iTempValue *= std::max(0, 3 * iConsumptionByPopulation - iAdjustedFoodDifference);
-					iTempValue /= 3 * std::max(1, iConsumptionByPopulation);
-					if (iHappinessLevel < 0)
-					{
-						iTempValue *= 2;
-						iTempValue /= 1 + 2 * -iHappinessLevel;
-					}
-					iFoodGrowthValue += iTempValue;
-				}
 				//Slavery Override
 				if (bCanPopRush && (iHappinessLevel > 0))
 				{
@@ -10498,29 +10337,16 @@ int CvCityAI::AI_yieldValueInternal(short* piYields, short* piCommerceYields, bo
 
 	int iProductionValue = 0;
 	int iCommerceValue = 0;
-	//	⛔ SURPLUS FOOD IS NOT WASTED, SO ITS VALUE IS NOT CAPPED BY HOW BADLY THIS CITY WANTS TO GROW (owner).
-	//	`CvCity::doGrowth` SUBTRACTS the threshold and the remainder rolls into the next bar, so every point of
-	//	food eventually becomes a citizen. Capping the food term at `iFoodGrowthValue` therefore threw the tile's
-	//	real output away the moment growth was slow or unwanted: a 7-food plot scored its hammers alone and lost
-	//	to a specialist, which is the base-yield-under-a-commerce-yield inversion the ruling forbids
-	//	([citizen-assignment.md]).
-	//	⚑ THE ONE STATE WHERE THE CAP IS RIGHT is the one the engine itself discards food in: under avoid-growth
-	//	it PINS `m_iFood` at the threshold, so surplus above it genuinely evaporates. The cap belongs there and
-	//	nowhere else.
-	int iFoodValue = iMaxFoodValue * aiYields[YIELD_FOOD];
+	int iFoodValue = iBaseFoodValue * aiYields[YIELD_FOOD];
 	if (bAvoidGrowth || AI_isEmphasizeAvoidGrowth())
 	{
-		iFoodValue = std::min(iFoodGrowthValue, iFoodValue);
+		iFoodValue = 0;
 	}
 	// if food is production, the count it
 	int adjustedYIELD_PRODUCTION = (((bFoodIsProduction) ? aiYields[YIELD_FOOD] : 0) + aiYields[YIELD_PRODUCTION]);
 
 	// value production medium(15)
 	iProductionValue += (adjustedYIELD_PRODUCTION * iBaseProductionValue);
-	if (!isProduction() && !isHuman())
-	{
-		iProductionValue /= 2;
-	}
 	/************************************************************************************************/
 	/* BETTER_BTS_AI_MOD                      05/18/09                                jdog5000      */
 	/*                                                                                              */
@@ -10530,7 +10356,7 @@ int CvCityAI::AI_yieldValueInternal(short* piYields, short* piCommerceYields, bo
 		// Particularly helps coastal cities with plains forests
 	if (aiYields[YIELD_PRODUCTION] > 0)
 	{
-		if (!bFoodIsProduction && isProduction())
+		if (!bFoodIsProduction)
 		{
 			if (foodDifference(false) >= 100 * GC.getFOOD_CONSUMPTION_PER_POPULATION())
 			{

--- a/Sources/Engine/CvCity.cpp
+++ b/Sources/Engine/CvCity.cpp
@@ -1885,7 +1885,7 @@ bool CvCity::canWork(const CvPlot* pPlot) const
 
 	if (getCityPlotIndex(pPlot) >= getNumCityPlots()) return false; // Just in case FAssertMsg doesn't end the function.
 
-	//in the rare case that a city ends up with an invisible animal inside the city or something, the city plot should be made immune to the following effect.
+	//	the centre plot is always worked, so nothing standing on it may take it away
 	if (pPlot != plot())
 	{
 		if (pPlot->plotCheck(PUF_canSiege, getOwner()) != NULL)

--- a/Sources/Engine/CvUnit.cpp
+++ b/Sources/Engine/CvUnit.cpp
@@ -12135,7 +12135,7 @@ bool CvUnit::canSiege(TeamTypes eTeam) const
 		return false;
 	}
 
-	if (getOwner() == PREY_PLAYER)
+	if (isAnimal())
 	{
 		return false;
 	}

--- a/docs/reference/citizen-assignment.md
+++ b/docs/reference/citizen-assignment.md
@@ -271,6 +271,17 @@ facts, the culture-level fact and the working-city fact all announce today. No n
 reassignment; the radius growing with culture / `adds3rdRing`, adding tiles that were never candidates — no
 per-plot fact announces this) and the water-work TEAM capability.
 
+### ⛔ WILDLIFE DOES NOT BESIEGE A PLOT — a siege is a HOSTILE FACTION denying the tile
+
+`CvUnit::canSiege` is what takes a plot away from its working city, and **`isAnimal()` refuses it outright**:
+predators, prey and beasts are a threat to a UNIT standing on the tile, never an occupation that stops the city
+harvesting it. What may still siege is every hostile faction — enemy nations, barbarians, neanderthals and the
+insectoids (a city-owning faction, which is why `isAnimal()` deliberately excludes `INSECT_PLAYER`).
+⚑ **The cost was never only the lost tile.** `canSiege` also gates the `AI_setAssignWorkDirty` marks in
+`CvUnit::setXY`, so while wildlife qualified, every animal step marked its working city for a FULL citizen
+re-assignment — and animals are both numerous and constantly moving. A predicate this narrow reaches the
+governor's churn as much as the tile.
+
 ⛔ **Three marks are UNIT-MOVEMENT driven and stand as live per-move marks PENDING A DELIBERATE DECISION:** an enemy unit sieging a plot (`CvUnit::setXY`), a naval blockade (`CvPlot::changeBlockadedCount`),
 and the military-happiness garrison count (`CvCity::changeMilitaryHappinessUnits`). Unit movement never dirties
 a cache ([unit-carried modifiers apply on top, live, never cached](../cascade/09-wellbeing-channels.md#2b-the-wellbeing-channels--health--happiness-signed-split-the-2a-sibling)), so these must

--- a/docs/reference/citizen-assignment.md
+++ b/docs/reference/citizen-assignment.md
@@ -49,6 +49,20 @@ is what makes the table derivable rather than three hand-tuned sets, and what le
 inventing a magnitude. ⛔ **Each channel is suppressed AT MOST ONCE**, structurally: one pass per channel, not
 one pass per emphasizer.
 
+### ⚖ THE AI DRIVES THE KNOB — get buildings out, or get bigger
+
+`AI_doEmphasize` sets an AI city's emphasis once per turn, and it is the ONLY thing that makes that city prefer
+a channel: **a live building frontier asks for PRODUCTION; otherwise room to grow asks for FOOD.** The frontier
+is the enabler's maintained offer (`getAvailableBuildings`), so the question costs one vector fill per city per
+turn, and `AI_EMPHASIZE_BUILD_FRONTIER` is how big the offer must be to count.
+
+⛔ **ASKING IT HERE IS THE POINT — a per-candidate growth projection is the shape this replaces.** `AI_yieldValue`
+runs per candidate per citizen, so a "does this city want to grow?" model living inside the scoring body answered
+one question thousands of times a turn and expressed the answer nowhere a reader could see. The demand decision
+is taken ONCE and is legible afterwards as the city's emphasis state.
+⚠ A city whose frontier is empty is not asking for hammers — with nothing to build they bank as overflow
+([yields-growth.md](yields-growth.md) § The order queue), so the knob correctly falls to food or to neither.
+
 > **⛔ AN EMPHASIS MUST REACH THE DECISIONS TAKEN *BEFORE* THE MULTIPLIERS, NOT ONLY THE MULTIPLIERS.** The
 > SLAVERY TRANSLATION decides whether a tile's food counts as food or is re-booked as production (whip
 > fodder), and it ran ahead of the emphasis stack — so emphasis could never reach it, and the food-emphasis
@@ -73,17 +87,25 @@ same — *"it harms production for eras going forward."* Against an 8-population
 the term models does not exist, so no coefficient tunes it into shape; the term is sized for a BTS-era 1–2
 population whip. ⚠ Emphasis already refuses it outright — emphasis never cares about whipping.
 
-## ⚖ GROWTH BEATS ALMOST ANYTHING — THE STANDING WEIGHT OF THIS GAME
+## ⛔ NEITHER CHANNEL OUTWEIGHS THE OTHER AT REST — THE EMPHASIS KNOB DECIDES
 
-**"The way this game works, growth > almost anything."** S2S is a very long game with an enormous build tree,
-so a citizen added early compounds for the rest of it — which makes FOOD the dominant term in a citizen
-decision by default, not merely a competitive one. ⛔ A valuation that ranks a food-rich tile below a
-specialist, or below a hammer tile, is wrong on this game's own terms however defensible its arithmetic looks.
-⚑ The weights already encode the intent — `iMaxFoodValue = 3 × iBaseProductionValue − 1`, i.e. food is worth
-~3× production per unit — so a defect here is almost never the RATIO. It is something CAPPING or ZEROING the
-food term before the ratio is ever applied, and both known instances did exactly that (below).
-⚠ **It governs the DEFAULT.** An explicit emphasis is the player overriding this, so suppressing food while
-production is emphasized is the model working — the ruling binds where nothing was asked for.
+**Food and production weigh the SAME per point in a citizen decision, and `EMPHASIZE_*` is the only thing that
+makes a city prefer one over the other** (`iBaseFoodValue = iBaseProductionValue`). An equal-food/equal-hammer
+tile is a genuine tie until something asks for a channel.
+
+⛔ **A BAKED RATIO IS THE SHAPE THIS FORBIDS, AND IT DOES NOT BIAS THE RANKING — IT FIXES IT.** Emphasis is a
+ratio shift of ×1.30 promote against ×0.75 suppress, so it can move a comparison by roughly 1.7×. A constant
+favouring one channel by a MULTIPLE therefore cannot be crossed by any emphasis state the game can reach: the
+suppressed channel can never rank first, the knob reads as inert, and the AI looks like it holds a preference
+nobody gave it. ⚑ So read a lopsided food-vs-hammer outcome as a BASE-CONSTANT question first — the same move
+as reading [a lopsided AI preference as a SCALE question first](../../AGENTS.md).
+
+⚖ **PRODUCTION IS UPSTREAM OF GROWTH, SO IT IS NEVER THE JUNIOR CHANNEL BY DEFAULT.** Hammers become buildings,
+and buildings are what let a citizen be fed, kept healthy and seated at all — so food worked before that
+infrastructure exists compounds into population the city cannot use. A city with a live building frontier wants
+hammers; a developed city with nothing left worth building wants food. ⚠ That is a property of **the city**,
+never of the era: a city founded late starts at the first state, and a built-out capital reaches the second one
+early.
 
 ## ⚖ A BASE YIELD ALWAYS OUTWEIGHS A COMMERCE YIELD
 
@@ -92,26 +114,17 @@ A plot's worth is what it PRODUCES, and a tile carrying real food and hammers mu
 output is gold or research — so no state of the city may drive a base-yield term below the commerce terms it is
 being ranked against.
 
-> **⛔ THE `min` ON FOOD IS THE SHAPE THAT BREAKS THIS.** `iFoodValue = min(iFoodGrowthValue, iMaxFoodValue ×
-> food)` makes food worth **the lesser** of its growth contribution and its own quantity, so the moment the city
-> stops wanting to grow — avoid-growth, the happy/health cap, the growth damper — food is worth approximately
-> NOTHING and the tile is valued on its hammers alone.
-> ⚑ **Measured:** a 7-food / 2-production / 3-commerce sea plot caps at 44 × 700 = 30,800 on the food leg, but
-> under a collapsed growth value scores ~3,000 (its production) + ~30 (its commerce) — against specialists at
-> ~5,400 in the same city. The best tile available goes unworked, and it is always the same tile class, because
-> the verdict is a pure function of the yields and the growth state.
-> ⇒ **Growth value is an ADDITION on top of food's intrinsic worth, never a CEILING over it.** The food a tile
-> yields does not stop existing when growth is unwanted: it offsets consumption and feeds the very specialists
-> that are out-scoring it.
-> ⚑ **THE DECIDING FACT IS THE ENGINE'S OWN: SURPLUS FOOD IS NOT WASTED.** `CvCity::doGrowth`
-> SUBTRACTS the threshold and the remainder rolls into the next bar, so every point of food eventually
-> becomes a citizen — which is why a cap on food's value can never be right in general.
-> ⚖ **The ONE state where a cap IS right is the one the engine discards food in:** under avoid-growth it
-> PINS `m_iFood` at the threshold, so surplus above it genuinely evaporates. The growth-value cap applies
-> there and nowhere else.
-> ⚠ **Emphasis MASKS this rather than fixing it** — emphasizing food lifts the term back above the specialists,
-> which is why the defect reads as "emphasis is required to get sane assignment" instead of as a food-valuation
-> bug.
+> **⛔ SURPLUS FOOD IS NOT WASTED, so nothing may cap food's value by how badly the city wants to grow.**
+> `CvCity::changeFood` SUBTRACTS the threshold and rolls the remainder into the next bar, so every point of food
+> eventually becomes a citizen. A cap keyed on growth appetite therefore throws away output the city will
+> actually receive, and it does so hardest on the best tiles — the verdict being a pure function of the yields
+> and the growth state, the same tile class goes unworked every time.
+> ⚖ **THE ENGINE DISCARDS FOOD IN EXACTLY ONE STATE, AND IT IS NARROWER THAN "AVOID GROWTH".** `changeFood`
+> pins `m_iFood` at the threshold when `(isHuman() && AI_avoidGrowth()) || AI_isEmphasizeAvoidGrowth()` — so for
+> an AI city ONLY the avoid-growth EMPHASIS evaporates surplus; `AI_avoidGrowth()` alone (angry citizens, food
+> production) leaves the city growing normally.
+> ⚠ The valuation still zeroes food across the whole of `bAvoidGrowth`, which is a POLICY (do not grow into
+> unhappiness) rather than the mechanical fact above. Do not cite the pin as its justification.
 
 ## What re-orders the list, and what does not
 
@@ -163,7 +176,7 @@ edge (Python / the `Cy` bindings).
 
 ⚑ **A score is only ever compared against another score, so its absolute scale CANCELS.** That is why no
 conversion is needed: a calibration constant that MULTIPLIES its yield (`iBaseProductionValue`,
-`iBaseCommerceValue[]`, `iMaxFoodValue`) carries the scale for free, so whether a weight multiplies 15 or 1500
+`iBaseCommerceValue[]`, `iBaseFoodValue`) carries the scale for free, so whether a weight multiplies 15 or 1500
 ranks identically.
 
 > **⛔ SCALE-INVARIANCE IS A PROPERTY OF MULTIPLIED TERMS ONLY — AN ADDITIVE CONSTANT IS NOT INVARIANT, AND
@@ -178,8 +191,7 @@ ranks identically.
 >
 > ⚑ **Each fails SILENTLY and in a different direction, which is why they need enumerating rather than
 > watching for.** The measured instances: the clause that FORCES a starving city onto its moderate-food tiles
-> became worth a few percent of an ordinary plot; the damper meant for cities *already* growing fast pinned at
-> its floor and took **×0.26 off every city's food growth value**; the bad-plot filter
+> became worth a few percent of an ordinary plot; the bad-plot filter
 > (`AI_potentialPlot`) could only answer false for a tile yielding literally nothing; and
 > `AI_getPlotMagicValue`'s `min(consumptionPerPop, 2×bestYield)` reductant took the ×1 arm against a ×1
 > numerator and always exceeded it, so `AI_countGoodTiles` returned 0 on every call for the life of the mod —


### PR DESCRIPTION
Refs #367 (umbrella — not closed; the building/unit-valuation and avoid-growth/great-people sub-items remain).

## The finding

`AI_yieldValueInternal` weighed food at **44 per point** against production at **15** — `iMaxFoodValue = (3 * iBaseProductionValue) - 1`, flat for the whole game, with no era, frontier or demand term anywhere.

Emphasis is a ×1.30 promote against a ×0.75 suppress — a 1.73× swing. It could never cross a 2.9× head start:

| state | food | production | winner |
|---|---|---|---|
| neutral | 44 | 15 | food **2.9×** |
| production emphasis on | 33 | 19.5 | food **1.7×** |
| wonder in queue (+50 special) | 44 | 22.5 | food **2.0×** |
| emphasis **and** wonder | 33 | 29.3 | food **1.1×** |

Food won every equal-yield tile in **every state the game can reach**, including a player holding production emphasis while building a world wonder. Emphasis was not weak — it was outgunned before it started, which is why it has read as inert for years.

`#367`'s open question was whether AI self-emphasis should change. It should: emphasis is the knob a city AI uses to choose between *getting buildings out* and *getting bigger*.

## The change

- **Head start removed** — `iBaseFoodValue = iBaseProductionValue`. Equal food and hammers is a genuine tie; `EMPHASIZE_*` is the only thing that breaks it.
- **`AI_doEmphasize` gains the triggers it never had** — a live building frontier asks for production, otherwise room to grow asks for food. Keyed off the emphasis data's own yield change, not hardcoded ids. The frontier is the enabler's maintained offer (`getAvailableBuildings`), so it costs one vector fill per city per turn.
- **Removed the `AI_specialYieldMultiplier(YIELD_PRODUCTION) < 50` gate**, which switched emphasis evaluation off exactly when the city most wanted hammers — and the note above it stating the AI should never use emphasis.
- **Two empty-queue suppressions removed** — an AI-only `iProductionValue /= 2` on an empty order queue, and the `isProduction()` gate on the BBAI production rescue. Both keyed off the same flag in opposite directions, so a city with nothing queued took the penalty and was denied the antidote.
- **172 dead lines deleted** — after the above, `iFoodGrowthValue` had five writes and zero reads. Its whole demand model (`iPopToGrow`, a 17–41 factor, a health penalty, a fast-growth damper) was computed per candidate and used only as a `min` cap under avoid-growth.

Net **−162 lines**.

### Structural note

"Does this city want to grow?" used to be re-derived inside the per-candidate scoring body — thousands of times per turn, with the answer visible nowhere. It is now one decision per turn, legible afterwards as the city's emphasis state.

## Reviewer notes

**Blast radius beyond the stated scope.** The deleted block also mutated `iHappinessLevel`/`iHealthLevel`/`iFoodPerTurn`, and two live terms read them: the whip gate and the great-people food term now read *current* values rather than growth-projected ones. Every mutation in that block was explicitly a growth projection ("how happy will we be by the time we grow") and neither consumer asks a growth question — but it is a behaviour change in terms this PR did not set out to touch.

**`AI_EMPHASIZE_BUILD_FRONTIER = 3` is a judgement call**, not derived — the tuning knob here. Edge worth knowing: a city with an *empty* frontier gets no production emphasis. Correct (with nothing to build, hammers bank as overflow), but it means the trigger does nothing for a city whose frontier is zero.

**Doc corrections carried in the same change.** `citizen-assignment.md` presented the head start as intended and told the next reader a defect there is "almost never the RATIO". Also: `CvCity::doGrowth` does not exist (it is `changeFood`), and the avoid-growth pin is narrower than documented — `(isHuman() && AI_avoidGrowth()) || AI_isEmphasizeAvoidGrowth()`, so for an AI city only the avoid-growth *emphasis* evaporates surplus food. The valuation still zeroes food across all of `bAvoidGrowth`, which is policy, not that mechanic.

**Follow-up left out deliberately:** `bIgnoreGrowth` is now dead at the terminus but still threaded through `AI_plotValue` → `AI_yieldValue` → the LRU cache key → `AI_scoreCitizenOptions` (~30 sites), and `AI_ignoreGrowth()` flipping still triggers a full re-score that can no longer change a value. Kept separate so neither diff obscures the other.

## Verification

- `Assert rebuild` green (41s).
- `verify-docs.py` links clean; `citizen-assignment.md` cleared from the stale-symbol census.
- Owner confirmed in-game that emphasis now visibly moves the ranking — the first time it could.

---

# Second fix on this branch: wildlife besieged city plots

Owner observation, no separate issue: *animals block plots from being worked; only enemy nations and barbs used to.*

`CvUnit::canSiege` excluded **`PREY_PLAYER` only** — but there are three wildlife players. `BEAST_PLAYER` and `PREDATOR_PLAYER` denied a plot to its working city exactly like a barbarian stack, so a panther standing in the fat cross took the tile off the city.

The predicate is now `isAnimal()` — the test that already existed, covering all three, rather than the one player that happened to be named. What may still siege is every hostile **faction**: enemy nations, barbarians, neanderthals, and the insectoids (`INSECT_PLAYER` owns and razes cities, which is why `isAnimal()` deliberately excludes it).

### The tile was not the whole cost

`canSiege` also gates the two `AI_setAssignWorkDirty` marks in `CvUnit::setXY`. While wildlife qualified, **every animal step marked its working city for a full citizen re-assignment** — and animals are both numerous and constantly moving. This removes that per-move governor churn along with the blocking, so there is a turn-time component to it as well.

Also replaced the comment above `CvCity::canWork`'s siege gate, which justified the centre-plot exemption by "an invisible animal inside the city" — something `canSiege`'s own invisibility test already handled, and which now cannot arise at all.

Rulings recorded in `docs/reference/citizen-assignment.md`.

`Assert rebuild` green; `verify-docs.py` links clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
