### PR TITLE
fix: AI_refreshExploreRange no longer reports a non-advancing move as progress

### DIFF
--- a/Sources/AI/CvUnitAI.cpp
+++ b/Sources/AI/CvUnitAI.cpp
@@ -17132,15 +17132,18 @@ bool CvUnitAI::AI_refreshExploreRange(int iRange, bool bIncludeVisibilityRefresh
 		}
 	}
 
-	if (pBestPlot && pBestExplorePlot)
+	//	⛔ COMMIT ONLY A MOVE THAT ACTUALLY ADVANCES THIS TURN. For a land unit pBestPlot IS
+	//	getPathEndTurnPlot() -- where this turn's movement ends -- so atPlot(pBestPlot) means the pathfinder
+	//	has already said the unit finishes the turn where it stands. Pushing toward the far explore plot in
+	//	that state cannot advance it, yet returns TRUE, so the caller reads a no-op as progress and asks
+	//	again at the same plot every slice until the engine's own re-decide backstop trips.
+	//	Answering FALSE hands the caller its terminating fallbacks (borders / patrol / safety / SKIP), which
+	//	is what actually ends the unit's turn.
+	if (pBestPlot && pBestExplorePlot && !atPlot(pBestPlot))
 	{
 		PROFILE("AI_exploreRange 4");
 
-		FAssert(!atPlot(pBestPlot));
-		if (!atPlot(pBestPlot))
-			return getGroup()->pushMissionInternal(MISSION_MOVE_TO, pBestPlot->getX(), pBestPlot->getY(), MOVE_NO_ENEMY_TERRITORY | MOVE_HEAL_AS_NEEDED25, false, false, MISSIONAI_EXPLORE, pPreviouslySelectedPlot != NULL ? pPreviouslySelectedPlot : pBestExplorePlot);
-		else if (!atPlot(pBestExplorePlot))
-			return getGroup()->pushMissionInternal(MISSION_MOVE_TO, pBestExplorePlot->getX(), pBestExplorePlot->getY(), MOVE_NO_ENEMY_TERRITORY | MOVE_HEAL_AS_NEEDED25, false, false, MISSIONAI_EXPLORE, pPreviouslySelectedPlot != NULL ? pPreviouslySelectedPlot : pBestExplorePlot);
+		return getGroup()->pushMissionInternal(MISSION_MOVE_TO, pBestPlot->getX(), pBestPlot->getY(), MOVE_NO_ENEMY_TERRITORY | MOVE_HEAL_AS_NEEDED25, false, false, MISSIONAI_EXPLORE, pPreviouslySelectedPlot != NULL ? pPreviouslySelectedPlot : pBestExplorePlot);
 	}
 	if (candidatesRejectedForMoveSafety)
 	{


### PR DESCRIPTION
Closes #189.

The function could return `TRUE` while leaving the unit exactly where it started, so the caller counted a no-op as progress and re-asked at the same plot every slice until the engine's own re-decide backstop tripped — ~50 expensive re-decides per stuck unit per turn, which reads as a turn hang once several units are in it.

## The no-progress branch was structural, not incidental

```cpp
FAssert(!atPlot(pBestPlot));
if (!atPlot(pBestPlot))             // progresses -> push
    return pushMissionInternal(... pBestPlot ...);
else if (!atPlot(pBestExplorePlot)) // <-- reached ONLY when no progress is possible
    return pushMissionInternal(... pBestExplorePlot ...);
```

For a land unit **`pBestPlot` IS `getPathEndTurnPlot()`** — where this turn's movement ends. So reaching the `else if` meant the pathfinder had *already said* the unit finishes the turn where it stands. Pushing toward the distant explore plot from there cannot advance it: same path, same flags, same answer.

⇒ The branch existed **only** for the state in which no progressing move exists, and it converted that state into a `TRUE` return.

⚑ The `FAssert` directly above it asserted `!atPlot(pBestPlot)` — *the very condition the branch was there to handle*. The code asserted the state could not occur while carrying a handler for it. Both go.

## Why returning FALSE is the right answer

It is what the callers already expect. `CvHunterAI::hunterMove` falls through to `AI_moveToBorders` and its terminating fallbacks; the `CvUnitAI` explore path continues to its own tail. **Those are the steps that actually END a unit's turn** — and the spurious `TRUE` was precisely what kept them from ever being reached.

This is the **pseudo-progress terminal** class AGENTS.md catalogues (a free action that cannot change the state must not satisfy the decision loop), and the fix is the one that rule prescribes: the step stops being turn-satisfying, rather than being made cheaper.

## Deliberately unchanged

⚠ **`CvHunterAI::detectSpin` stays.** It bounds the *symptom* (8 re-decides instead of ~50) and remains the backstop for any other source of the same shape. This removes one cause; it is not a reason to drop the guard.

## Verification

`Assert rebuild` green, 45.6s.

⚠ Runtime confirmation is a FinalRelease turn on a mature save, which I have not run: `HunterAI.log` should stop showing repeated `[HAI/begin]` at a single plot for one unit (the issue recorded 53 entries, 51 at `(63,7)`), and `detectSpin`'s firing rate should fall sharply from the reported ~15/turn. That rate is a good measurable acceptance signal if you want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUMESCMx2CKVYmJzqFkBNQ