### PR TITLE
cleanup: drop the dead DCM air-bomb tech capability from the curator and the data

### DIFF
--- a/Assets/Data/techs/atomic/tech_guided_weapons.json
+++ b/Assets/Data/techs/atomic/tech_guided_weapons.json
@@ -42,9 +42,6 @@
    ]
   }
  },
- "capabilities": {
-  "dcmAirBomb2": true
- },
  "cost": {
   "research": 15474
  },

--- a/Assets/Data/techs/industrial/tech_radio.json
+++ b/Assets/Data/techs/industrial/tech_radio.json
@@ -43,9 +43,6 @@
    ]
   }
  },
- "capabilities": {
-  "dcmAirBomb1": true
- },
  "cost": {
   "research": 7718
  },

--- a/Sources/Infos/CvClassificationIds.h
+++ b/Sources/Infos/CvClassificationIds.h
@@ -218,7 +218,7 @@ enum CharacteristicClsTypes
 	NUM_CLS_CHARACTERISTIC_TYPES = 9
 };
 
-// CLSD_CAPABILITY -- the `capabilities` block (17 authored keys)
+// CLSD_CAPABILITY -- the `capabilities` block (15 authored keys)
 enum CapabilityClsTypes
 {
 	CLS_CAPABILITY_CAN_BUILD_BRIDGES = 0,
@@ -232,13 +232,11 @@ enum CapabilityClsTypes
 	CLS_CAPABILITY_CAN_SET_ESPIONAGE_RATE = 8,
 	CLS_CAPABILITY_CAN_SET_SCIENCE_RATE = 9,
 	CLS_CAPABILITY_CAN_SPREAD_IRRIGATION = 10,
-	CLS_CAPABILITY_DCM_AIR_BOMB_1 = 11,
-	CLS_CAPABILITY_DCM_AIR_BOMB_2 = 12,
-	CLS_CAPABILITY_HAS_CENTERED_MAP = 13,
-	CLS_CAPABILITY_HAS_LANGUAGE = 14,
-	CLS_CAPABILITY_HAS_RIVER_TRADE = 15,
-	CLS_CAPABILITY_HAS_WHOLE_MAP_REVEALED = 16,
-	NUM_CLS_CAPABILITY_TYPES = 17
+	CLS_CAPABILITY_HAS_CENTERED_MAP = 11,
+	CLS_CAPABILITY_HAS_LANGUAGE = 12,
+	CLS_CAPABILITY_HAS_RIVER_TRADE = 13,
+	CLS_CAPABILITY_HAS_WHOLE_MAP_REVEALED = 14,
+	NUM_CLS_CAPABILITY_TYPES = 15
 };
 
 // CLSD_POLICY -- the `policies` block (20 authored keys)
@@ -496,8 +494,6 @@ static const char* const CLS_SEED_CLSD_CAPABILITY[] =
 	"canSetEspionageRate",
 	"canSetScienceRate",
 	"canSpreadIrrigation",
-	"dcmAirBomb1",
-	"dcmAirBomb2",
 	"hasCenteredMap",
 	"hasLanguage",
 	"hasRiverTrade",

--- a/Sources/Infos/CvClassificationRegistry.cpp
+++ b/Sources/Infos/CvClassificationRegistry.cpp
@@ -27,7 +27,7 @@ namespace
 
 	// camelCase / snake_case key -> UPPER_SNAKE: '_' before an upper that starts a word (prev lower, or next
 	// lower after an acronym run) and before a digit run following a letter. "setScienceRate" -> SET_SCIENCE_RATE,
-	// "maxHP" -> MAX_HP, "dcmAirBomb" -> DCM_AIR_BOMB, "is_cargo_vessel" -> IS_CARGO_VESSEL.
+	// "maxHP" -> MAX_HP, "adds3rdRing" -> ADDS_3RD_RING, "is_cargo_vessel" -> IS_CARGO_VESSEL.
 	std::string clsUpperSnake(const std::string& key)
 	{
 		std::string out;

--- a/Tools/Migration/curate_tech.py
+++ b/Tools/Migration/curate_tech.py
@@ -119,7 +119,11 @@ def allowed_fn(rec, store):
 
 
 CFG = cc.EntityConfig("TechInfo", cost_rename={"iCost": "research"}, grants=GRANTS, era_fn=era_fn,
-                      requires_fn=requires_fn, allowed_fn=allowed_fn, extra_drop={"bGlobal"},
+                      # bDCMAirBombTech1/2 gated DCM air bombing, a subsystem that is gone from the engine.
+                      # DROPPED explicitly rather than merely unmapped: an unmapped bool falls through to
+                      # identity, and identity carries no effects.
+                      requires_fn=requires_fn, allowed_fn=allowed_fn,
+                      extra_drop={"bGlobal", "bDCMAirBombTech1", "bDCMAirBombTech2"},
                       enabler_block="capabilities")   # tech enabler channels are empire CAPABILITIES (owner 2026-06-29)
 
 

--- a/Tools/Migration/mapping/TechInfo.json
+++ b/Tools/Migration/mapping/TechInfo.json
@@ -39,9 +39,7 @@
     "bMapCentering": {"scope": "team", "channel": "hasCenteredMap", "kind": "enabler"},
     "bMapVisible": {"scope": "team", "channel": "hasWholeMapRevealed", "kind": "enabler"},
     "bRebaseAnywhere": {"scope": "player", "channel": "canRebaseAnywhere", "kind": "enabler"},
-    "bLanguage": {"scope": "team", "channel": "hasLanguage", "kind": "enabler"},
-    "bDCMAirBombTech1": {"scope": "team", "channel": "dcmAirBomb1", "kind": "enabler"},
-    "bDCMAirBombTech2": {"scope": "team", "channel": "dcmAirBomb2", "kind": "enabler"}
+    "bLanguage": {"scope": "team", "channel": "hasLanguage", "kind": "enabler"}
   },
   "inversionsOut": {},
   "enablerEdges": {},


### PR DESCRIPTION
Refs #446 — clears the tractable half. **Deliberately does not close it**; see what remains.

DCM air bombing is gone from the engine, but the curator still mapped the two legacy tech tags into a live capability channel, so **every regen re-emitted them**:

```json
"bDCMAirBombTech1": {"scope":"team","channel":"dcmAirBomb1","kind":"enabler"}
```

That minted `CLS_CAPABILITY_DCM_AIR_BOMB_1/2` and wrote a `capabilities` block into two tech files, for a capability **no C++ consumer reads**.

## Dropped explicitly, not merely unmapped — and that distinction is the whole fix

Removing the channel mapping alone does **not** drop the tag. An unmapped bool **falls through to `identity`**, and my first attempt emitted:

```json
"dCMAirBombTech2": true
```

into the identity block — *strictly worse* than the capability it replaced, since json.md §7 is explicit that identity carries no effects and an effect authored there is a data error. I caught it by diffing the regen rather than assuming.

So the tags are named in `curate_tech`'s `extra_drop` beside `bGlobal` — the same knowingly-dropped treatment the per-instance cost ramp (superseded-ideas #25) and the HN capture mark (#29) already take.

Both techs carried nothing else in `capabilities`, so the block goes entirely rather than being left empty.

## The regenerated id table

`CvClassificationIds.h`: the capability category drops **17 → 15** keys, and the four constants after the removed pair shift down. Safe by construction — the enum and its seed table regenerate together, **nothing serializes a classification id**, and there is no consumer of `CLS_CAPABILITY_DCM_AIR_BOMB_*` (checked).

The naming-example comment in `CvClassificationRegistry.cpp` used `"dcmAirBomb"` to illustrate the digit rule; it now uses `"adds3rdRing"`, a live key demonstrating the same rule.

## Deliberately NOT touched

- **The legacy XML tags** in `Assets/XML` and `Assets/Modules` — curator **input**, which stays.
- **Their entries in the curator's handled sets** for units and buildings. Unlisting those would make the tags *unhandled* and start reporting as unconsumed keys — the opposite of the intent.

## What remains on #446

Only the **mission-XML question**: `CIV4MissionInfos.xml` declares **135** `MISSION_*` rows against **99** `REGISTER_MISSION` calls. ⚠ That gap is *not* airbomb-specific — the five `MISSION_AIRBOMB1-5` rows are only 5 of the 36 — and `MissionTypes` ordinals are index-based, so removing rows risks the ordinal-shift class AGENTS.md records (the deletion that turned off every close button). It wants understanding on its own terms, and arguably its own issue.

## Verification

| check | result |
|---|---|
| unmodified regen first | **zero diff** — proves the committed data was in sync, so this diff is purely the change |
| `Assert rebuild` | green, 41.0s |
| `XmlValidator -a` (from `Assets/`) | **404 files**, no errors |
| `grep -ri dcmairbomb Assets/Data` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUMESCMx2CKVYmJzqFkBNQ