### PR TITLE
fix(ai): stop asserting on the contract broker's documented NULL join unit (#336)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -630,6 +630,19 @@ with no worker at all can never build its first one.
   call sites never checked the counter at all. ⇒ Gate it centrally, in `AI_chooseUnit`, never per call site.
   ⚑ `[CIT/order] action=tenderUnit` records the demand: before it, the order log carried construct and
   maintainProcess only, so unit production was invisible in the one place a reader looks for what a city decided.
+- **⚖ A WORK REQUEST NAMES EITHER A UNIT TO JOIN OR A PLACE TO GO, AND THE PLACE IS THE COMMON CASE — so a
+  NULL `pJoinUnit` is the CONTRACT, never a failure.** `advertiseWork` stores `iUnitId = -1` whenever it is
+  handed no join unit, and `findUnit(-1)` answers NULL by an explicit early return; the two `CvCityAI` requests
+  (the floating-defender ask and the city's own unit demand) are exactly that shape, and they are the highest-
+  volume requests in the game. Every consumer is written for it — `finalizeTenderContracts` falls back to the
+  recorded plot, `processContracts` branches on NULL at each step and picks `MISSIONAI_CONTRACT` over
+  `MISSIONAI_CONTRACT_UNIT`.
+  ⛔ **So do NOT read a NULL join unit as a dead-unit symptom, and never assert against it** — an
+  `FAssert(NULL != pJoinUnit)` fires on the ordinary majority path and buries the one case that IS a defect.
+  ⚖ **THAT case is a request whose `iUnitId` is NOT -1 and no longer resolves:** it named a unit and lost it, so
+  the rendezvous is stale and the contract is RELEASED (`[CTB/contract/lost] action=joinGone`), returning the
+  unit to the market rather than walking it to an empty plot. ⚑ The discriminator is `iUnitId != -1`, never
+  the NULLness of the resolved pointer — those are two different questions and only the first one separates them.
 - **⛔ DISTANCE IS A GATE AND A TIE-BREAK, NEVER A TERM IN THE SCORE.** Path distance does not belong in scoring
   at all: over-relying on travel speed is how the AI ends up spamming fast cheap units. A bid that depreciates by
   its own haul rewards a unit for being FAST on top of already rewarding it for being CHEAP — cheap-and-fast wins

--- a/Sources/AI/CvContractBroker.cpp
+++ b/Sources/AI/CvContractBroker.cpp
@@ -90,6 +90,7 @@ namespace
 
 		// [CTB/contract/lost]
 		CTB_CONTRACT_LOST,             // [CTB/contract/lost] unit= workRequest=
+		CTB_CONTRACT_JOIN_GONE,        // [CTB/contract/lost] action=joinGone unit= workRequest= joinUnit=
 
 		// [CTB/contract]
 		CTB_CONTRACT_DISPATCHED,       // [CTB/contract] unit= atX= atY= priority= aiType= joinUnit= workRequest=
@@ -149,6 +150,7 @@ namespace
 		case CTB_MATCH_SATISFIED:       return "[CTB/match] action=satisfied";
 		case CTB_MATCH_PARTIAL:         return "[CTB/match/partial]";
 		case CTB_CONTRACT_LOST:         return "[CTB/contract/lost]";
+		case CTB_CONTRACT_JOIN_GONE:    return "[CTB/contract/lost] action=joinGone";
 		case CTB_CONTRACT_DISPATCHED:   return "[CTB/contract] action=dispatched";
 		case CTB_CONTRACT_NOMATCH:      return "[CTB/contract] action=noMatch";
 		case CTB_CONTRACT_NOTLISTED:    return "[CTB/contract] action=notListed";
@@ -1372,13 +1374,30 @@ bool CvContractBroker::makeContract(CvUnit* pUnit, int& iAtX, int& iAtY, CvUnit*
 					m_advertisingUnits[iI].iContractedWorkRequest = -1;
 					return false;
 				}
-				FAssert(NULL != contractedRequest);
 
 				iAtX = contractedRequest->iAtX;
 				iAtY = contractedRequest->iAtY;
 
 				pJoinUnit = findUnit(contractedRequest->iUnitId);
-				FAssert(NULL != pJoinUnit);
+
+				//	A NULL join unit has two causes and only one of them is a defect. A request whose
+				//	iUnitId is -1 never named a unit at all -- the work is a PLACE (the city requests
+				//	above), and the whole consumer side is written for it. But a request that DID name a
+				//	unit and no longer resolves has lost the thing being joined, so the rendezvous is
+				//	stale: releasing it here is the same answer the lost-request branch gives above, and
+				//	it puts the unit back on the market instead of walking it to an empty plot.
+				if (contractedRequest->iUnitId != -1 && pJoinUnit == NULL)
+				{
+					log(1, "[CTB/contract/lost] unit=%d contracted workRequest=%d joinUnit=%d no longer exists, releasing",
+						pUnit->getID(), iWorkRequest, contractedRequest->iUnitId);
+					eventSpine().emit(CvSpineEvent(EVENTKIND_DIAGNOSTIC, SD_CONTRACT, CTB_CONTRACT_JOIN_GONE, 1)
+						.addI(CTBF_unit, pUnit->getID())
+						.addI(CTBF_workRequest, iWorkRequest)
+						.addI(CTBF_joinUnit, contractedRequest->iUnitId));
+					m_advertisingUnits[iI].iContractedWorkRequest = -1;
+					return false;
+				}
+
 				// [CTB/contract] -- the broker matches a unit to a work request (the
 				// key decision: this unit is dispatched to satisfy that need).
 				log(1, "[CTB/contract] unit=%d -> work at (%d,%d) priority=%d aiType=%d joinUnit=%d (workRequest=%d)",


### PR DESCRIPTION
Closes #336.

## The issue's diagnosis was wrong

#336 read the ~50×/turn `FAssert(NULL != pJoinUnit)` as *"requests routinely outlive their requesting units"*, and proposed releasing the contract whenever `pJoinUnit` is NULL.

That would have broken the common path badly. `advertiseWork` stores `iUnitId = -1` whenever it is handed no join unit, and `findUnit(-1)` returns NULL by an explicit early return:

```cpp
if (pJoinUnit == NULL) { newRequest.iUnitId = -1; }
else                   { newRequest.iUnitId = pJoinUnit->getID(); }
```

The header documents this in as many words — *"pJoinUnit may be NULL but if not it is a request to join that unit's group"*. Of the 13 `advertiseWork` call sites, **two pass NULL** — both in `CvCityAI`: the floating-defender request and the city's own unit demand. Those are the highest-volume requests in the game, which is the whole 50×/turn with no dead unit anywhere in the story.

The assert was asserting the opposite of the contract, and the issue's fix would have released every city work request.

## Three consumers already handled it; the assert did not

| site | behaviour on a NULL/unresolvable join unit |
|---|---|
| `finalizeTenderContracts` | falls back to the recorded plot — deliberate |
| `postProcessUnitsLookingForWork` | `[CTB/postprocess] action=gone`, skips — routine |
| `processContracts` | branches on NULL at **every** step; picks `MISSIONAI_CONTRACT` over `MISSIONAI_CONTRACT_UNIT` |
| `makeContract` | **asserted** |

## The real defect underneath

The noise was hiding one genuine case: a request that *did* name a unit whose id no longer resolves. There the rendezvous really is stale, and the old code dispatched the worker to it regardless.

That case now releases the contract exactly as the `[CTB/contract/lost]` branch directly above does, returning the unit to the market. **The discriminator is `iUnitId != -1`, not the NULLness of the resolved pointer** — those are two different questions, and only the first separates the legitimate case from the defect.

New spine fact `[CTB/contract/lost] action=joinGone` carries `unit`/`workRequest`/`joinUnit`, so the frequency of the real case is now measurable rather than inferred. It reuses existing `CTBF_*` field tags, so there is no new field declaration and no `verify-spine-fields` exposure.

Also drops `FAssert(NULL != contractedRequest)`, which the NULL branch three lines above already returned on.

## Verification

- `Assert rebuild` green, 45.2s, zero errors, zero `C1003`.
- `verify-docs.py`: links clean (1660 checked).
- C++ only — no Python, XML, or serialized state touched.
- **Not run:** a live turn. The behaviour change on the real case is a release-and-re-advertise; a tester should watch `ContractBroker.log` for `action=joinGone` lines, which are now the only thing that should appear where the assert used to. `Asserts.log` should lose the `makeContract:893` family entirely.

## Docs

`AGENTS.md` § THE CONTRACT BROKER gains the rule: a work request names either a unit to join or a place to go, the place is the common case, and NULL is therefore the contract rather than a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
