### PR TITLE
fix(data): give LUMBERJACK the wood-chain deposits it was missing (#191)

### DIFF
--- a/Assets/Data/_additions/buildings.json
+++ b/Assets/Data/_additions/buildings.json
@@ -87,5 +87,14 @@
    { "any": [ "BUILDING_DANCE_HUT", "BUILDING_DANCE_HALL", "BUILDING_NIGHT_CLUB", "BUILDING_FIRE_PIT", "BUILDING_BONFIRE", "BUILDING_IMU", "BUILDING_CHARCOAL_BURNER" ] },
    { "type": "MAPCATEGORY_EARTH", "scope": "plot" }
   ] } }
- }
+ },
+
+ "BUILDING_CARPENTER":       { "production": { "city": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "BUILDING_CHARCOAL_BURNER": { "production": { "city": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "BUILDING_COOPER":          { "production": { "city": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "BUILDING_FURNITURE_MAKER": { "production": { "city": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "BUILDING_LUMBER_CAMP":     { "production": { "city": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "BUILDING_LUMBER_MILL":     { "production": { "city": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "BUILDING_SHIPWRIGHT":      { "production": { "city": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "BUILDING_AGROFOREST":      { "production": { "city": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 3 } } } } }
 }

--- a/Assets/Data/_additions/civics.json
+++ b/Assets/Data/_additions/civics.json
@@ -1,0 +1,5 @@
+{
+ "CIVIC_BIOLOGICAL_CASTES": { "production": { "empire": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "CIVIC_CASTE_SYSTEM":      { "production": { "empire": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "CIVIC_PROLETARIAT":       { "production": { "empire": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } }
+}

--- a/Assets/Data/_additions/routes.json
+++ b/Assets/Data/_additions/routes.json
@@ -1,0 +1,17 @@
+{
+ "ROUTE_ROAD":              { "production": { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "ROUTE_PAVED_ROAD":        { "production": { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "ROUTE_HIGHWAY":           { "commerce":   { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "ROUTE_RAILROAD":          { "production": { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } },
+                              "commerce":   { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "ROUTE_ELECTRIC_RAILROAD": { "production": { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } },
+                              "commerce":   { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "ROUTE_MAGLEV":            { "production": { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } },
+                              "commerce":   { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "ROUTE_VACTRAIN":          { "production": { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } },
+                              "commerce":   { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "ROUTE_GRAVITY_TRAIN":     { "production": { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } },
+                              "commerce":   { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } },
+ "ROUTE_JUMPLANE":          { "production": { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } },
+                              "commerce":   { "plot": { "improvements": { "IMPROVEMENT_LUMBERJACK": { "flat": 1 } } } } }
+}

--- a/Assets/Data/buildings/ancient/building_charcoal_burner.json
+++ b/Assets/Data/buildings/ancient/building_charcoal_burner.json
@@ -90,6 +90,9 @@
    "improvements": {
     "IMPROVEMENT_LUMBERMILL": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }

--- a/Assets/Data/buildings/ancient/building_cooper.json
+++ b/Assets/Data/buildings/ancient/building_cooper.json
@@ -67,6 +67,9 @@
    "improvements": {
     "IMPROVEMENT_LUMBERMILL": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }

--- a/Assets/Data/buildings/ancient/building_shipwright.json
+++ b/Assets/Data/buildings/ancient/building_shipwright.json
@@ -78,6 +78,9 @@
    "improvements": {
     "IMPROVEMENT_LUMBERMILL": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }

--- a/Assets/Data/buildings/classical/building_lumber_mill.json
+++ b/Assets/Data/buildings/classical/building_lumber_mill.json
@@ -82,6 +82,9 @@
    "improvements": {
     "IMPROVEMENT_LUMBERMILL": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }

--- a/Assets/Data/buildings/nanotech/building_agroforest.json
+++ b/Assets/Data/buildings/nanotech/building_agroforest.json
@@ -60,6 +60,9 @@
    "improvements": {
     "IMPROVEMENT_LUMBERMILL": {
      "flat": 3
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 3
     }
    }
   }

--- a/Assets/Data/buildings/prehistoric/building_carpenter.json
+++ b/Assets/Data/buildings/prehistoric/building_carpenter.json
@@ -59,6 +59,9 @@
    "improvements": {
     "IMPROVEMENT_LUMBERMILL": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }

--- a/Assets/Data/buildings/prehistoric/building_furniture_maker.json
+++ b/Assets/Data/buildings/prehistoric/building_furniture_maker.json
@@ -67,6 +67,9 @@
    "improvements": {
     "IMPROVEMENT_LUMBERMILL": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }

--- a/Assets/Data/buildings/prehistoric/building_lumber_camp.json
+++ b/Assets/Data/buildings/prehistoric/building_lumber_camp.json
@@ -68,6 +68,9 @@
    "improvements": {
     "IMPROVEMENT_LUMBERMILL": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }

--- a/Assets/Data/civics/society/civic_biological_castes.json
+++ b/Assets/Data/civics/society/civic_biological_castes.json
@@ -43,6 +43,9 @@
     },
     "IMPROVEMENT_HYBRID_FOREST": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }

--- a/Assets/Data/civics/society/civic_caste_system.json
+++ b/Assets/Data/civics/society/civic_caste_system.json
@@ -54,6 +54,9 @@
     },
     "IMPROVEMENT_HYBRID_FOREST": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }

--- a/Assets/Data/civics/society/civic_proletariat.json
+++ b/Assets/Data/civics/society/civic_proletariat.json
@@ -31,6 +31,9 @@
     },
     "IMPROVEMENT_HYBRID_FOREST": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }

--- a/Assets/Data/routes/route_electric_railroad.json
+++ b/Assets/Data/routes/route_electric_railroad.json
@@ -35,6 +35,9 @@
     },
     "IMPROVEMENT_WORKSHOP": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }
@@ -73,6 +76,9 @@
      "flat": 1
     },
     "IMPROVEMENT_FACTORY": {
+     "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
      "flat": 1
     }
    }

--- a/Assets/Data/routes/route_gravity_train.json
+++ b/Assets/Data/routes/route_gravity_train.json
@@ -51,6 +51,9 @@
     },
     "IMPROVEMENT_WORKSHOP": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }
@@ -96,6 +99,9 @@
      "flat": 1
     },
     "IMPROVEMENT_FOREST_PRESERVE": {
+     "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
      "flat": 1
     }
    }

--- a/Assets/Data/routes/route_highway.json
+++ b/Assets/Data/routes/route_highway.json
@@ -65,6 +65,9 @@
     },
     "IMPROVEMENT_FOREST_PRESERVE": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }

--- a/Assets/Data/routes/route_jumplane.json
+++ b/Assets/Data/routes/route_jumplane.json
@@ -49,6 +49,9 @@
     },
     "IMPROVEMENT_WORKSHOP": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }
@@ -97,6 +100,9 @@
      "flat": 1
     },
     "IMPROVEMENT_FOREST_PRESERVE": {
+     "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
      "flat": 1
     }
    }

--- a/Assets/Data/routes/route_maglev.json
+++ b/Assets/Data/routes/route_maglev.json
@@ -47,6 +47,9 @@
     },
     "IMPROVEMENT_WORKSHOP": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }
@@ -92,6 +95,9 @@
      "flat": 1
     },
     "IMPROVEMENT_FOREST_PRESERVE": {
+     "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
      "flat": 1
     }
    }

--- a/Assets/Data/routes/route_paved_road.json
+++ b/Assets/Data/routes/route_paved_road.json
@@ -14,6 +14,9 @@
     },
     "IMPROVEMENT_WORKSHOP": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }

--- a/Assets/Data/routes/route_railroad.json
+++ b/Assets/Data/routes/route_railroad.json
@@ -35,6 +35,9 @@
     },
     "IMPROVEMENT_WORKSHOP": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }
@@ -73,6 +76,9 @@
      "flat": 1
     },
     "IMPROVEMENT_FACTORY": {
+     "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
      "flat": 1
     }
    }

--- a/Assets/Data/routes/route_road.json
+++ b/Assets/Data/routes/route_road.json
@@ -11,6 +11,9 @@
     },
     "IMPROVEMENT_WORKSHOP": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }

--- a/Assets/Data/routes/route_vactrain.json
+++ b/Assets/Data/routes/route_vactrain.json
@@ -51,6 +51,9 @@
     },
     "IMPROVEMENT_WORKSHOP": {
      "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
+     "flat": 1
     }
    }
   }
@@ -96,6 +99,9 @@
      "flat": 1
     },
     "IMPROVEMENT_FOREST_PRESERVE": {
+     "flat": 1
+    },
+    "IMPROVEMENT_LUMBERJACK": {
      "flat": 1
     }
    }


### PR DESCRIPTION
Closes #191.

**The rule, applied uniformly:** every source that deposits onto `IMPROVEMENT_LUMBERMILL` now deposits identically onto `IMPROVEMENT_LUMBERJACK`.

## The gap was wider than the issue recorded

A census over `Assets/Data` by file + path + value:

| group | LUMBERMILL | TREEFARM | HYBRID_FOREST | LUMBERJACK (before) |
|---|:--:|:--:|:--:|:--:|
| 8 wood buildings — `production.city.improvements` | ✅ | — | — | **✗** |
| 3 civics — `production.empire.improvements` | ✅ | ✅ | ✅ | **✗** |
| 9 routes — `production`/`commerce.plot.improvements` | ✅ | ✅ | ✅ | **✗** |
| traits | ✅ | ✅ | ✅ | ✅ |
| **total deposits** | **36** | 27 | 27 | **13** |

#191 named nine sources; it missed `civic_biological_castes`, `civic_caste_system`, and the **entire route plane**. TREEFARM and HYBRID_FOREST already carry the civic and route deposits — so LUMBERJACK was the only member of the wood chain without them. The improvement a lumbermill *upgrades from* got nothing from the buildings, civics and routes that feed the chain.

Values mirror LUMBERMILL exactly: `flat: 1` throughout, `flat: 3` for agroforest.

## Authored in the overlay, not the XML

The `CIV4*Infos.xml` files are curator **input** for the one-time migration. New content authored there is new gameplay written into a dead surface — so this goes in `Assets/Data/_additions/<type>.json`, which is deep-merged over the curated output and **re-applied automatically at process exit** for any folder a curator rewrites. An addition therefore survives regeneration by construction rather than by anyone remembering to re-run something.

`_additions/civics.json` and `_additions/routes.json` are new overlay files; `buildings.json` gains 8 entries.

## Verification

- **`curate_additions.py --write`**: buildings 33 applied / civics 3 / routes 9 — **0 missing**.
- **Regen-survival, tested not assumed:** a full `curate_building.py --write` over **5180 files** left the changed-file set **identical** and the additions intact. That proves both that the committed data was in sync beforehand and that the overlay survives a regen.
- **Re-run census: ZERO** deposits remain on LUMBERMILL that LUMBERJACK lacks (39 vs 36).
- The 3 entries LUMBERJACK holds alone are the pre-existing `progressist` `improvementUpgradeRate` traits — correct, since an upgrade-rate bonus belongs to the improvement that *upgrades*, not the terminal one.
- No C++ or XML touched, so no build required.

## Note on the earlier framing

The issue closed with *"which ones, and at what magnitude, is a balance call — a lumberjack is the entry-tier improvement, so it may legitimately deserve less than the mill rather than parity."* The ruling taken here is uniformity: the lumberjack is a lumber improvement in the same chain, and the sources that feed the chain should not skip it. No reduced entry-tier values were invented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
