### PR TITLE
fix(logging): one universal log level in the menu, and a ratchet on the legacy surface (#476)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,24 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File "../Tools/_Build.ps1" <C
   game mechanics are not, and the preprocessor cannot tell you which. The check REPORTS those three classes for
   a human verdict and never fails on them. ⛔ It also flags TU-LOCAL guards (`#define`d in a `Sources/` file, so
   ON in some translation units and OFF in others) as never-collapse-mechanically.
+- **BUG options + the logging surface: `python Tools/verify-bug-options.py`** — a BUG option is addressed by
+  STRING from C++ (`getBugOptionINT("Autolog__LogLevelStream", 1)`) and declared in XML far away
+  (`Assets/Config/*.xml`), and **nothing connects the two** — no compiler, no loader, no assert. So a knob can be
+  half-wired in EITHER direction and the game runs, saying nothing. Three checks:
+  - **READ BUT NOT DECLARED (fails)** — the lookup then always answers the call-site DEFAULT, so the option is
+    pinned and unreachable from the options screen AND the `.ini`, while looking exactly like a working knob.
+    *(Worked: `Autolog__LogLevelStream` drove `gStreamLogLevel` and was declared nowhere, welding the `/events`
+    verbosity to 1 — un-raisable precisely when someone went looking for it.)*
+  - **A DECLARED `LogLevel*` NOBODY CONSUMES (fails)** — the mirror: a dropdown promising control that does not
+    exist. ⚠ A reference from an options TAB does not count as consumption, which is the whole point — the three
+    dead dropdowns were all rendered and all read by nothing. Consumption is a DLL read, a Python getter
+    (explicit `get=` or the auto-derived `get<Id>`), or a `<change>` handler.
+  - **THE LEGACY LOGGING SURFACE IS A RATCHET (fails only on a RISE)** — direct `gDLL->logMsg` sites, the
+    scope-named globals and the BBAI helpers are legacy that **cannot be removed yet**, so the check never
+    demands their removal; it refuses GROWTH only. ⛔ That is the anti-rollerskate mechanism, because the pull is
+    never *"revive the legacy logger"* — it is *"add one more line beside the twenty already here"*. A new gate
+    reads the UNIVERSAL level and a new emit goes through the event spine; **never raise a ceiling to pass**, and
+    lower it in the same commit when the surface shrinks.
 - **Python migration burndown: `python Tools/verify-python-bindings.py [--list]`** — counts the methods still
   DECLARED on a `Cy*` wrapper, registered nowhere, and still CALLED from Python: i.e. consumers not yet
   re-pointed onto the coherent reads. ⛔ **NOT a bug count, and NOT a re-registration list.** The `Cy*` bindings

--- a/Assets/Config/Autolog.xml
+++ b/Assets/Config/Autolog.xml
@@ -10,13 +10,28 @@
 			<option id="Enabled" key="Enabled" type="boolean" default="True" get="isEnabled"/>
 			<option id="Silent" key="Silent" type="boolean" default="False" get="isSilent"/>
 
-			<list id="LogLevelPlayerBBAI" key="LogLevelPlayerBBAI" type="int" default="0" listType="int" values="0,1,2,3,4" get="getLogLevelPlayerBBAI"/>
-			<list id="LogLevelTeamBBAI" key="LogLevelTeamBBAI" type="int" default="0" listType="int" values="0,1,2,3,4" get="getLogLevelTeamBBAI"/>
-			<list id="LogLevelCityBBAI" key="LogLevelCityBBAI" type="int" default="0" listType="int" values="0,1,2,3,4" get="getLogLevelCityBBAI"/>
-			<list id="LogLevelUnitBBAI" key="LogLevelUnitBBAI" type="int" default="0" listType="int" values="0,1,2,3,4" get="getLogLevelUnitBBAI"/>
+			<!-- THE UNIVERSAL LOG LEVEL. One number gates every log FILE. The DLL reads this single option and
+			     drives gPlayerLogLevel/gTeamLogLevel/gCityLogLevel/gUnitLogLevel from it (CvGlobals.cpp), so the
+			     legacy BBAI call sites MIMIC the universal level rather than carrying knobs of their own. There
+			     were once three more dropdowns here (Team/City/Unit); the DLL never read them, so they promised
+			     per-scope control that does not exist. Do not re-add one: a new gate reads the universal level.
+			     Levels: 1 headline - 2 per-decision - 3 per-candidate - 4 inner-loop firehose. -->
+			<list id="LogLevelPlayerBBAI" key="LogLevelPlayerBBAI" type="int" default="0" listType="int" values="0,1,2,3,4" get="getLogLevelPlayerBBAI"
+				label="Log level (universal)"
+				help="Detail level for the game's log files in Documents/My Games/Beyond The Sword/Logs. One number gates them all. 0 off, 1 headline, 2 per-decision, 3 per-candidate, 4 inner-loop firehose (very large files)."/>
 
-			<!-- Wall-clock turn-phase timing -> Performance.log; read in the DLL as gPerfLogLevel. Independent of the BBAI levels above. -->
-			<list id="LogLevelPerf" key="LogLevelPerf" type="int" default="0" listType="int" values="0,1,2,3,4"/>
+			<!-- The /events stream consumer's OWN gate, deliberately decoupled from the file level above: a domain
+			     can stream at full volume while the files stay quiet, and vice versa. Read in the DLL as
+			     gStreamLogLevel. Was READ but never DECLARED here, so it sat pinned at its default and could not
+			     be changed from the menu or from Autolog.ini. -->
+			<list id="LogLevelStream" key="LogLevelStream" type="int" default="1" listType="int" values="0,1,2,3,4"
+				label="Event stream level"
+				help="Detail level for the live /events HTTP stream. Independent of the log-file level. 0 off, 1 domain facts only, 2-4 add diagnostic and trace detail."/>
+
+			<!-- Wall-clock turn-phase timing -> Performance.log; read in the DLL as gPerfLogLevel. Independent of the universal level above. -->
+			<list id="LogLevelPerf" key="LogLevelPerf" type="int" default="0" listType="int" values="0,1,2,3,4"
+				label="Performance census level"
+				help="Detail level for the per-turn timing census written to Performance.log. Independent of the universal log level."/>
 
 			<!-- Dev live-state HTTP endpoint PoC (#387); read in the DLL (CvHttpServer), takes effect on closing the options screen. -->
 			<option id="HttpServer" key="HttpServer" type="boolean" default="False" label="HTTP Server (dev)"

--- a/Assets/Python/BUG/Tabs/BugAutologOptionsTab.py
+++ b/Assets/Python/BUG/Tabs/BugAutologOptionsTab.py
@@ -18,17 +18,24 @@ class BugAutologOptionsTab(BugOptionsTab.BugOptionsTab):
 		self.createTab(screen)
 		column = self.addOneColumnLayout(screen, self.createMainPanel(screen))
 
-		self.addCheckbox(screen, column, "Autolog__MiscLogging")
+		# DEVELOPER / BUG-REPORT CONTROLS -- first, and kept apart from the autolog event toggles further
+		# down. This is the block a reporter gets talked through, and it used to sit behind ~35 checkboxes
+		# belonging to a different mod's feature and a different audience.
+		# The log level is ONE control because there is one number: the DLL reads LogLevelPlayerBBAI and
+		# drives every scope global from it, so the legacy BBAI call sites mimic the universal level.
+		# The Team/City/Unit dropdowns that used to stand here were read by NOTHING -- do not re-add them.
+		devLeft, devCenter, devRight = self.addThreeColumnLayout(screen, column, "AutologDev")
+		self.addIntDropdown(screen, devLeft, devLeft, "Autolog__LogLevelPlayerBBAI")
+		self.addIntDropdown(screen, devCenter, devCenter, "Autolog__LogLevelStream")
+		self.addIntDropdown(screen, devRight, devRight, "Autolog__LogLevelPerf")
+		self.addCheckbox(screen, devLeft, "Autolog__MiscLogging")
+		self.addCheckbox(screen, devCenter, "Autolog__HttpServer")
+
+		# THE LEGACY AUTOLOG (a different mod's player-facing feature) starts here.
 		screen.attachHSeparator(column, column + "Sep0")
 		left, center, right = self.addThreeColumnLayout(screen, column, "Autolog0")
 		self.addCheckbox(screen, left, "Autolog__Enabled")
 		self.addCheckbox(screen, left, "Autolog__Silent")
-		self.addCheckbox(screen, left, "Autolog__HttpServer")
-		self.addIntDropdown(screen, center, center, "Autolog__LogLevelTeamBBAI")
-		self.addIntDropdown(screen, center, center, "Autolog__LogLevelPlayerBBAI")
-		self.addIntDropdown(screen, right, right, "Autolog__LogLevelUnitBBAI")
-		self.addIntDropdown(screen, right, right, "Autolog__LogLevelCityBBAI")
-		self.addIntDropdown(screen, center, center, "Autolog__LogLevelPerf")
 
 		# File and Format
 		screen.attachHSeparator(column, column + "Sep1")

--- a/Tools/verify-bug-options.py
+++ b/Tools/verify-bug-options.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""verify-bug-options -- a BUG option the DLL reads must be reachable, and the logging
+surface may only shrink.
+
+Three checks, and each exists because the failure is SILENT. A BUG option is addressed by
+string from C++ (`getBugOptionINT("Autolog__LogLevelStream", 1)`) and declared in XML far
+away (`Assets/Config/*.xml`). Nothing connects the two: no compiler, no loader, no assert.
+So a knob can be half-wired in either direction and the game runs, reporting nothing.
+
+  1. READ BUT NOT DECLARED  (fails)
+     `getBugOption*` on an id no `Assets/Config` file declares. The lookup then always
+     answers the DEFAULT passed at the call site -- the knob is pinned, unreachable from
+     the options screen AND from the .ini, and it looks exactly like a working option.
+     Worked case: `Autolog__LogLevelStream` was read as `gStreamLogLevel` and declared
+     nowhere, so the /events stream verbosity was welded to 1. It could not be turned up
+     precisely when someone went looking for it.
+
+  2. A DECLARED LOG LEVEL MUST BE READ  (fails)
+     The mirror. A `LogLevel*` option nobody reads renders a dropdown that promises
+     control it does not have -- you set "unit logging" to 4, nothing happens, and there
+     is no error to chase. Worked case: LogLevelTeamBBAI / LogLevelCityBBAI /
+     LogLevelUnitBBAI were all settable and all read by nothing, because there is ONE
+     number: the DLL reads LogLevelPlayerBBAI and drives every scope global from it.
+     Scoped to the log-level family on purpose -- most BUG options are read by Python,
+     not the DLL, so a general declared-but-unread check would be noise.
+
+  3. THE LEGACY LOGGING SURFACE IS A RATCHET  (fails only on a RISE)
+     Direct `gDLL->logMsg` call sites, the scope-named globals, and the BBAI helpers are
+     legacy. They CANNOT be removed yet -- the BBAI logging is still in place and
+     replacing it is its own piece of work -- so this does not demand their removal. It
+     only refuses GROWTH: today's counts are the ceiling. That is the whole anti-
+     rollerskate mechanism, because the pull is never "revive the legacy logger", it is
+     "add one more line next to the twenty already here".
+     ⛔ A NEW gate reads the UNIVERSAL level; a new emit goes through the event spine
+     (docs/spine.md). If a count below rises, that is the thing to fix -- never the
+     baseline. A count that FALLS should be committed with the baseline lowered.
+
+Run from the repo root:  python Tools/verify-bug-options.py
+"""
+
+import io
+import os
+import re
+import sys
+
+
+#	The legacy logging ceiling. Lower these when the surface shrinks; never raise them.
+LEGACY_LOGGING_CEILING = {
+    "gDLL->logMsg call sites": 71,
+    "gTeamLogLevel reads": 11,
+    "gCityLogLevel reads": 10,
+    "gUnitLogLevel reads": 33,
+    "logBBAI call sites": 14,
+}
+
+SOURCE_ROOT = "Sources"
+CONFIG_ROOT = os.path.join("Assets", "Config")
+
+
+def read_text(path):
+    return io.open(path, encoding="utf-8", errors="ignore").read()
+
+
+def source_files():
+    for dirpath, dirnames, filenames in os.walk(SOURCE_ROOT):
+        if "SourceArchive" in dirpath:
+            continue
+        for name in filenames:
+            if name.endswith(".cpp") or name.endswith(".h"):
+                yield os.path.join(dirpath, name)
+
+
+def collect_reads():
+    """Every BUG option addressed from C++, mapped to the file that reads it."""
+    reads = {}
+    pattern = re.compile(r'getBugOption(?:INT|BOOL|STRING|FLOAT)?\s*\(\s*"([^"]+)"')
+    for path in source_files():
+        text = read_text(path)
+        for match in pattern.finditer(text):
+            reads.setdefault(match.group(1), os.path.basename(path))
+    return reads
+
+
+def collect_declarations():
+    """Every option/list declared in Assets/Config, keyed as <optionsId>__<id>.
+
+    The prefix comes from the enclosing `<options id="...">` element, NOT the filename --
+    "BULL City Bar.xml" declares the CityBar family, so deriving it from the file name
+    reports almost every option as missing.
+    """
+    declared = {}
+    block = re.compile(r'<options\b[^>]*\bid="([^"]+)"(.*?)</options>', re.S)
+    entry = re.compile(r'<(?:option|list)\b[^>]*\bid="([^"]+)"[^>]*?(/?)>', re.S)
+    if not os.path.isdir(CONFIG_ROOT):
+        return declared
+    for name in sorted(os.listdir(CONFIG_ROOT)):
+        if not name.endswith(".xml"):
+            continue
+        text = read_text(os.path.join(CONFIG_ROOT, name))
+        for options_block in block.finditer(text):
+            prefix = options_block.group(1)
+            body = options_block.group(2)
+            for option in entry.finditer(body):
+                option_id = option.group(1)
+                tail = body[option.end():option.end() + 400]
+                getter = re.search(r'\bget="([^"]+)"', option.group(0))
+                declared[prefix + "__" + option_id] = {
+                    "file": name,
+                    "id": option_id,
+                    #	An option is Python-readable through its GETTER: the explicit get="..." when one is
+                    #	declared, otherwise the auto-derived get<Id>. A <change> handler is a consumer too.
+                    "getters": [getter.group(1)] if getter else ["get" + option_id],
+                    "has_change": option.group(2) != "/" and "<change" in tail.split("</")[0],
+                }
+    return declared
+
+
+def python_text():
+    """Every Python source under Assets, concatenated -- the consumer side of a BUG option."""
+    chunks = []
+    for root in (os.path.join("Assets", "Python"),):
+        for dirpath, dirnames, filenames in os.walk(root):
+            for name in filenames:
+                if name.endswith(".py"):
+                    chunks.append(read_text(os.path.join(dirpath, name)))
+    return "\n".join(chunks)
+
+
+def count_occurrences(needle, word_boundary):
+    total = 0
+    pattern = re.compile(r"\b" + re.escape(needle) + r"\b" if word_boundary else re.escape(needle))
+    for path in source_files():
+        total += len(pattern.findall(read_text(path)))
+    return total
+
+
+def main():
+    reads = collect_reads()
+    declared = collect_declarations()
+    failures = 0
+
+    python_source = python_text()
+
+    # 1 -- read but not declared: the knob is pinned at its call-site default.
+    unreachable = sorted(name for name in reads if name not in declared)
+    for name in unreachable:
+        print("UNREACHABLE  %-42s read in %s but declared in no Assets/Config file"
+              % (name, reads[name]))
+    if unreachable:
+        print("")
+        print("A read with no declaration always answers the default passed at the call")
+        print("site, so the option cannot be changed from the options screen OR from the")
+        print(".ini -- and it looks like a working knob. Declare it, or drop the read.")
+        print("")
+        failures += len(unreachable)
+
+    # 2 -- a declared log level nobody consumes promises control that does not exist.
+    #	⚠ A reference from an options TAB does not count: the three dead dropdowns this check exists for were
+    #	all rendered by BugAutologOptionsTab and read by nothing, which is exactly the defect.
+    dead_levels = []
+    for name in sorted(declared):
+        if "LogLevel" not in name:
+            continue
+        info = declared[name]
+        if name in reads or info["has_change"]:
+            continue
+        if any(re.search(r"\b" + re.escape(g) + r"\b", python_source) for g in info["getters"]):
+            continue
+        dead_levels.append(name)
+    for name in dead_levels:
+        print("DEAD KNOB    %-42s declared in %s, read by no DLL code and no Python getter"
+              % (name, declared[name]["file"]))
+    if dead_levels:
+        print("")
+        print("A settable log level the DLL never reads renders a dropdown that does")
+        print("nothing. There is ONE number: the DLL drives every scope global from the")
+        print("universal level, so the legacy BBAI sites mimic it. Drop the declaration")
+        print("rather than adding a read -- a new gate reads the universal level.")
+        print("")
+        failures += len(dead_levels)
+
+    # 3 -- the legacy logging surface may only shrink.
+    measured = {
+        "gDLL->logMsg call sites": count_occurrences("gDLL->logMsg(", False),
+        "gTeamLogLevel reads": count_occurrences("gTeamLogLevel", True),
+        "gCityLogLevel reads": count_occurrences("gCityLogLevel", True),
+        "gUnitLogLevel reads": count_occurrences("gUnitLogLevel", True),
+        "logBBAI call sites": count_occurrences("logBBAI", True),
+    }
+    risen = []
+    fallen = []
+    for label in sorted(LEGACY_LOGGING_CEILING):
+        ceiling = LEGACY_LOGGING_CEILING[label]
+        now = measured[label]
+        if now > ceiling:
+            risen.append((label, ceiling, now))
+        elif now < ceiling:
+            fallen.append((label, ceiling, now))
+    for label, ceiling, now in risen:
+        print("LEGACY GREW  %-42s %d -> %d" % (label, ceiling, now))
+    if risen:
+        print("")
+        print("The legacy logging surface is a RATCHET: it cannot be removed yet (the")
+        print("BBAI logging is still in place), so this only refuses GROWTH. A new gate")
+        print("reads the UNIVERSAL level and a new emit goes through the event spine")
+        print("(docs/spine.md) -- do not raise the ceiling to make this pass.")
+        print("")
+        failures += len(risen)
+
+    for label, ceiling, now in fallen:
+        print("shrank       %-42s %d -> %d  (lower the ceiling in this file)"
+              % (label, ceiling, now))
+
+    print("bug options: %d read from C++, %d declared across Assets/Config" % (len(reads), len(declared)))
+    print("legacy logging: " + ", ".join(
+        "%s=%d" % (label.split()[0], measured[label]) for label in sorted(measured)))
+
+    if failures:
+        return 1
+    print("bug options clean -- every read is reachable, every log level is live, and the")
+    print("legacy logging surface has not grown.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/spine/08-the-live-surfaces-gates-the-tag.md
+++ b/docs/spine/08-the-live-surfaces-gates-the-tag.md
@@ -23,6 +23,23 @@
   being tidied first. ⛔ **So do NOT "fix" this by collapsing the three names onto `gPlayerLogLevel`** — that is a
   sweep across a surface scheduled for deletion, and the ["deferred" is banned](../../AGENTS.md#design) reflex ("slated and never done ⇒ failure
   to fix") MISREADS it. The work is MIGRATING DOMAINS ONTO THE SPINE; the gates then disappear on their own.
+- **⚖ THE ONE NUMBER IS THE *UNIVERSAL* LOG LEVEL, AND THE LEGACY SITES MIMIC IT.** The single-value assignment
+  is not a shortcut that lost three knobs — it is what makes the legacy BBAI logging FOLLOW the universal level
+  instead of drifting on gates of its own. ⇒ The scope names are the accident; the universal level is the thing.
+  ⚑ **And the end state is not "rename it to something better" — it is that the level belongs to the CONSUMER.**
+  A gate global lives at the CALL SITE, which is the legacy shape; once a domain emits, what remains is the file
+  consumer's level and `gStreamLogLevel`, one per consumer. So the two live knobs are already consumer-shaped
+  (file, stream) and the four globals are the residue.
+- **⚖ THE OPTIONS SCREEN SHOWS ONE LEVEL PER CONSUMER — never one per scope.** `Autolog.xml` declares exactly
+  three: the **universal** level (`LogLevelPlayerBBAI`, gating every log FILE), the **stream** level
+  (`LogLevelStream`), and the independent **perf census** level (`LogLevelPerf`). ⛔ Do NOT add a per-scope
+  dropdown back: there is one number behind it, so a scope knob renders a control that silently does nothing.
+  *(Three of them stood there for years — Team/City/Unit — all settable, all read by nothing, with `Player`
+  rendered second so the only live one was not even the obvious one.)*
+  ⚠ **A knob is wired in TWO places that nothing connects** — the C++ `getBugOption*` string and the
+  `Assets/Config` declaration — so either half can go missing silently: `LogLevelStream` was read and never
+  declared, pinning the stream at 1. `python Tools/verify-bug-options.py` is the check for both directions, and
+  it carries the ratchet that keeps the legacy `logMsg` surface from growing.
 - **Level semantics:** 1 = headline (`begin`/`best`/`decision`), 2 = per-decision (`score`/`order`/`act`), 3 =
   per-candidate (`cand`/`skip`), 4 = inner-loop (a genuine fire hazard — CTB emits 10k+ lines/turn at 4). Owner plays
   at 3.


### PR DESCRIPTION
Closes #476.

## The menu

The DLL reads **one** log-level option and drives all four scope globals from it, so the legacy BBAI call sites **mimic the universal level** rather than carrying gates of their own. The tab rendered **four** dropdowns against that one number.

| option | before | after |
|---|---|---|
| `LogLevelPlayerBBAI` | rendered **second** | the one level, rendered first |
| `LogLevelTeamBBAI` / `LogLevelCityBBAI` / `LogLevelUnitBBAI` | settable, **read by nothing** | removed |
| `LogLevelStream` | **read by the DLL, declared nowhere** → welded to 1 | declared |
| `LogLevelPerf`, `HttpServer`, `MiscLogging` | mixed into the legacy block | dev block, first |

Setting "unit logging" to 4 silently got you nothing, and `Player` rendered second so the only live control wasn't even the obvious one. `LogLevelStream` was the inverse — read as `gStreamLogLevel`, declared nowhere, so `/events` verbosity could not be raised from the menu *or* from `Autolog.ini`, which is exactly when you'd go looking for it.

**Labels are consumer-shaped, not scope-shaped**, because that is what the gates are: *Log level (universal)* for every log file, *Event stream level* for the deliberately-decoupled `/events` consumer, *Performance census level* for the independent perf gate. The dev block now sits first, separated from the ~35 legacy autolog event toggles that belong to a different mod's feature and a different audience.

## ⛔ No C++ changed

The scope globals and the BBAI logging **stay**. `spine.md` §8 rules that they retire *with* the direct `logMsg` call sites and never by being tidied first, and replacing that logging is its own piece of work. Removing the dead dropdowns changes **no logging behaviour** — all four globals were already driven from the single option.

## The guard — `Tools/verify-bug-options.py`

A BUG option is wired in two places nothing connects: a C++ string (`getBugOptionINT("Autolog__LogLevelStream", 1)`) and an XML declaration in `Assets/Config`. No compiler, no loader, no assert sits between them — so either half can go missing in total silence. That is why this is a check rather than a rule.

1. **Read but not declared (fails)** — the lookup always answers the call-site default, so the knob is pinned and unreachable while looking like it works. Measured: **1 violation across 75 reads / 445 declarations**, and it was `LogLevelStream`.
2. **A declared `LogLevel*` nobody consumes (fails)** — the mirror. ⚠ A reference from an options **tab** deliberately does *not* count as consumption — the three dead dropdowns were all rendered. Consumption means a DLL read, a Python getter (explicit `get=` or auto-derived `get<Id>`), or a `<change>` handler.
3. **The legacy logging surface is a ratchet (fails only on a rise)** — 71 `logMsg` sites, 11/10/33 alias reads, 14 `logBBAI`. It does **not** demand removal, because that isn't possible yet; it refuses **growth**. That's the anti-rollerskate mechanism, because the pull is never *"revive the legacy logger"* — it's *"add one more line beside the twenty already here"*.

### Negative-tested, all four branches

| simulated defect | result |
|---|---|
| remove the `LogLevelStream` declaration | `UNREACHABLE` → exit 1 |
| re-add a dead `LogLevelTeamBBAI` | `DEAD KNOB` → exit 1 |
| a new `gDLL->logMsg` site | `LEGACY GREW` → exit 1 |
| the surface shrinking | advisory, exit 0 |

## Verification

- `verify-bug-options.py` clean; `verify-python24`, `verify-python-syntax`, `verify-docs` (1664 links) all clean.
- `XmlValidator.exe -a` from `Assets/`: **404 files, no errors**; `Autolog.xml` parses and now declares exactly three lists.
- No C++ touched, so no build required.
- **Not run:** the options screen itself. A tester should see one log-level dropdown plus stream and perf in a dev block at the top of the Logging tab, and be able to raise `/events` verbosity for the first time.

## Docs

- `AGENTS.md` § Validation — the new tool and its three checks.
- `docs/spine/08-…` — the universal level and why the legacy sites mimic it, that the level ultimately belongs to the **consumer** (file, stream) rather than to a scope, and ⛔ never re-add a per-scope dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
