### PR TITLE
fix(ui): drop the era-keyed health-bar divisor that compensates for nothing (#477)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,6 +478,12 @@ not findings to re-discover.
   violation that belongs to the §4c-ter cluster pass, NOT today's balance defect. ⛔ Do not "fix" it by converting
   `getBestLandUnitCombat()` alone: two sites already lift it back with `100 *`, and the air sites read the genuinely
   human `getAirCombat()`, so a lone conversion manufactures fresh fudge factors and fails the cluster gate.
+  ⚠ **It carries a SECOND defect on a different axis, and it belongs to the SAME pass:** `getBestLandUnit` SELECTS
+  the winner on the live unit's resolved `baseCombatStrHuman()`, while `getBestLandUnitCombat` returns the
+  **INFO's authored** strength (`getScalar(SCALAR_STRENGTH, …)`). Selection and denominator therefore read
+  different quantities, so the number does not describe the unit that won the selection. ⛔ Do not repair that
+  alone either — it is the SAME nine AI call sites (`AI_combatValue` among them), so a lone change re-scales
+  every combat valuation in the tree.
   (2) **`CvCityAI::AI_bestUnit` has NO cost term** — it takes the highest `AI_unitValue` outright — so unit spam
   can never originate in a value-per-hammer ratio there; it originates in value failing to DISCRIMINATE, or in the
   needed-counts ([parked/unit-ai-valuation.md](docs/plans/parked/unit-ai-valuation.md)).

--- a/Sources/Engine/CvUnit.cpp
+++ b/Sources/Engine/CvUnit.cpp
@@ -20410,11 +20410,6 @@ void CvUnit::cheat(bool bCtrl, bool bAlt, bool bShift)
 
 float CvUnit::getHealthBarModifier() const
 {
-	if (GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS))
-	{
-		const int iWidthDivisor = (1 + (int)GET_PLAYER(getOwner()).getCurrentEra()) * 4;
-		return ((GC.getDefineFLOAT("HEALTH_BAR_WIDTH") / iWidthDivisor) / (GC.getGame().getBestLandUnitCombat() * 2));
-	}
 	return (GC.getDefineFLOAT("HEALTH_BAR_WIDTH") / (GC.getGame().getBestLandUnitCombat() * 2));
 }
 


### PR DESCRIPTION
Closes #477.

## The divisor

```cpp
if (GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS))
{
    const int iWidthDivisor = (1 + (int)GET_PLAYER(getOwner()).getCurrentEra()) * 4;
    return ((GC.getDefineFLOAT("HEALTH_BAR_WIDTH") / iWidthDivisor) / (...));
}
```

Exactly **4× narrower** than the non-SM leg at era 0, widening from there.

**Its rationale is gone.** It existed to compensate for Size Matters strengths running far above authored values; `7d8bb0be4` rewrote `getSizeMattersOffsetValue()` to pivot on the unit type's own rank sum, so a unit at its type profile is offset 0 and `applySMRank` returns the value untouched at `rankChange == 0`. Nothing left to compensate for.

**And it could never have been correct anyway** — it is keyed on **era**, which has no relationship to rank inflation. Era does not track merging. Even before the pivot fix, an era-keyed divisor was not a compensation for a rank-driven quantity.

## Confined to display, verified rather than assumed

`getHealthBarModifier` is `DllExport` and has **no caller anywhere in the DLL** — the closed EXE is the only consumer. `engine.md` names health-bar widths explicitly among the values that die at the screen, so no synchronized state is reachable from this and there is no OOS surface.

## ⛔ The second half is deliberately NOT taken

The issue also asks whether `getBestLandUnitCombat` should return the resolved strength to match its own selection criterion. The mismatch is real and I confirmed it — `getBestLandUnit` selects on the live unit's `baseCombatStrHuman()` (`CvGame.cpp:4983`), while `getBestLandUnitCombat` returns the **info's authored** strength (`:4995`), so the denominator does not describe the unit that won.

But that function has **nine AI call sites**, including `CvGameAI.cpp:90` — `AI_combatValue` itself. AGENTS.md already rules on it directly:

> ⛔ Do not "fix" it by converting `getBestLandUnitCombat()` alone: two sites already lift it back with `100 *`, and the air sites read the genuinely human `getAirCombat()`, so a lone conversion manufactures fresh fudge factors and fails the cluster gate.

Both of those lift-back sites are visible in the tree (`CvPlayerAI.cpp:1532`, `CvTeamAI.cpp:4595`). Changing the function alone re-scales every combat valuation in the game — the "a term added to ONE valuation is worse than the gap it closes" failure. It belongs to the valuation cluster pass, and I have recorded it in `AGENTS.md` beside the existing ruling so the next reader finds both defects on that function together rather than rediscovering one.

Removing the divisor needs none of that: it is a separate leg on a display-only function.

## Verification

- `Assert rebuild` green, 45.1s, zero errors, zero `C1003`.
- `verify-docs.py`: links clean (1660 checked).
- **Not run:** a game. The visible change is health bars rendering at the same width with Size Matters on as with it off — 4× wider than today in the ancient era, narrowing that gap as eras advance. A tester only needs to toggle the option and look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
