### PR TITLE
fix: stop AI_formArmies destroying the army list and corrupting its ID counter

### DIFF
--- a/Sources/AI/CvPlayerAI.cpp
+++ b/Sources/AI/CvPlayerAI.cpp
@@ -32725,11 +32725,6 @@ void CvPlayerAI::AI_formArmies()
 			CvArmy* pArmy = NULL;
 			if (m_armies.getCount() == 0 || bArmyGrouped)
 			{
-				if (m_armies.getCurrentID() == 8192) //Cavltix - if not init
-				{
-					m_armies.init();
-					m_armies.setCurrentID(1);
-				}
 				// Create the army
 				bArmyGrouped = false;
 				pArmy = m_armies.add();

--- a/Sources/Engine/CvPlayer.cpp
+++ b/Sources/Engine/CvPlayer.cpp
@@ -319,8 +319,11 @@ void CvPlayer::baseInit(PlayerTypes eID)
 
 	}
 #ifdef CVARMY_BREAKSAVE
+	// init() already seeds m_iCurrentID with FLTA_MAX_BUCKETS, which IS the valid initial id for this
+	// container. Overwriting it with 0 broke the format invariant setCurrentID itself asserts (the id bits
+	// may not be zero) and left the counter one add() away from the value a caller was reading as
+	// "uninitialised".
 	m_armies.init(1);
-	m_armies.setCurrentID(0);
 #endif // CVARMY_BREAKSAVE
 
 	m_eventsTriggered.init();


### PR DESCRIPTION
Closes #364.

```cpp
if (m_armies.getCurrentID() == 8192) // Cavltix - if not init
{ m_armies.init(); m_armies.setCurrentID(1); }
```

**8192 is `FLTA_MAX_BUCKETS`, and it is the CORRECT initial value** — both the `FFreeListTrashArray` constructor and `init()` seed `m_iCurrentID` with exactly it. The test does not detect an uninitialised array; it detects a healthy one.

## What it actually did — worse than a stray assert

`baseInit` ran `m_armies.init(1); m_armies.setCurrentID(0);` — `init()` correctly set 8192 and **the next line overwrote it with 0**. The first `add()` then saw `iLastUsed(0) == currentID(0)` and advanced the counter to **8192**.

⇒ As soon as **one** army existed, the sentinel matched. And `init()` begins with `uninit()`, which **deletes every element** — so the player's armies were destroyed the next time this branch ran, and the counter re-seeded from a malformed base where `setID(1 + index)` puts index bits inside the id field.

Both writes also violate the format invariants `setCurrentID` itself asserts (`1` has index bits set and no id bits; `0` has no id bits) — the reported ~12 firings/turn, 6 occurrences × both invariants. ⚠ In FinalRelease the asserts compile out; the corruption does not.

## The fix is deletion on both sides

- the re-init dance goes — the container is already initialised in `baseInit`, and `add()` manages the counter
- the `setCurrentID(0)` goes with it, because `init(1)` has already seeded the valid initial id, and overwriting it is what put the counter one `add()` away from the sentinel in the first place

Fixing only the reported site would have left the counter still starting at 0.

## Checked, not assumed

- **No siblings:** after this change the tree contains **no caller** of `setCurrentID` or `getCurrentID` outside the container.
- **The accessors STAY** — they are live and load-bearing for the FLTA save `Read`/`Write` paths (`:570`, `:605`, `:654`, `:704`, `:744`), so this is not a dead-code removal.
- **No save migration needed** — `m_armies` is not serialized and `baseInit` re-initialises it per load, so no save carries the corrupted counter.
- `CVARMY_BREAKSAVE` is defined unconditionally in `Sources/Defines/CvDefines.h:10`, so the `baseInit` half is live in every build rather than a dormant branch.

## Verification

`Assert rebuild` green, 40.0s. ⚠ Runtime confirmation wants an Assert end-turn on a mature save — the `CvGame::updateMoves` → `setTurnActive` → `AI_doTurnUnitsPre` → `AI_formArmies` assert stack should be gone. Not run here; flagging it as the thing to look at.

⚑ Worth noting for #410 (AI armies umbrella): armies being wiped once the first one formed is a plausible contributor to "the AI never forms real armies", so that umbrella may want re-testing after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUMESCMx2CKVYmJzqFkBNQ