### PR TITLE
fix: three modular-merge defects in the info loaders

### DIFF
--- a/Sources/Defines/CvDiplomacyClasses.cpp
+++ b/Sources/Defines/CvDiplomacyClasses.cpp
@@ -402,17 +402,21 @@ bool CvDiplomacyInfo::FindResponseIndex(const CvDiplomacyResponse* pNewResponse,
 
 	if ( getNumResponses() == 1 )
 	{
-		iIndex = 0;
+		*iIndex = 0;
 		return true;
 	}
 
 	// Text
 	if ( iCase == 1 )
 	{
-		bool bOnlyText = true;
-
 		for ( int i = 0; i < getNumResponses(); ++i )
 		{
+			// Per RESPONSE, never once for the whole vector: this flag starts TRUE and is only ever
+			// cleared, so hoisting it out of the loop let one selector-bearing response poison every
+			// later one and made a text-only response unmatchable (it appended as a duplicate instead
+			// of merging).
+			bool bOnlyText = true;
+
 			for ( int iElement = 0; iElement < GC.getNumLeaderHeadInfos(); ++iElement )
 			{
 				if ( getLeaderHeadTypes(i, iElement) ) bOnlyText = false;

--- a/Sources/Infos/CvEventTriggerInfo.cpp
+++ b/Sources/Infos/CvEventTriggerInfo.cpp
@@ -881,11 +881,19 @@ void CvEventTriggerInfo::copyNonDefaults(const CvEventTriggerInfo* pClassInfo)
 
 	CvInfoUtil(this).copyNonDefaults(pClassInfo);
 
-	// Pre-existing quirk kept as-is (pure loader migration): these are parallel-by-index
-	// (text, era) lists, but CopyNonDefaultsFromVector dedups and sorts each list
-	// independently, so a modular override that adds texts can scramble the pairing.
-	CvXMLLoadUtility::CopyNonDefaultsFromVector(m_aiTextEra, pClassInfo->m_aiTextEra);
-	CvXMLLoadUtility::CopyNonDefaultsFromVector(m_aszText, pClassInfo->m_aszText);
+	// (text, era) are PARALLEL BY INDEX -- getNumTexts asserts the two sizes match, and the consumer
+	// reads getText(i) against getTextEra(i) to pick era-appropriate event text. So they merge as PAIRS:
+	// the generic CopyNonDefaultsFromVector dedups and sorts each vector independently, which reorders
+	// one list against the other and can leave the two different lengths.
+	for (size_t i = 0; i < pClassInfo->m_aszText.size(); ++i)
+	{
+		if (algo::none_of_equal(m_aszText, pClassInfo->m_aszText[i]))
+		{
+			m_aszText.push_back(pClassInfo->m_aszText[i]);
+			m_aiTextEra.push_back(i < pClassInfo->m_aiTextEra.size() ? pClassInfo->m_aiTextEra[i] : NO_ERA);
+		}
+	}
+
 	CvXMLLoadUtility::CopyNonDefaultsFromVector(m_aszWorldNews, pClassInfo->m_aszWorldNews);
 
 	m_PrereqMinProperties.copyNonDefaults(pClassInfo->getPrereqMinProperties());

--- a/Sources/Infos/CvWorldPickerInfo.cpp
+++ b/Sources/Infos/CvWorldPickerInfo.cpp
@@ -235,10 +235,7 @@ void CvWorldPickerInfo::copyNonDefaults(CvWorldPickerInfo* pClassInfo)
 	{
 		for ( int i = 0; i < pClassInfo->getNumWaterLevelGloss(); i++ )
 		{
-			// XXX pre-existing copy-paste bug: gloss paths are merged into the DECALS
-			// vector, so m_aWaterLevelGloss never receives merged entries. Preserved
-			// as-is by the #196 loader migration (pure-loader change, no semantics).
-			m_aWaterLevelDecals.push_back(pClassInfo->getWaterLevelGlossPath(i));
+			m_aWaterLevelGloss.push_back(pClassInfo->getWaterLevelGlossPath(i));
 		}
 	}
 }


### PR DESCRIPTION
Closes #356. Closes #357. Closes #355.

All three are `copyNonDefaults` bugs — the path a **module** takes when it overrides a base info — so each is invisible in a base-only game and corrupts data the moment a module touches that record. Two carried an in-tree comment marking them as known; both were left in place by the #196 loader migration, which was deliberately pure-loader.

Grouped into one PR because they are one class in one layer.

## #356 — `CvWorldPickerInfo`, gloss merged into decals

A one-word copy-paste, and it fails in **both** directions: `m_aWaterLevelGloss` never receives its merged entries, *and* `m_aWaterLevelDecals` is silently polluted with gloss paths.

## #357 — `CvDiplomacyInfo::FindResponseIndex`, two defects

**`bOnlyText` poisoning.** Declared once *outside* the response loop. It starts  and is only ever cleared, so one selector-bearing response early in the vector poisoned every later one — a text-only response could never be matched, and module text-only responses appended as duplicates instead of merging. Now per-response.

⚠ **Cases 2–6 look identical and are NOT affected**, which I checked before touching them: their flags start , and the loop only *continues* when the flag is false — so every iteration already began from a value identical to a fresh init. The initialization **polarity** is what makes case 1 unique. Fixing them too would have been churn against no defect.

**Pointer-assign typo.** The single-response early-out did `iIndex = 0` — assigning the pointer *parameter* instead of the pointee. Benign only because the sole caller pre-initializes its int to 0: correct by luck at one call site, not by construction.

Two further observations in the issue — the `getNumResponses() == 1` early-out matching regardless of selector compatibility, and `m_aeCivilizationTypes` being ignored by the merge classification — are **not** touched here. They are design questions about what merging should mean, not defects with an obviously correct repair.

## #355 — `CvEventTriggerInfo`, (text, era) pairing scrambled

`m_aszText` and `m_aiTextEra` are **parallel by index**, but each was merged through `CopyNonDefaultsFromVector`, which dedups and then **sorts** its vector. Applied independently to two parallel lists, that reorders one against the other — and the dedup can leave them different **lengths**, which `getNumTexts()` literally asserts against:

```cpp
FAssert(m_aiTextEra.size() == m_aszText.size());
```

The consumer (`CvPlayer.cpp:19005`) reads `getText(i)` against `getTextEra(i)` to pick era-appropriate event text, so the visible symptom is **an event showing the wrong era's text**.

They now merge as pairs. The `NO_ERA` fallback is defensive only — `read()` pushes both in lockstep, so the source is genuinely parallel.

## Verification

`Assert rebuild` green, 42.2s. ⚠ No runtime check is possible for these without a module that exercises each merge path — the whole point is that they are dormant until a module overrides the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUMESCMx2CKVYmJzqFkBNQ