### PR TITLE
build: delete the Profile/ProfileExtra configs so the profiler is unselectable

### DIFF
--- a/.claude/skills/build-dll/SKILL.md
+++ b/.claude/skills/build-dll/SKILL.md
@@ -14,7 +14,7 @@ The build is driven by `Tools/_Build.ps1` (a FastBuild wrapper). Always run it
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "../Tools/_Build.ps1" <Config> <verb> [<verb> ...]
 ```
 
-- **Configs:** `Assert`, `Debug`, `Release`, `FinalRelease`, `Profile`, `ProfileExtra`.
+- **Configs:** `Assert`, `Debug`, `Release`, `FinalRelease`, `Testing`.
   Output → `Build/<Config>/CvGameCoreDLL.dll` (+ `.pdb`).
 - **Verbs (composable, in order):** `clean`, `build` (incremental), `rebuild` (clean+build), `deploy` (xcopy DLL/PDB into `Assets/`).
 - **Modifier — `nostop` (opt-in):** passes FastBuild's `-nostoponerror` so the build keeps going after a failed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,12 +102,16 @@ The build is driven by **`Tools/_Build.ps1`** (a FastBuild wrapper). Invoke it
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "../Tools/_Build.ps1" <Config> <verb> [<verb> ...]
 ```
 
-- **Configs:** `Assert`, `Debug`, `Release`, `FinalRelease`, `Profile`, `ProfileExtra`.
+- **Configs:** `Assert`, `Debug`, `Release`, `FinalRelease`, `Testing`.
   Output lands in `Build/<Config>/CvGameCoreDLL.dll` (+ `.pdb`).
-  - **⛔ The `Profile`/`ProfileExtra` configs are BROKEN and purposeless: never use them, and never
-    add `PROFILE()`/FProfiler scopes as instrumentation — they report to nothing.** The ONE instrument is the
+  - **⛔ THE INTERNAL PROFILER CANNOT BE SELECTED, AND THAT IS STRUCTURAL — never
+    add `PROFILE()`/FProfiler scopes as instrumentation, because they report to nothing.** `USE_INTERNAL_PROFILER`
+    is defined NOWHERE, so no config compiles the profiler in; the `Profile`/`ProfileExtra` configs that once did
+    are deleted. ⚠ `_Build.ps1` passes its config argument straight to FastBuild with no whitelist, so a
+    config that EXISTS is a config anyone can select — which is why the fix was removing them rather than
+    discouraging them. The ONE instrument is the
     gated `[PERF]` logging (`logPerf`/`gPerfLogLevel`, `Autolog__LogLevelPerf`), which ships in every build.
-    **The macros compile to NOTHING outside those configs, so the scopes already in the tree are INERT** — not a
+    **The macros now compile to NOTHING in every config, so the scopes already in the tree are INERT** — not a
     defect, not a purge backlog. What binds is the DIRECTION: **we never build TOWARD using the profiler.** So a
     broken/stale FProfiler include or reference is **DELETED as irrelevant code, never repaired** — "the build
     can't find `FProfiler.h`" is never a reason to restore it

--- a/Sources/AGENTS.md
+++ b/Sources/AGENTS.md
@@ -48,7 +48,7 @@ root `AGENTS.md`.
 
 - Build entry point is `Tools/_Build.ps1`, run **from `Sources/`**:
   `powershell.exe -NoProfile -ExecutionPolicy Bypass -File "../Tools/_Build.ps1" <Config> <verb...>`.
-  Configs: `Assert`/`Debug`/`Release`/`FinalRelease`/`Profile`/`ProfileExtra`; verbs: `clean`/`build`/`rebuild`/`deploy`.
+  Configs: `Assert`/`Debug`/`Release`/`FinalRelease`/`Testing`; verbs: `clean`/`build`/`rebuild`/`deploy`.
 - Quick compile check after editing: `Assert build` (~30s incremental). `MakeDLL*.bat` always rebuild+deploy.
 - **`FASSERT`/`FAssertMsg` compile out of `Release` and `FinalRelease`** (only `Assert`/`Debug`/`Testing`
   define `FASSERT_ENABLE`, per `fbuild.bff` — *not* the `.vcxproj`). FinalRelease is the build players

--- a/Sources/fbuild.bff
+++ b/Sources/fbuild.bff
@@ -147,11 +147,11 @@ Settings
     Using(.ConfigNonDebugCommon)
     .ConfigName     = 'Release'
 
-    // ⛔ NEVER compile the internal profiler into Release, doing so made the 3
-    // ungated PROFILE_BEGIN sites (CvGame::update per-FRAME, doTurn, CvPlotGroup) run IFPBeginSample +
+    // ⛔ NEVER compile the internal profiler into ANY config. Doing so made the 3 ungated
+    // PROFILE_BEGIN sites (CvGame::update per-FRAME, doTurn, CvPlotGroup) run IFPBeginSample +
     // a critical-section per call -> a memory-allocation-failure crash on end-turn. The census /
-    // [MODIFIER/perf] gated logging IS the perf surface; the PROFILE_* system is kraken bait, ticketed for
-    // removal in #449. Release stays profiler-free.
+    // [MODIFIER/perf] gated logging IS the perf surface. USE_INTERNAL_PROFILER is now defined
+    // nowhere, so no config can select it; the inert PROFILE_* scopes compile to nothing.
 ]
 
 .ConfigAssert =
@@ -163,25 +163,7 @@ Settings
                     + ' /DFASSERT_LOGGING'
 ]
 
-.ConfigProfile = 
-[
-    Using(.ConfigNonDebugCommon)
-    .ConfigName     = 'Profile'
-
-    .CLOptions      + ' /DFP_PROFILE_ENABLE' 
-                    + ' /DUSE_INTERNAL_PROFILER'
-]
-
-.ConfigProfileExtra = 
-[
-    Using(.ConfigNonDebugCommon)
-    .ConfigName     = 'ProfileExtra'
-
-    .CLOptions      + ' /DFP_PROFILE_EXTRA_ENABLE' 
-                    + ' /DUSE_INTERNAL_PROFILER'
-]
-
-.ConfigTesting = 
+.ConfigTesting =
 [
     Using(.ConfigNonDebugCommon)
     .ConfigName     = 'Testing'
@@ -199,7 +181,7 @@ Settings
                     + ' /DFINAL_RELEASE'
 ]
 
-.Configs = { .ConfigDebug, .ConfigRelease, .ConfigAssert, .ConfigProfile, .ConfigProfileExtra, .ConfigTesting, 
+.Configs = { .ConfigDebug, .ConfigRelease, .ConfigAssert, .ConfigTesting,
 	.ConfigFinalRelease }
 
 .AllTargets = {}

--- a/Tools/MakeDLLProfile.bat
+++ b/Tools/MakeDLLProfile.bat
@@ -1,4 +1,0 @@
-@echo off
-PUSHD "%~dp0"
-call _MakeDLL.bat Profile rebuild deploy
-POPD

--- a/Tools/MakeDLLProfileExtra.bat
+++ b/Tools/MakeDLLProfileExtra.bat
@@ -1,4 +1,0 @@
-@echo off
-PUSHD "%~dp0"
-call _MakeDLL.bat ProfileExtra rebuild deploy
-POPD


### PR DESCRIPTION
Closes #449.

`USE_INTERNAL_PROFILER` is now defined **nowhere** in the tree, so the internal profiler is unreachable by construction rather than discouraged by prose.

## Why deleting the configs *is* the fix

`Tools/_Build.ps1` passes its config argument straight to FastBuild with **no whitelist**, so a config that EXISTS is a config anyone can select by typing its name. While `ConfigProfile`/`ConfigProfileExtra` were declared, `_Build.ps1 Profile build` still produced a DLL with the profiler compiled in — the exact build that crashed on end-turn, because the three ungated `PROFILE_BEGIN` sites (`CvGame::update` per-**frame**, `doTurn`, `CvPlotGroup`) call the sampler directly, bypassing every scope gate, with a critical section per call.

That is the hard-typing-over-prose ladder: a build that cannot be selected beats a rule someone has to remember.

## What changed

- `Sources/fbuild.bff` — the two config blocks deleted, and dropped from `.Configs`
- `Tools/MakeDLLProfile.bat`, `Tools/MakeDLLProfileExtra.bat` — deleted; one-line launchers that would otherwise invoke a config that no longer exists
- `AGENTS.md`, `Sources/AGENTS.md`, `.claude/skills/build-dll/SKILL.md` — the config lists, which all still advertised `Profile`/`ProfileExtra` as selectable

## Deliberately NOT touched

- **The ~761 `PROFILE_FUNC()` scopes.** They compile to nothing in every surviving config and are explicitly *not a purge backlog*; removing them is churn against a no-op.
- **`docs/plans/parked/turn-time-optimization.md`**, which references the configs — parked docs are carried as-is with stale paths by design and are re-grounded when their initiative becomes active.

## The Release comment

Kept, minus its now-stale `#449` pointer. A deliberate off-switch is protected by its **reason** — a sweep that eats an unexplained switch re-introduces a crash nobody remembers — so the end-turn crash account survives in full.

## Verification

`Assert rebuild` green: `FBuild: OK: Assert-build`, 76 objects, 46.2s wall. That is the authoritative check that `fbuild.bff` still parses and nothing referenced the deleted blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUMESCMx2CKVYmJzqFkBNQ