### PR TITLE
fix(data): give Tribal Guardian a defaultUnitAI its allowed list permits (#399)

### DIFF
--- a/Assets/Data/units/unit_tribal_guardian.json
+++ b/Assets/Data/units/unit_tribal_guardian.json
@@ -98,6 +98,7 @@
   "xpValueAttack": 1,
   "xpValueDefense": 2,
   "domain": "DOMAIN_LAND",
+  "defaultUnitAI": "UNITAI_CITY_DEFENSE",
   "formationType": "FORMATION_TYPE_DEFAULT",
   "advisor": "ADVISOR_MILITARY",
   "unitAIs": [

--- a/Assets/XML/Units/U_Land_CIV4UnitInfos.xml
+++ b/Assets/XML/Units/U_Land_CIV4UnitInfos.xml
@@ -22504,6 +22504,7 @@
             <iMaxPlayerInstances>1</iMaxPlayerInstances>
             <bUnlimitedException>1</bUnlimitedException>
             <Special>SPECIALUNIT_PEOPLE</Special>
+			<DefaultUnitAI>UNITAI_CITY_DEFENSE</DefaultUnitAI>
 			<Description>TXT_KEY_UNIT_TRIBAL_GUARDIAN</Description>
 			<Civilopedia>TXT_KEY_UNIT_TRIBAL_GUARDIAN_PEDIA</Civilopedia>
 			<Advisor>ADVISOR_MILITARY</Advisor>


### PR DESCRIPTION
Closes #399.

## The mismatch, confirmed against the tree

`unit_tribal_guardian.json` carried no `identity.defaultUnitAI`, so `CvUnitInfo::readJson` took its fallback:

```cpp
m_iDefaultUnitAI = jsonIdFk(*pIdentity, "defaultUnitAI");
if (m_iDefaultUnitAI < 0)
{
    // legacy load default: -1 negative-indexes the AI count arrays
    m_iDefaultUnitAI = GC.getInfoTypeForString("UNITAI_UNKNOWN");
}
```

`UNITAI_UNKNOWN` is **not** in the unit's own `identity.unitAIs`, which is `["UNITAI_CITY_DEFENSE"]` and nothing else. So the unit's default role was one it is not permitted to hold, against an allowed list of exactly one other role.

Because the allowed list holds **exactly one** role, there is only one self-consistent default. This is a consistency repair with a single possible answer, not the balance call the issue's second option (widening the allowed list) would have been.

## It was the last one

#399 recorded *"2 of 2074"* units without the key and asked that the other be checked. A fresh census over `Assets/Data/units`:

```
unit jsons scanned: 2073
without identity.defaultUnitAI: 1
   UNIT_TRIBAL_GUARDIAN | unitAIs= ['UNITAI_CITY_DEFENSE']
```

The sibling was fixed in the interim. With this change the count is **zero**, and the `UNITAI_UNKNOWN` fallback no longer fires for any authored unit.

## Pipeline

`Assets/Data/**` is derived, so the fix went into the curator input — `<DefaultUnitAI>UNITAI_CITY_DEFENSE</DefaultUnitAI>` on `U_Land_CIV4UnitInfos.xml`, placed where sibling entries carry it — followed by a full `curate_unit.py --write`.

**The regen over all 2073 units produced a one-line diff.** That is simultaneously the proof that the committed data was in sync beforehand and that this change is isolated to the one field.

## Verification

- `XmlValidator.exe -a` from `Assets/` in PowerShell: **404 files, no errors** (file count checked, not just the "without error(s)" line).
- `curate_unit.py --sample UNIT_TRIBAL_GUARDIAN`: `"defaultUnitAI": "UNITAI_CITY_DEFENSE"` present in the identity block.
- `curate_unit.py --write`: 2073 UnitInfo + 7 SpecialUnitInfo written, diff = 1 line.
- No C++ change, so no build needed.

## Left open deliberately — the systemic half

#399 also notes that *"a `defaultUnitAI`-less unit is a silent fallback to a role it may not be allowed, and the fallback produces no error."* That is true and is **not** fixed here.

Two directions, and neither is a small change:

1. **Fail loud** — a "missing required key" census alongside the existing `[READJSON] ERROR unknown-key` / `unresolvedFk` coverage in `CvReadJson.cpp`. This fits the fail-loud discipline, but it is a new census class in the load pipeline, not a line.
2. **Auto-pick `unitAIs[0]`** when the key is absent. Tempting and tiny — but it is silent self-repair, which masks the authoring error rather than surfacing it, so it points the wrong way.

Raising rather than building: the concrete defect is closed, and whether the load pipeline should grow a missing-key census is a design call worth making on its own terms. Happy to take direction either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
