### PR TITLE
fix: walk a cargo MANIFEST in scheduleDeath, not the live plot unit list

### DIFF
--- a/Sources/Engine/CvUnit.cpp
+++ b/Sources/Engine/CvUnit.cpp
@@ -1337,9 +1337,30 @@ bool CvUnit::scheduleDeath(bool bDelay, PlayerTypes ePlayer, bool bMessaged)
 	{
 		if (hasCargo())
 		{
+			// The cargo MANIFEST is taken before the walk, because resolving a cargo unit's fate mutates
+			// the plot's unit list in two independent ways: an ESCAPING unit leaves the plot through
+			// setXY, and a DROWNING one is deleted outright whenever bDelay is false (every Python kill,
+			// the delayed-death reap, the flanking kill). Iterating the live view across either is
+			// undefined, so neither a snapshot nor forcing bDelay would be sufficient on its own.
+			// It records IDENTITIES rather than pointers: a nested cargo cascade -- a transport carrying
+			// a transport -- can free a unit that a pointer snapshot would still be holding, so each
+			// entry is re-resolved and one that died meanwhile simply resolves to NULL.
+			std::vector<IDInfo> cargoManifest;
+
 			foreach_(CvUnit* unitX, pPlot->units())
 			{
-				if (unitX == this || unitX->getTransportUnit() != this)
+				if (unitX != this && unitX->getTransportUnit() == this)
+				{
+					cargoManifest.push_back(unitX->getIDInfo());
+				}
+			}
+
+			foreach_(const IDInfo& cargoUnitId, cargoManifest)
+			{
+				CvUnit* unitX = getUnit(cargoUnitId);
+
+				// Gone, or no longer ours, since the manifest was taken.
+				if (unitX == NULL || unitX->getTransportUnit() != this)
 				{
 					continue;
 				}

--- a/docs/reference/unit-lifecycle.md
+++ b/docs/reference/unit-lifecycle.md
@@ -130,11 +130,21 @@ routes, all live:
 - `scheduleDeath`'s cargo loop → `unitX->kill(bDelay, …)` — a nested full death sequence per cargo unit.
 - `die()`'s capture block → `pkCapturedUnit->kill(false, …)` and the Python `unitCaptured` handler.
 
-⚠ **The cargo loop iterates `pPlot->units()` — the unmutated view — while its nested kills can delete units
-from that very list** when `bDelay` is false (which is every Python kill, `doDelayedDeath`'s reap, and the
-flanking kill). `units_safe()` is the snapshot variant used elsewhere for exactly this
-(`CvUnit::setXY`, `CvSelectionGroup::doDelayedDeath`). This is a known hazard in the cargo path, not a
-statement that it is safe.
+⛔ **The cargo loop walks a MANIFEST taken before it starts, never the live plot list — and the reason is that
+resolving a cargo unit's fate mutates that list by TWO independent routes.** An **escaping** unit leaves the
+plot through `setXY`, and a **drowning** one is deleted outright whenever `bDelay` is false (every Python kill,
+`doDelayedDeath`'s reap, the flanking kill). ⚠ So the escape route mutates the container *whatever* `bDelay`
+says: forcing the recursive kill to delay would not have made the live walk safe.
+
+⚑ **The manifest holds IDENTITIES (`IDInfo`), not pointers, and that is the half a snapshot alone does not
+buy.** `units_safe()` copies raw `CvUnit*` (`copy_iterator`), which survives container mutation but not
+DELETION — and a nested cargo cascade (a transport carrying a transport) frees units that are themselves on
+this plot, so a pointer snapshot can be left holding freed memory that the loop's own transport guard then
+dereferences. Each entry is re-resolved through `getUnit(IDInfo)` instead, so a unit that died meanwhile
+resolves to NULL and is skipped — which is correct, it is already dead.
+
+⚖ The set walked is therefore the cargo manifest **at the moment of the killing blow**, which is the thing
+being resolved; the draws are unchanged, in the same order, over the same units.
 
 ## See also
 - [spine.md](../spine.md) — `SEVT_UNIT_KILLED` / `SEVT_UNIT_DEATH_SCHEDULE_ADDED / _REMOVED` and the reseed.


### PR DESCRIPTION
Closes #452.

`CvUnit::scheduleDeath`'s cargo block iterated `pPlot->units()` — the **live view** — while resolving each cargo unit's fate mutates that very list. Undefined behaviour on a path that runs whenever a loaded transport dies.

## The list is mutated by TWO independent routes

This is the finding that changes the fix, and neither of the issue's two proposed options survives it:

| route | when |
|---|---|
| a **drowning** cargo unit is **deleted** | whenever `bDelay` is false — every Python kill (all 19 `CyUnit::kill` sites), `doDelayedDeath`'s reap, the flanking kill |
| an **escaping** cargo unit leaves via `setXY` | **regardless of `bDelay`** |

⇒ **Forcing the recursive kill to `bDelay=true`** (the issue's decision #2) would *not* have made the live walk safe — the survival path still moves units out of the container being iterated.

⇒ **A pointer snapshot alone is also insufficient.** `units_safe()` is `copy_iterator`, which copies raw `CvUnit*`: that survives container mutation but **not deletion**. A nested cargo cascade — a transport carrying a transport — frees units that are themselves on this plot, so such a snapshot can be left holding freed memory, which the loop's own transport guard then dereferences.

## The fix: identities, not pointers

The manifest is collected as `IDInfo` **before** the walk, and each entry is re-resolved through `getUnit(IDInfo)` — the same resolution `getTransportUnit()` itself uses. A unit that died meanwhile resolves to `NULL` and is skipped, which is correct: it is already dead.

This closes both routes and the nested-cascade case together.

## No semantic change — so the issue's open question needs no ruling

The issue asked for a decision on snapshot-vs-live cargo semantics. This shape sidesteps it:

- the **same cargo set** is walked, in the **same order**
- the **same `bDelay`** is passed through
- the **same synchronized draws** happen, in the same sequence — which matters, because the draw count and order on that stream are shared save state
- the only units skipped are ones **already dead** or **no longer this transport's cargo**, both of which the live walk would also have passed over

That set *is* the cargo manifest at the moment of the killing blow — which the issue itself argued is the correct semantic.

## Docs

`docs/reference/unit-lifecycle.md` carried this as a known live hazard ("not a statement that it is safe"). Updated in the same change, including why neither single-fix option was sufficient — the escape route defeating `bDelay`, and `copy_iterator` not surviving deletion.

## Verification

`Assert rebuild` green, 41.8s. `verify-docs` links/anchors pass. ⚠ No runtime verification: reproducing this needs a loaded transport dying via a `bDelay=false` path with a nested cargo cascade — the change is argued from the mutation routes, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUMESCMx2CKVYmJzqFkBNQ