### PR TITLE
feat(readjson): census the MISSING required key — the reader's quietest miss

### DIFF
--- a/Sources/Data/CvReadJson.cpp
+++ b/Sources/Data/CvReadJson.cpp
@@ -71,7 +71,10 @@ enum RjEvt
 	RJE_KEY_UNKNOWN,   // a non-reserved object key outside the closed family vocabulary ("<type>:<key>")
 	RJE_REMAPPED,      // one aliased entity's full-registry section re-map: what it maps (type + edge/family counts)
 	RJE_MAP_DONE,      // the initial JSON map (PASS 1+2) is DONE -- entities/resolved/remapped/ms
-	RJE_REVERSE_DONE   // the general reverse pass (RELATED + REQUIRED_BY + own-output landing) is DONE -- add counts/ms
+	RJE_REVERSE_DONE,  // the general reverse pass (RELATED + REQUIRED_BY + own-output landing) is DONE -- add counts/ms
+	//	⚠ APPENDED, never inserted: the numeric event id rides the /events stream, so renumbering an existing one
+	//	silently re-labels every line a reader has already captured (engine.md -- prefer adding at the END).
+	RJE_KEY_MISSING    // a REQUIRED key the entity did not author ("<type>:<key>=<fallback>") -- the silent default
 };
 
 // DOMAIN-LOCAL field tags, shared by name across lines where a field recurs.
@@ -104,6 +107,7 @@ static const char* rj_prefix(int evt)
 	case RJE_EDGE_UNRES:   return "[READJSON/unresolved-fk]";
 	case RJE_SECTION_UNCONSUMED: return "[READJSON/unconsumed-section]";
 	case RJE_KEY_UNKNOWN:  return "[READJSON/unknown-key]";
+	case RJE_KEY_MISSING:  return "[READJSON/missing-key]";
 	case RJE_GRANT_SURVEY: return "[READJSON/grant-survey]";
 	case RJE_GRANT_UNRES:  return "[READJSON/grant-unresolved]";
 	case RJE_KEY:          return "[READJSON/key]";
@@ -672,6 +676,14 @@ void loadJson(JsonLoadPhase eLoadPhase)
 	for (std::set<std::string>::const_iterator it = unknownKeys.begin(); it != unknownKeys.end(); ++it)
 		eventSpine().emit(CvSpineEvent(EVENTKIND_DIAGNOSTIC, SD_READJSON, RJE_KEY_UNKNOWN, 1).addStr(RJF_ID, it->c_str()));
 
+	// MISSING REQUIRED keys, per authoring entity ("<type>:<key>=<fallback>", recorded by the reading info at the
+	// site that substitutes the default). The mirror of the unknown-key census and the quietest of the four: an
+	// unknown key is data the reader cannot place, this is data that was never there at all, so nothing about the
+	// parse looks wrong and the substituted value is indistinguishable from an authored one.
+	const std::set<std::string>& missingKeys = jsonMissingKeys();
+	for (std::set<std::string>::const_iterator it = missingKeys.begin(); it != missingKeys.end(); ++it)
+		eventSpine().emit(CvSpineEvent(EVENTKIND_DIAGNOSTIC, SD_READJSON, RJE_KEY_MISSING, 1).addStr(RJF_ID, it->c_str()));
+
 	gDLL->logMsg("Loading.log", CvString::format("[READJSON] step spine-emits-done ms=%u", (unsigned)(GetTickCount() - s2sT0)).c_str(), true, false);
 	// READ-BACK survey: reconstruct the modifier stats + per-entity structure counts from the MAPPED data (the
 	// home) -- the compiled §6 entries on getModifiers(), the spec model (docs/architecture/patterns.md §The INFO DATA-OUT contract (info-side, never cascade-side)) -- proving the
@@ -814,8 +826,15 @@ void loadJson(JsonLoadPhase eLoadPhase)
 	const std::set<std::string>& unconsumedSections = jsonUnconsumedSections();
 	for (std::set<std::string>::const_iterator it = unconsumedSections.begin(); it != unconsumedSections.end(); ++it)
 		gDLL->logMsg("Loading.log", CvString::format("[READJSON] unconsumed-section %s", it->c_str()).c_str(), true, false);
-	gDLL->logMsg("Loading.log", CvString::format("[READJSON] coverage unresolvedFk=%d unconsumedSections=%d unknownKeys=%d",
-		(int)unresolvedFks.size(), (int)unconsumedSections.size(), iUnknownKeyKinds).c_str(), true, false);
+	// Each missing REQUIRED key gets its own LOUD ERROR line, for the same reason an unknown key does: a value
+	// nobody authored is running the game, and it is the only one of the four misses that leaves no trace in the
+	// data itself. The line carries the substituted fallback so the report names what is actually in effect.
+	const std::set<std::string>& missingRequiredKeys = jsonMissingKeys();
+	for (std::set<std::string>::const_iterator it = missingRequiredKeys.begin(); it != missingRequiredKeys.end(); ++it)
+		gDLL->logMsg("Loading.log", CvString::format("[READJSON] ERROR missing-key %s", it->c_str()).c_str(), true, false);
+	gDLL->logMsg("Loading.log", CvString::format("[READJSON] coverage unresolvedFk=%d unconsumedSections=%d unknownKeys=%d missingKeys=%d",
+		(int)unresolvedFks.size(), (int)unconsumedSections.size(), iUnknownKeyKinds,
+		(int)missingRequiredKeys.size()).c_str(), true, false);
 
 	// The kind-coverage half of the same bar (CvInfoKinds): every authored member the vocabulary does not carry
 	// flowed through the compile pass as an interned segment -- surfaced per distinct family.member so a

--- a/Sources/Infos/CvBuildInfo.cpp
+++ b/Sources/Infos/CvBuildInfo.cpp
@@ -198,12 +198,17 @@ void CvBuildInfo::mapFrom(const picojson::value& entity)
 			{
 				if (!featureRows[iRow].is<picojson::object>())
 				{
+					jsonNoteUnconsumed(getType(), "produces.features/rowNotAnObject");
 					continue;
 				}
 				const picojson::object& featureRow = featureRows[iRow].get<picojson::object>();
 				const int iFeature = jsonIdFk(featureRow, "feature");
 				if (iFeature < 0)
 				{
+					//	The row is DROPPED WHOLE, so say so. jsonIdFk answers -1 for two different failures and the
+					//	call site cannot tell them apart: an id that did not RESOLVE is already on the unresolved-fk
+					//	census, but an ABSENT key is on no census at all -- which is the half that was silent.
+					jsonNoteUnconsumed(getType(), "produces.features/rowHasNoFeature");
 					continue;
 				}
 				FeatureStruct featureStruct;
@@ -225,12 +230,14 @@ void CvBuildInfo::mapFrom(const picojson::value& entity)
 			{
 				if (!terrainRows[iRow].is<picojson::object>())
 				{
+					jsonNoteUnconsumed(getType(), "produces.terraform/rowNotAnObject");
 					continue;
 				}
 				const picojson::object& terrainRow = terrainRows[iRow].get<picojson::object>();
 				const int iTerrain = jsonIdFk(terrainRow, "terrain");
 				if (iTerrain < 0)
 				{
+					jsonNoteUnconsumed(getType(), "produces.terraform/rowHasNoTerrain");
 					continue;
 				}
 				TerrainStructs terrainStruct;

--- a/Sources/Infos/CvJsonParse.cpp
+++ b/Sources/Infos/CvJsonParse.cpp
@@ -21,11 +21,13 @@ int jsonX100(double h)
 static std::set<std::string> s_unresolved;
 static std::set<std::string> s_unconsumed;
 static std::set<std::string> s_unknownKeys;
+static std::set<std::string> s_missingKeys;
 
-void jsonResetDiag()                                    { s_unresolved.clear(); s_unconsumed.clear(); s_unknownKeys.clear(); }
+void jsonResetDiag()                                    { s_unresolved.clear(); s_unconsumed.clear(); s_unknownKeys.clear(); s_missingKeys.clear(); }
 const std::set<std::string>& jsonUnresolvedIds()        { return s_unresolved; }
 const std::set<std::string>& jsonUnconsumedSections()   { return s_unconsumed; }
 const std::set<std::string>& jsonUnknownKeys()          { return s_unknownKeys; }
+const std::set<std::string>& jsonMissingKeys()          { return s_missingKeys; }
 
 // The bound is a runaway guard, not a display cap: at 64 a single flooding class (every CIVILIZATION_ dropping
 // `grants`) filled the census by itself and HID every other miss behind it -- the diagnostic silently truncated
@@ -41,6 +43,11 @@ void jsonNoteUnconsumed(const std::string& szType, const std::string& szSection)
 void jsonNoteUnknownKey(const std::string& szType, const std::string& szKey)
 {
 	if (s_unknownKeys.size() < JSON_DIAG_MAX) s_unknownKeys.insert(szType + ":" + szKey);
+}
+
+void jsonNoteMissingKey(const std::string& szType, const std::string& szKey, const std::string& szFallback)
+{
+	if (s_missingKeys.size() < JSON_DIAG_MAX) s_missingKeys.insert(szType + ":" + szKey + "=" + szFallback);
 }
 
 int jsonResolveId(const std::string& id)

--- a/Sources/Infos/CvJsonParse.h
+++ b/Sources/Infos/CvJsonParse.h
@@ -162,5 +162,14 @@ const std::set<std::string>& jsonUnconsumedSections();
 // "<typeId>:<key>" -- the reader prints each as an unconditional [READJSON] ERROR unknown-key line.
 void jsonNoteUnknownKey(const std::string& szType, const std::string& szKey);
 const std::set<std::string>& jsonUnknownKeys();
+// A key the reading info REQUIRES that the entity did not author, recorded AT THE SITE that substitutes a
+// fallback: "<typeId>:<key>=<fallback>". ⛔ This is the one miss the other three censuses structurally CANNOT
+// see -- the file parses, every key present is known, every section is consumed, and the value is simply a
+// default nobody chose. It is therefore the quietest failure the reader has, and the only evidence is a
+// substituted value that looks exactly like an authored one.
+// ⚖ Record ONLY where the fallback is a SEMANTIC choice that can be wrong (a role, a domain, a category) --
+// never for a numeric zero or an empty list, where absence and the default mean the same thing.
+void jsonNoteMissingKey(const std::string& szType, const std::string& szKey, const std::string& szFallback);
+const std::set<std::string>& jsonMissingKeys();
 
 #endif // CV_JSON_PARSE_H

--- a/Sources/Infos/CvUnitInfo.cpp
+++ b/Sources/Infos/CvUnitInfo.cpp
@@ -502,6 +502,7 @@ void CvUnitInfo::mapFrom(const picojson::value& entity)
 		{
 			// legacy load default: -1 negative-indexes the AI count arrays
 			m_iDefaultUnitAI = GC.getInfoTypeForString("UNITAI_UNKNOWN");
+			jsonNoteMissingKey(getType(), "identity.defaultUnitAI", "UNITAI_UNKNOWN");
 		}
 		m_iSpecialUnitType = jsonIdFk(*pIdentity, "special");
 		m_iAdvisor = jsonIdFk(*pIdentity, "advisor");

--- a/docs/architecture/patterns/08-the-one-reader-the-load-pipeline.md
+++ b/docs/architecture/patterns/08-the-one-reader-the-load-pipeline.md
@@ -16,6 +16,14 @@
 - **Fail-loud key coverage.** The reader accounts EVERY top-level key of every entity to exactly one consumer (a
   reserved-section parser or the modifier-family walk); an unconsumed key is a loud load-time report. "The info
   matches the JSON structure" is thereby a mechanical check, never an agent's self-assertion.
+  ⛔ **AND COVERAGE RUNS BOTH WAYS — accounting for every key PRESENT does not account for a key ABSENT.** A
+  required key nobody authored passes every check above: there is no key to place, no section left unconsumed,
+  no id that fails to resolve. The reader substitutes a default and the game runs on a value no author chose,
+  with the substitution indistinguishable from authorship. ⇒ **A fallback over a SEMANTIC default is therefore
+  itself a reportable miss** (`jsonNoteMissingKey`), and it is the count to read FIRST, because it is the only
+  one whose evidence does not exist in the data. ⚖ Not every default qualifies: where absence and the default
+  carry the same meaning — a numeric zero, an empty list, a value the curator deliberately elides — there is
+  nothing unknown to report, and reporting it buries the misses that matter.
 - **The `Json` name-fragment is reserved for the load-time parse surface** (the reader + the parse walkers). A
   runtime-resident type carries no `Json` in its name — so a `Json*`-named type living past load is, by its own
   name, misnamed or misplaced.

--- a/docs/reference/engine.md
+++ b/docs/reference/engine.md
@@ -259,11 +259,32 @@ where it is. Read what the option is being ASKED, never match on the option name
     (processes/votes/espionage-missions/spawns) register late, so the postmenu re-run is what completes every
     cross-category FK edge. The postmenu pass ends by FREEING the store — after load, no JSON-shaped object
     survives.
-  - **Fail-loud coverage** — the three failure counts print UNCONDITIONALLY to `Loading.log` on every pass
-    (`[READJSON] coverage unresolvedFk=N unconsumedSections=N unknownKeys=N`), plus one
+  - **Fail-loud coverage** — the four failure counts print UNCONDITIONALLY to `Loading.log` on every pass
+    (`[READJSON] coverage unresolvedFk=N unconsumedSections=N unknownKeys=N missingKeys=N`), plus one
     `[READJSON] ERROR unknown-key` line per non-reserved object key outside the CLOSED family vocabulary
-    (`CvJsonParse.cpp` `CJK_FAMILY_KEYS`, mirrored from `Tools/Migration/family_census.py`); the per-item
+    (`CvJsonParse.cpp` `CJK_FAMILY_KEYS`, mirrored from `Tools/Migration/family_census.py`) and one
+    `[READJSON] ERROR missing-key` line per REQUIRED key no entity authored; the per-item
     detail rides the `SD_READJSON` spine events.
+  - **⛔ `jsonIdFk` ANSWERS `-1` FOR TWO DIFFERENT FAILURES, AND THE CALL SITE CANNOT TELL THEM APART.** A key
+    that is PRESENT with an id that does not resolve routes through `jsonResolveId`, so it lands on the
+    `unresolvedFk` census; a key that is simply ABSENT returns `-1` having touched no census at all. Both reach
+    the reader as the same `< 0`, so for years the reported half and the silent half were indistinguishable at
+    every fallback in the tree.
+    ⚑ **The absent half is the QUIETEST miss the reader has**, and that is structural rather than a matter of
+    degree: an unknown key is data the reader cannot place, an unconsumed section is data that reaches no getter,
+    an unresolved FK is an id that names nothing — all three leave a TRACE IN THE DATA. A missing key leaves
+    none. The file parses, every key present is known, every section is consumed, and the substituted default is
+    indistinguishable from an authored value. *(Worked: `UNIT_TRIBAL_GUARDIAN` ran on a `UNITAI_UNKNOWN` default
+    its own `identity.unitAIs` forbade, and nothing anywhere said so.)*
+    ⇒ **So a fallback substituting a SEMANTIC default records it** — `jsonNoteMissingKey(type, key, fallback)`,
+    naming the value actually in effect. ⚖ Only where the default can be WRONG: a role, a domain, a category. A
+    numeric zero or an empty list is not recorded, and neither is a default the CURATOR deliberately elides
+    (`identity.aggression` omits its 5) — there, absence and the default mean the same thing and a report would
+    be noise that buries the real ones.
+  - **⛔ A DROPPED ROW ANNOUNCES THROUGH THE EXISTING CENSUS, never a new one** ([a dropped trigger
+    announces](../specs/triggers.md)). A malformed or id-less element inside a consumed
+    section is `jsonNoteUnconsumed(type, "<section>/<why>")` — the shape `CvGrants` already uses
+    (`entryHasNoResolvableId`) and `CvBuildInfo`'s `produces.features` / `produces.terraform` rows now match.
 - **`CvInfoUtil`** is the XML loader for the not-yet-replaced info types: one `getDataMembers()` declaration
   derives read/copyNonDefaults/checkSum/init (`CvBuildInfo` is the reference). **The forward direction is
   top-down JSON via `readJson`, which bypasses `CvInfoUtil` entirely** — do NOT chase the old "migrate remaining


### PR DESCRIPTION
The systemic half flagged in #516. Better to know what is unknown than not to know it.

## The gap

`jsonIdFk` answers `-1` for two structurally different failures, and the call site cannot tell them apart:

```cpp
int jsonIdFk(const picojson::object& io, const char* key)
{
    picojson::object::const_iterator it = io.find(key);
    return (it != io.end() && it->second.is<std::string>()) ? jsonResolveId(...) : -1;
}
```

| situation | census |
|---|---|
| key **present**, id does not resolve | `jsonResolveId` → `unresolvedFk` — **loud** |
| key **absent** | returns `-1`, touching no census at all — **silent** |

Both reach the reader as the same `< 0`. So at every fallback in the tree, the reported half and the silent half have been indistinguishable.

## Why this one is the quietest, structurally

The reader had three failure classes, and **all three leave a trace in the data**:

- an **unknown key** is data the reader cannot place,
- an **unconsumed section** is data that reaches no getter,
- an **unresolved FK** is an id that names nothing.

A **missing key leaves none**. The file parses, every key present is known, every section is consumed, and the substituted default is indistinguishable from an authored value. There is nothing to grep for, because the evidence is the *absence* of something.

**Worked case (#399):** `UNIT_TRIBAL_GUARDIAN` ran on a `UNITAI_UNKNOWN` default that its own `identity.unitAIs` forbade. Every existing check passed. Nothing anywhere said so.

## The change

`jsonNoteMissingKey(type, key, fallback)` records it **at the site that substitutes the default**, naming the value actually in effect (`<type>:<key>=<fallback>`), so the report says what is running rather than only what is absent.

It rides the **existing** census — no new mechanism, per the ⛔ ruling in [`docs/specs/triggers.md`](docs/specs/triggers.md) that every drop routes through the ONE load-time census and **not** a second reporting path or a bespoke spine domain:

- an unconditional `[READJSON] ERROR missing-key <type>:<key>=<fallback>` line, exactly as `unknown-key` gets one;
- a `missingKeys=N` term on the existing `[READJSON] coverage` line;
- per-item detail on the existing `SD_READJSON` domain via a new `RJE_KEY_MISSING`, **appended** to the event enum rather than inserted — the numeric id rides `/events`, so renumbering would silently re-label lines already captured.

## Scoped so it stays readable

Recorded **only** where the fallback is a semantic choice that can be wrong — a role, a domain, a category.

**Not** recorded for a numeric zero, an empty list, or a default the curator deliberately elides (`identity.aggression` omits its `5` by convention). There, absence and the default mean the same thing, and reporting them would bury the misses that matter — the same failure mode as the old `JSON_DIAG_MAX = 64` cap, where one flooding class hid every other miss behind it.

## Also: four silently dropped rows

`CvBuildInfo` dropped malformed or id-less `produces.features` / `produces.terraform` rows with a bare `continue` — authored data that never reaches a getter, reported nowhere. Now wired through the **existing** `jsonNoteUnconsumed`, matching the shape `CvGrants` already uses (`entryHasNoResolvableId`).

## Verification

- `Assert rebuild` green, 46.9s, zero errors, zero `C1003`.
- `verify-spine-fields.py`: clean (81 declared / 69 emitted). `RJE_KEY_MISSING` reuses `RJF_ID` with `addStr`, already declared `SFT_STR`, so no new field declaration.
- `verify-docs.py`: links clean (1660 checked).
- **Not run:** a game load. On a healthy tree the expected output is `missingKeys=0` and no `ERROR missing-key` lines — #516 removes the only known instance. That is the point: the count is a ratchet that should sit at zero, and any future rise names the entity, the key, and the value silently running in its place.

## Docs

- `docs/reference/engine.md` — coverage is now four counts; plus the `jsonIdFk` two-failures fact and the rule for which fallbacks record.
- `docs/architecture/patterns/08-the-one-reader-the-load-pipeline.md` — the fail-loud key-coverage law now states that coverage runs **both ways**: accounting for every key present does not account for a key absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
