### PR TITLE
fix(cargo): the transport system was dead end-to-end (#524)

### DIFF
--- a/Assets/savemigration.txt
+++ b/Assets/savemigration.txt
@@ -2315,3 +2315,14 @@ CvCity::m_iWorkableRadiusOverride
 | COMMERCE_TERM_PROCESS_CONVERSION through CvCity::getCommerceTerms -> CyCity::getCommerceTerms. The Finance
 | Advisor reads that term instead of multiplying two raw members.
 CvCity::m_aiProductionToCommerceModifier  (int array, NUM_COMMERCE_TYPES)
+
+| The player's military-unit count -- a COUNT OVER THE PLAYER'S OWN UNITS, so it is derived and derived data
+| serializes nothing (save.md par.5). Being serialized is what let a maintenance drift SURVIVE a save: the
+| stored number arrived stale, disagreed with the units, and CvPlayer::read carried a recount that corrected
+| it and logged "count of military unit out of sync!" on every load -- a self-heal, and the fossil of the hole
+| it was compensating for (the scratch temp unit was tallied at init and then re-typed in place by
+| changeIdentity, which adjusts no counter). The hole is fixed at its source; with the value no longer read
+| from a save there is no stale copy left for a recompute to purge.
+| REPLACEMENT: rebuilt in CvPlayer::read from the unit list, after the units have streamed -- the definition
+| of the count rather than a correction of it. Maintained incrementally in play by CvUnit init/kill as before.
+CvPlayer::m_iNumMilitaryUnits             (int)

--- a/Sources/AI/CvCityAI.cpp
+++ b/Sources/AI/CvCityAI.cpp
@@ -1796,7 +1796,7 @@ void CvCityAI::AI_chooseProduction()
 						int iBestSeaAssaultCapacity = 0;
 						if (eBestAssaultUnit != NO_UNIT)
 						{
-							iBestSeaAssaultCapacity = GC.getUnitInfo(eBestAssaultUnit).getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100;
+							iBestSeaAssaultCapacity = GC.getUnitInfo(eBestAssaultUnit).getCargoSpaceTotal() / 100;
 						}
 
 						if (iBestSeaAssaultCapacity > 0)
@@ -3340,7 +3340,7 @@ void CvCityAI::AI_chooseProduction()
 			int iBestSeaAssaultCapacity = 0;
 			if (eBestAssaultUnit != NO_UNIT)
 			{
-				iBestSeaAssaultCapacity = GC.getUnitInfo(eBestAssaultUnit).getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100;
+				iBestSeaAssaultCapacity = GC.getUnitInfo(eBestAssaultUnit).getCargoSpaceTotal() / 100;
 			}
 
 			int iAreaAttackCityUnits = player.AI_totalAreaUnitAIs(pArea, UNITAI_ATTACK_CITY);
@@ -3526,10 +3526,10 @@ void CvCityAI::AI_chooseProduction()
 						if (eBestMissileCarrierUnit != NO_UNIT)
 						{
 
-							int iMissileCarrierAirNeeded = iMissileCarriers * GC.getUnitInfo(eBestMissileCarrierUnit).getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100;
+							int iMissileCarrierAirNeeded = iMissileCarriers * GC.getUnitInfo(eBestMissileCarrierUnit).getCargoSpaceTotal() / 100;
 
 							if ((player.AI_totalUnitAIs(UNITAI_MISSILE_AIR) < iMissileCarrierAirNeeded) ||
-								(bPrimaryArea && (player.AI_totalAreaUnitAIs(pArea, UNITAI_MISSILE_CARRIER_SEA) * GC.getUnitInfo(eBestMissileCarrierUnit).getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100 < player.AI_totalAreaUnitAIs(pArea, UNITAI_MISSILE_AIR))))
+								(bPrimaryArea && (player.AI_totalAreaUnitAIs(pArea, UNITAI_MISSILE_CARRIER_SEA) * GC.getUnitInfo(eBestMissileCarrierUnit).getCargoSpaceTotal() / 100 < player.AI_totalAreaUnitAIs(pArea, UNITAI_MISSILE_AIR))))
 							{
 								// Don't always build missiles, more likely if really low
 								if (AI_chooseUnit("need missiles", UNITAI_MISSILE_AIR, (player.AI_totalUnitAIs(UNITAI_MISSILE_AIR) < iMissileCarrierAirNeeded / 2) ? 50 : 20))
@@ -3556,7 +3556,7 @@ void CvCityAI::AI_chooseProduction()
 			if (eBestCarrierUnit != NO_UNIT)
 			{
 
-				const int iCarrierAirNeeded = iCarriers * GC.getUnitInfo(eBestCarrierUnit).getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100;
+				const int iCarrierAirNeeded = iCarriers * GC.getUnitInfo(eBestCarrierUnit).getCargoSpaceTotal() / 100;
 
 				// Reduce chances if city gives no air experience
 				if (player.AI_totalUnitAIs(UNITAI_CARRIER_AIR) < iCarrierAirNeeded

--- a/Sources/AI/CvPlayerAI.cpp
+++ b/Sources/AI/CvPlayerAI.cpp
@@ -6361,9 +6361,9 @@ int CvPlayerAI::AI_techUnitValue(TechTypes eTech, int iPathLength, bool& bEnable
 					{
 						iAssaultValue += 1000 * std::max(0, AI_unitImpassableCount(eUnitX) - AI_unitImpassableCount(eExistingUnit));
 
-						const int iOld = (GC.getUnitInfo(eExistingUnit).getMovement(MOVEMENT_MOVES, CASC_SCOPE_UNIT) / 100) * GC.getUnitInfo(eExistingUnit).getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100;
+						const int iOld = (GC.getUnitInfo(eExistingUnit).getMovement(MOVEMENT_MOVES, CASC_SCOPE_UNIT) / 100) * GC.getUnitInfo(eExistingUnit).getCargoSpaceTotal() / 100;
 
-						iAssaultValue += 800 * ((unitX.getMovement(MOVEMENT_MOVES, CASC_SCOPE_UNIT) / 100) * unitX.getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100 - iOld) / std::max(1, iOld);
+						iAssaultValue += 800 * ((unitX.getMovement(MOVEMENT_MOVES, CASC_SCOPE_UNIT) / 100) * unitX.getCargoSpaceTotal() / 100 - iOld) / std::max(1, iOld);
 					}
 
 					if (iAssaultValue > 0)
@@ -10881,7 +10881,7 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 		case UNITAI_ASSAULT_SEA:
 		case UNITAI_SETTLER_SEA:
 		{
-			if (kUnitInfo.getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100 > 0 && kUnitInfo.getSpecialCargo() == NO_SPECIALUNIT)
+			if (kUnitInfo.getCargoSpaceTotal() / 100 > 0 && kUnitInfo.admitsCargoDomain(DOMAIN_LAND))
 			{
 				bValid = true;
 			}
@@ -10892,11 +10892,12 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 		case UNITAI_CARRIER_SEA:
 		case UNITAI_MISSILE_CARRIER_SEA:
 		{
-			// A special-cargo transport is valid for these carrier roles (mirrors the general-cargo
-			// ASSAULT_SEA/SETTLER_SEA case above). This previously gated on CvSpecialUnitInfo's
-			// CarrierUnitAITypes, but that data never loaded (loader/XML tag mismatch) and the loop
-			// passed eUnitAI instead of its own counter — so it was always false (dead). See #194.
-			if (kUnitInfo.getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100 > 0 && kUnitInfo.getSpecialCargo() != NO_SPECIALUNIT)
+			// An AIR-carrying hold is what these roles are: the carrier flies its cargo, where the
+			// ASSAULT_SEA/SETTLER_SEA case above ferries LAND units. This gated on the info's SpecialCargo
+			// scalar, which the JSON model authors on NO unit -- so it was false for every candidate and
+			// AI_unitValue returned 0 across the whole role (the second dead gate here; the first read
+			// CvSpecialUnitInfo's CarrierUnitAITypes, data that never loaded). See #194, #524.
+			if (kUnitInfo.getCargoSpaceTotal() / 100 > 0 && kUnitInfo.admitsCargoDomain(DOMAIN_AIR))
 			{
 				bValid = true;
 			}
@@ -11621,7 +11622,7 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 			{
 				iValue += (iCombatValue / 2);
 				iValue += ((kUnitInfo.getMovement(MOVEMENT_MOVES, CASC_SCOPE_UNIT) / 100) * 200);
-				iValue += (kUnitInfo.getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100 * 300);
+				iValue += (kUnitInfo.getCargoSpaceTotal() / 100 * 300);
 				// Never build galley transports when ocean faring ones exist (issue mainly for Carracks)
 				iValue /= (1 + AI_unitImpassableCount(eUnit));
 				break;
@@ -11630,14 +11631,14 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 			{
 				iValue += iCombatValue;
 				iValue += ((kUnitInfo.getMovement(MOVEMENT_MOVES, CASC_SCOPE_UNIT) / 100) * 50);
-				iValue += (kUnitInfo.getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100 * 400);
+				iValue += (kUnitInfo.getCargoSpaceTotal() / 100 * 400);
 				break;
 			}
 			case UNITAI_MISSILE_CARRIER_SEA:
 			{
 				iValue += iCombatValue;
 				iValue += iCombatValue * ((kUnitInfo.getMovement(MOVEMENT_MOVES, CASC_SCOPE_UNIT) / 100) - 1) /4 ;
-				iValue += (25 + iCombatValue) * (3 + (kUnitInfo.getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100));
+				iValue += (25 + iCombatValue) * (3 + (kUnitInfo.getCargoSpaceTotal() / 100));
 				break;
 			}
 			case UNITAI_PIRATE_SEA:

--- a/Sources/AI/CvUnitAI.cpp
+++ b/Sources/AI/CvUnitAI.cpp
@@ -10156,7 +10156,7 @@ void CvUnitAI::AI_attackAirMove()
 			kPlayer.AI_bestAreaUnitAIValue(UNITAI_CARRIER_SEA, NULL, &eBestCarrierUnit);
 			if (eBestCarrierUnit != NO_UNIT)
 			{
-				int iCarrierAirNeeded = iCarriers * GC.getUnitInfo(eBestCarrierUnit).getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100;
+				int iCarrierAirNeeded = iCarriers * GC.getUnitInfo(eBestCarrierUnit).getCargoSpaceTotal() / 100;
 				if (kPlayer.AI_totalUnitAIs(UNITAI_CARRIER_AIR) < iCarrierAirNeeded)
 				{
 					AI_setUnitAIType(UNITAI_CARRIER_AIR);
@@ -11965,7 +11965,7 @@ bool CvUnitAI::AI_load(UnitAITypes eUnitAI, MissionAITypes eMissionAI, UnitAITyp
 				// if the unit under evaluation is the type we were wanting to get loaded through this command
 				if (eLoopUnitAI == eUnitAI)// || (eUnitAI == UNITAI_ASSAULT_SEA && eLoopUnitAI == UNITAI_ESCORT_SEA))
 				{
-					int iCargoSpaceAvailable = pLoopUnit->cargoSpaceAvailable(getSpecialUnitType(), getDomainType());
+					int iCargoSpaceAvailable = pLoopUnit->cargoSpaceAvailable(getUnitType());
 
 					// iCargoSpaceAvailable refers to the space (in unit counts here) available to load units on the transport under eval
 					if (GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS))
@@ -12102,7 +12102,7 @@ bool CvUnitAI::AI_load(UnitAITypes eUnitAI, MissionAITypes eMissionAI, UnitAITyp
 		{
 			// BBAI TODO: To split or not to split?
 			//Here is where it gets complicated again...
-			const int iCargoSpaceAvailable = bestTransportUnit->cargoSpaceAvailable(getSpecialUnitType(), getDomainType());
+			const int iCargoSpaceAvailable = bestTransportUnit->cargoSpaceAvailable(getUnitType());
 
 			FAssertMsg(iCargoSpaceAvailable > 0, "best unit has no space");
 
@@ -22856,9 +22856,7 @@ bool CvUnitAI::AI_pickupStranded(UnitAITypes eUnitAI, int iMaxPath)
 
 					const int iMaxValuePath = (iBestValue == 0 ? MAX_INT : iValue / iBestValue);
 
-					SpecialUnitTypes eSpecialCargo = (SpecialUnitTypes)pHeadUnit->getSpecialUnitType();
-					DomainTypes eDomainCargo = (DomainTypes)pHeadUnit->getDomainType();
-					if (!bSM || getGroup()->getCargoSpaceAvailable(eSpecialCargo, eDomainCargo) >= groupX->getNumUnitCargoVolumeTotal())
+					if (!bSM || getGroup()->getCargoSpaceAvailable(pHeadUnit->getUnitType()) >= groupX->getNumUnitCargoVolumeTotal())
 					{
 						int iPathTurns = 0;
 						if (generatePath(pPickupPlot, 0, true, &iPathTurns, std::min(iMaxPath, iMaxValuePath)))

--- a/Sources/Engine/CvCity.cpp
+++ b/Sources/Engine/CvCity.cpp
@@ -505,7 +505,11 @@ void CvCity::getBuildingInCity(BuildingTypes eBuilding, int (&read)[NUM_CITY_BUI
 	read[CITY_BUILDING_PRODUCTION_DECAY] = isBuildingProductionDecay(eBuilding) ? 1 : 0;
 	//	WHO BUILT IT -- the ledger's own record, which is the only home this fact has ever had; there is no
 	//	`getBuildingOriginalOwner` on the city and never was, so a caller that wants it asks the ledger.
-	read[CITY_BUILDING_ORIGINAL_OWNER]   = (int)getBuildingData(eBuilding).eBuiltBy;
+	//	⚠ Only when the city HOLDS it: this read is asked about EVERY building (that is what CITY_BUILDING_HAS is
+	//	for), and the ledger has no entry for one the city never built.
+	read[CITY_BUILDING_ORIGINAL_OWNER]   = read[CITY_BUILDING_HAS] != 0
+		? (int)getBuildingData(eBuilding).eBuiltBy
+		: (int)NO_PLAYER;
 }
 
 
@@ -16444,10 +16448,15 @@ bool CvCity::hasBuilding(const BuildingTypes eType) const
 	return m_bHasBuildings[eType];
 }
 
+//	⚖ ABSENCE IS PART OF THE CONTRACT, NOT A MISUSE -- the answer for a building the city does not hold is the
+//	sentinel pair below, and two callers depend on exactly that: the group read (which reports CITY_BUILDING_HAS
+//	and must therefore be askable about any building) and CyCity::getBuildingBuiltTime, which Python calls for
+//	arbitrary ids. CityContext::buildingBuildYear documents the same sentinel.
+//	⛔ So this carried no assert on m_bHasBuildings: it fired on the ordinary total query -- 103k times in one
+//	save load -- claiming a defect where the function was answering exactly as specified.
 BuiltBuildingData CvCity::getBuildingData(const BuildingTypes eType) const
 {
 	FASSERT_BOUNDS(0, GC.getNumBuildingInfos(), eType);
-	FAssert(m_bHasBuildings[eType]);
 	if (m_bHasBuildings[eType])
 	{
 		return m_buildingLedger.find(eType)->second;

--- a/Sources/Engine/CvGame.cpp
+++ b/Sources/Engine/CvGame.cpp
@@ -7190,7 +7190,7 @@ void CvGame::createBarbarianUnits()
 					{
 						iValue += 200;
 					}
-					iValue += kUnit.getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100 * (25 + getSorenRandNum(25, "Cargo Space Value"));
+					iValue += kUnit.getCargoSpaceTotal() / 100 * (25 + getSorenRandNum(25, "Cargo Space Value"));
 
 					if (iValue > iBestValue)
 					{
@@ -11477,7 +11477,7 @@ void CvGame::loadPirateShip(CvUnit* pUnit)
 		{
 			const CvUnitInfo& unitInfo = GC.getUnitInfo((UnitTypes) iJ);
 
-			if (validBarbarianShipUnit(unitInfo, (UnitTypes) iJ) && (!bSM || pUnit->cargoSpaceAvailable((SpecialUnitTypes)unitInfo.getSpecialUnitType(), unitInfo.getDomain()) > 0))
+			if (validBarbarianShipUnit(unitInfo, (UnitTypes) iJ) && (!bSM || pUnit->cargoSpaceAvailable((UnitTypes) iJ) > 0))
 			{
 				int iValue = 1 + getSorenRandNum(1000, "Barb Unit Selection");
 
@@ -11497,7 +11497,7 @@ void CvGame::loadPirateShip(CvUnit* pUnit)
 		{
 			CvUnit* pPirate = GET_PLAYER(BARBARIAN_PLAYER).createUnit((UnitTypes)iBestUnit, pUnit->getX(), pUnit->getY(), UNITAI_ATTACK);
 			if (pPirate != NULL
-			&& pUnit->cargoSpaceAvailable(pPirate->getSpecialUnitType(), pPirate->getDomainType()) >= pPirate->SMCargoVolume())
+			&& pUnit->cargoSpaceAvailable(pPirate->getUnitType()) >= pPirate->SMCargoVolume())
 			{
 				pPirate->setTransportUnit(pUnit);
 				pUnit->AI_setUnitAIType(UNITAI_ASSAULT_SEA);

--- a/Sources/Engine/CvGame.cpp
+++ b/Sources/Engine/CvGame.cpp
@@ -8439,6 +8439,25 @@ void CvGame::read(FDataStreamBase* pStream)
 	// at the postmenu data load (CvXMLLoadUtilitySet -> spineRegisterConsumers), which always precedes a save read.
 	emitGameLoadStarted();
 
+	//	⛔ EVERY TEAM IS BROUGHT TO A FULLY CONSTRUCTED STATE BEFORE ANYTHING STREAMS. A team's info-sized arrays
+	//	are allocated by reset(), and on a load the only reset() a team ever gets is the one inside its OWN read --
+	//	which the EXE runs AFTER the map. So through the whole of CvMap::read the teams stood half-constructed with
+	//	null arrays, and the map's in-read facts drive the cascade straight into them: every improvement fact
+	//	resolves its deposits' conditions, a tech-gated one asks EmpireContext::teamHasTech, and that read hit a
+	//	null m_pabHasTech 15852 times in one load.
+	//	⚑ The reads were TOLERANT, which is why this surfaced as assert noise rather than a crash -- and is exactly
+	//	why it survived: a half-constructed object answering plausibly is the shape that never gets found.
+	//	⚖ It is idempotent by construction: CvTeam::read opens with its own reset(), so this only moves the FIRST
+	//	one earlier. It changes no answer either -- an unallocated tech array already read as "no techs", which is
+	//	what a freshly reset one says -- and the tech facts that arrive later from CvPlayer::read re-book every
+	//	deposit they gate through the banked atom fans ([the load reseed](docs/spine/05-the-load-reseed.md)).
+	//	⛔ Do NOT reach for a guard at the read instead: a guard makes each reader responsible for a state that
+	//	should not exist, and there is no bottom to that list -- the object being whole is the invariant.
+	for (int iTeam = 0; iTeam < MAX_TEAMS; iTeam++)
+	{
+		GET_TEAM((TeamTypes)iTeam).reset((TeamTypes)iTeam);
+	}
+
 	WRAPPER_READ_STRING(wrapper, "CvGame", m_gameId);	// flags for expansion
 
 	uint uiFlag=0;

--- a/Sources/Engine/CvPlayer.cpp
+++ b/Sources/Engine/CvPlayer.cpp
@@ -16380,7 +16380,8 @@ void CvPlayer::read(FDataStreamBase* pStream)
 		WRAPPER_READ(wrapper, "CvPlayer", &m_iRevIdxDistanceModifier);
 		WRAPPER_READ(wrapper, "CvPlayer", &m_iNumNukeUnits);
 		WRAPPER_READ(wrapper, "CvPlayer", &m_iNumOutsideUnits);
-		WRAPPER_READ(wrapper, "CvPlayer", &m_iNumMilitaryUnits);
+		//	⛔ m_iNumMilitaryUnits is NOT read: it is a COUNT OVER THIS PLAYER'S OWN UNITS, so it is derived, and
+		//	derived data serializes nothing ([save.md] par.5). It is rebuilt from the units further down.
 		WRAPPER_READ(wrapper, "CvPlayer", &m_iConscriptCount);
 		WRAPPER_READ(wrapper, "CvPlayer", &m_iMaxConscript);
 		WRAPPER_READ(wrapper, "CvPlayer", &m_iHighestUnitLevel);
@@ -17539,21 +17540,27 @@ void CvPlayer::read(FDataStreamBase* pStream)
 				}
 			}
 		}
+		//	The military count REBUILT from the units, which are the thing it counts -- not compared against a
+		//	stored copy, because none is stored ([save.md] par.5: derived data serializes nothing, and with
+		//	nothing derived read from a save there is no stale value for a recompute to purge).
+		//	⛔ This was a recount that compared against the serialized value and CORRECTED it, announcing
+		//	"count of military unit out of sync!" -- a self-heal, and the fossil of the maintenance hole it was
+		//	compensating for ([no-staleness-no-selfheal.md]). The hole is fixed at its source (CvUnit::init and
+		//	the kill path no longer tally the scratch temp unit, which changeIdentity re-types without ever
+		//	adjusting a counter); the serialization is gone, so the comparison has nothing left to compare and
+		//	the reconstruction is all that remains.
+		//	⚠ It runs AFTER the unit list has streamed, which is what makes it the definition rather than a guess.
 		{
-			int iMilitary = 0;
+			int iMilitaryUnits = 0;
 
 			foreach_(const CvUnit* unitX, units())
 			{
 				if (!unitX->isTempUnit() && GC.getUnitInfo(unitX->getUnitType()).hasTag(CLS_TAG_MILITARY))
 				{
-					iMilitary++;
+					iMilitaryUnits++;
 				}
 			}
-			if (iMilitary != m_iNumMilitaryUnits)
-			{
-				FErrorMsg("count of military unit out of sync! Correcting");
-				m_iNumMilitaryUnits = iMilitary;
-			}
+			m_iNumMilitaryUnits = iMilitaryUnits;
 		}
 
 		{
@@ -17699,7 +17706,7 @@ void CvPlayer::write(FDataStreamBase* pStream)
 		WRAPPER_WRITE(wrapper, "CvPlayer", m_iRevIdxDistanceModifier);
 		WRAPPER_WRITE(wrapper, "CvPlayer", m_iNumNukeUnits);
 		WRAPPER_WRITE(wrapper, "CvPlayer", m_iNumOutsideUnits);
-		WRAPPER_WRITE(wrapper, "CvPlayer", m_iNumMilitaryUnits);
+		//	m_iNumMilitaryUnits is derived from the unit set and is rebuilt on load -- it is not written.
 		WRAPPER_WRITE(wrapper, "CvPlayer", m_iConscriptCount);
 		WRAPPER_WRITE(wrapper, "CvPlayer", m_iMaxConscript);
 		WRAPPER_WRITE(wrapper, "CvPlayer", m_iHighestUnitLevel);

--- a/Sources/Engine/CvSelectionGroup.cpp
+++ b/Sources/Engine/CvSelectionGroup.cpp
@@ -3924,7 +3924,7 @@ void CvSelectionGroup::setTransportUnit(CvUnit* pTransportUnit, CvSelectionGroup
 			return;
 		}
 
-		const int iCargoSpaceAvailable = pTransportUnit->cargoSpaceAvailable(pHeadUnit->getSpecialUnitType(), pHeadUnit->getDomainType());
+		const int iCargoSpaceAvailable = pTransportUnit->cargoSpaceAvailable(pHeadUnit->getUnitType());
 
 		// if no space at all, give up
 		if (iCargoSpaceAvailable < 1)
@@ -3948,9 +3948,7 @@ void CvSelectionGroup::setTransportUnit(CvUnit* pTransportUnit, CvSelectionGroup
 
 			FAssertMsg(iCargoSpaceAvailable >= getNumUnits(), "cargo size too small");
 		}
-		else if (iCargoSpaceAvailable < getNumUnitCargoVolumeTotal()
-			/*pTransportUnit->cargoSpaceAvailable(pHeadUnit->getSpecialUnitType(), pHeadUnit->getDomainType())*/
-			)
+		else if (iCargoSpaceAvailable < getNumUnitCargoVolumeTotal())
 		{
 			// If we can't fit the whole group but we can fit the first unit then split it off and load it on its own.
 			if (getNumUnits() > 1 && iCargoSpaceAvailable >= getHeadUnit()->SMCargoVolume())
@@ -3984,14 +3982,14 @@ void CvSelectionGroup::setTransportUnit(CvUnit* pTransportUnit, CvSelectionGroup
 			// if there is room, load the unit
 			if (GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS))
 			{
-				if (pTransportUnit->cargoSpaceAvailable(pLoopUnit->getSpecialUnitType(), pLoopUnit->getDomainType()) >= pLoopUnit->SMCargoVolume())
+				if (pTransportUnit->cargoSpaceAvailable(pLoopUnit->getUnitType()) >= pLoopUnit->SMCargoVolume())
 				{
 					pLoopUnit->setTransportUnit(pTransportUnit);
 				}
 				// We should continue on the loop because another unit might be able to fit
 				// todo: Should we perhaps consider all unit volumes before we start the loop? Perhaps do a packing algorithm to get the most in?
 			}
-			else if (pTransportUnit->cargoSpaceAvailable(pLoopUnit->getSpecialUnitType(), pLoopUnit->getDomainType()) > 0)
+			else if (pTransportUnit->cargoSpaceAvailable(pLoopUnit->getUnitType()) > 0)
 			{
 				pLoopUnit->setTransportUnit(pTransportUnit);
 			}
@@ -4030,7 +4028,7 @@ void CvSelectionGroup::setRemoteTransportUnit(CvUnit* pTransportUnit)
 		}
 		FAssertMsg(pHeadUnit != NULL, "non-zero group without head unit");
 
-		const int iCargoSpaceAvailable = pTransportUnit->cargoSpaceAvailable(pHeadUnit->getSpecialUnitType(), pHeadUnit->getDomainType());
+		const int iCargoSpaceAvailable = pTransportUnit->cargoSpaceAvailable(pHeadUnit->getUnitType());
 
 		// if no space at all, give up
 		if (iCargoSpaceAvailable < 1)
@@ -4086,11 +4084,11 @@ void CvSelectionGroup::setRemoteTransportUnit(CvUnit* pTransportUnit)
 					bool bSpaceAvailable = false;
 					if (GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS))
 					{
-						bSpaceAvailable = pTransportUnit->cargoSpaceAvailable(pLoopUnit->getSpecialUnitType(), pLoopUnit->getDomainType()) > pLoopUnit->SMCargoVolume();
+						bSpaceAvailable = pTransportUnit->cargoSpaceAvailable(pLoopUnit->getUnitType()) > pLoopUnit->SMCargoVolume();
 					}
 					else
 					{
-						bSpaceAvailable = pTransportUnit->cargoSpaceAvailable(pLoopUnit->getSpecialUnitType(), pLoopUnit->getDomainType()) > 0;
+						bSpaceAvailable = pTransportUnit->cargoSpaceAvailable(pLoopUnit->getUnitType()) > 0;
 					}
 					if (bSpaceAvailable)
 					{
@@ -5828,7 +5826,7 @@ int CvSelectionGroup::getCargoSpace() const
 	return iCargoCount;
 }
 
-int CvSelectionGroup::getCargoSpaceAvailable(SpecialUnitTypes eSpecialCargo, DomainTypes eDomainCargo) const
+int CvSelectionGroup::getCargoSpaceAvailable(UnitTypes eCargoUnit) const
 {
 	PROFILE_EXTRA_FUNC();
 	FAssert(getNumUnits() > 0);
@@ -5840,7 +5838,7 @@ int CvSelectionGroup::getCargoSpaceAvailable(SpecialUnitTypes eSpecialCargo, Dom
 	{
 		if (unitX->AI_getUnitAIType() == eUnitAI)
 		{
-			iCargoCount += unitX->cargoSpaceAvailable(eSpecialCargo, eDomainCargo);
+			iCargoCount += unitX->cargoSpaceAvailable(eCargoUnit);
 		}
 	}
 	return iCargoCount;

--- a/Sources/Engine/CvSelectionGroup.h
+++ b/Sources/Engine/CvSelectionGroup.h
@@ -351,7 +351,7 @@ public:
 	bool findNewLeader(UnitAITypes eAIType);
 	bool doMergeCheck() /* not const - does merge */;
 	int getCargoSpace() const;
-	int getCargoSpaceAvailable(SpecialUnitTypes eSpecialCargo, DomainTypes eDomainCargo) const;
+	int getCargoSpaceAvailable(UnitTypes eCargoUnit = NO_UNIT) const;
 	int countSeeInvisibleActive(UnitAITypes eUnitAI, InvisibleTypes eInvisibleType) const;
 	void releaseUnitAIs(UnitAITypes eUnitAI);
 

--- a/Sources/Engine/CvUnit.cpp
+++ b/Sources/Engine/CvUnit.cpp
@@ -457,7 +457,14 @@ void CvUnit::init(int iID, UnitTypes eUnit, UnitAITypes eUnitAI, PlayerTypes eOw
 			GET_PLAYER(eOwner).changeNumNukeUnits(1);
 		}
 
-		if (isMilitaryBranch())
+		//	⛔ THE SCRATCH UNIT IS NOT AN ARMY MEMBER, so it must not enter a player-level tally (the same
+		//	exclusion the birthmark test above makes for the rest of this unit's bookkeeping). It is created ONCE
+		//	and then re-typed in place by changeIdentity, which resets the unit without touching any counter --
+		//	so a counted temp unit contributes its FIRST type's verdict forever, and no later re-type corrects it.
+		//	⚑ That is what put every player's m_iNumMilitaryUnits permanently out of step with its own units and
+		//	left a recount-and-correct self-heal in CvPlayer::read to paper over it on every load.
+		//	⚠ isTempUnit() is answerable HERE because AI_init has already stamped the birthmark.
+		if (isMilitaryBranch() && !isTempUnit())
 		{
 			GET_PLAYER(eOwner).changeNumMilitaryUnits(1);
 		}
@@ -1599,7 +1606,8 @@ void CvUnit::die()
 		owner.changeNumNukeUnits(-1);
 	}
 
-	if (isMilitaryBranch())
+	//	The withdrawal side of the same exclusion -- one predicate at both ends, or the count drifts the other way.
+	if (isMilitaryBranch() && !isTempUnit())
 	{
 		owner.changeNumMilitaryUnits(-1);
 	}

--- a/Sources/Engine/CvUnit.cpp
+++ b/Sources/Engine/CvUnit.cpp
@@ -1254,7 +1254,7 @@ void CvUnit::convert(CvUnit* pUnit, const bool bKillOriginal)
 		// Check cargo types and capacity when upgrading transports
 		if (GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS))
 		{
-			if (cargoSpaceAvailable(pCargo->getSpecialUnitType(), pCargo->getDomainType()) > pCargo->getCargoVolume())
+			if (cargoSpaceAvailable(pCargo->getUnitType()) > pCargo->getCargoVolume())
 			{
 				pCargo->setTransportUnit(NULL);
 				pCargo->setTransportUnit(this);
@@ -1265,7 +1265,7 @@ void CvUnit::convert(CvUnit* pUnit, const bool bKillOriginal)
 				pCargo->jumpToNearestValidPlot();
 			}
 		}
-		else if (cargoSpaceAvailable(pCargo->getSpecialUnitType(), pCargo->getDomainType()) > 0)
+		else if (cargoSpaceAvailable(pCargo->getUnitType()) > 0)
 		{
 			pCargo->setTransportUnit(NULL);
 			pCargo->setTransportUnit(this);
@@ -5659,7 +5659,7 @@ bool CvUnit::canLoadOntoUnit(const CvUnit* pUnit, const CvPlot* pPlot) const
 	}
 
 	{
-		const int iCargoSpace = pUnit->cargoSpaceAvailable(getSpecialUnitType(), getDomainType());
+		const int iCargoSpace = pUnit->cargoSpaceAvailable(getUnitType());
 
 		if (iCargoSpace < 1 || GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS) && iCargoSpace < SMCargoVolume())
 		{
@@ -10343,7 +10343,7 @@ CvCity* CvUnit::getUpgradeCity(UnitTypes eUnit, bool bSearch, int* iSearchValue)
 			return NULL;
 		}
 	}
-	else if (kUnitInfo.getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100 < getCargo())
+	else if (kUnitInfo.getCargoSpaceTotal() / 100 < getCargo())
 	{
 		return NULL;
 	}
@@ -10352,13 +10352,12 @@ CvCity* CvUnit::getUpgradeCity(UnitTypes eUnit, bool bSearch, int* iSearchValue)
 	{
 		if (pLoopUnit->getTransportUnit() == this)
 		{
-			if (kUnitInfo.getSpecialCargo() != NO_SPECIALUNIT)
+			// The upgrade must not strand what is already aboard: the restriction is the `unit:` qualifier on
+			// the CANDIDATE's own cargo.space entries, evaluated against this cargo unit.
+			if (!kUnitInfo.admitsCargo(pLoopUnit->getUnitInfo()))
 			{
 				return NULL;
 			}
-			// The DOMAIN restriction is the `unit:` predicate qualifier on the candidate's own cargo.space
-			// entries ([modifier.md] par.6), so answering it needs the QUALIFIED entry read evaluated against
-			// this cargo unit -- the point sum is the unqualified capacity plane by construction and cannot.
 		}
 	}
 
@@ -13097,7 +13096,9 @@ int CvUnit::cargoSpace() const
 		}
 		return iCargoCapacity;
 	}
-	int iCargoCapacity = m_pUnitInfo->getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100 + m_iCargoCapacity;
+	//	getCargoSpaceTotal, never getCargo(CARGO_SPACE): the point sum folds only UNCONDITIONED entries and every
+	//	authored carrier qualifies its hold, so the point read answers 0 for all of them.
+	int iCargoCapacity = m_pUnitInfo->getCargoSpaceTotal() / 100 + m_iCargoCapacity;
 
 	int aiCargo[NUM_CARGO_KINDS];
 	GET_PLAYER(getOwner()).getCargoKinds(aiCargo);
@@ -13132,23 +13133,40 @@ bool CvUnit::isFull() const
 }
 
 
-int CvUnit::cargoSpaceAvailable(SpecialUnitTypes eSpecialCargo, DomainTypes eDomainCargo) const
+//	The free room this carrier has FOR THAT CANDIDATE -- so the carrier's restriction is answered here, which is
+//	where getCargo() says a `unit:` qualifier is evaluated: at the consumer, against each cargo candidate.
+//	⚖ It takes the candidate's UNIT TYPE and nothing else, because the restriction is answerable from the
+//	candidate's own info (domain + tag bitset). That serves the live-unit callers and the one info-only caller
+//	(the barbarian ship spawn, which has no unit yet) through a single read.
+//	⚠ NO_UNIT asks the unrestricted question -- "how much room at all" -- for the callers that only want the count.
+int CvUnit::cargoSpaceAvailable(UnitTypes eCargoUnit) const
 {
-	if (getSpecialCargo() != NO_SPECIALUNIT && getSpecialCargo() != eSpecialCargo)
+	if (eCargoUnit != NO_UNIT)
 	{
-		return 0;
-	}
-	if (getDomainCargo() != NO_DOMAIN && getDomainCargo() != eDomainCargo)
-	{
-		return 0;
-	}
-
-	if (GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS))
-	{
-		if  (eSpecialCargo != NO_SPECIALUNIT && getSMNotSpecialCargo() == eSpecialCargo)
+		const CvUnitInfo& kCargo = GC.getUnitInfo(eCargoUnit);
+		if (!m_pUnitInfo->admitsCargo(kCargo))
 		{
 			return 0;
 		}
+		//	The promotion-set overrides, the surviving half of the legacy scalars: a hold a promotion RETYPED
+		//	(PROMOTION_TRANSPORT_PEOPLE and its five siblings) still binds on top of the authored qualifier.
+		const SpecialUnitTypes eCargoSpecial = (SpecialUnitTypes)kCargo.getSpecialUnitType();
+		if (getDomainCargo() != NO_DOMAIN && getDomainCargo() != kCargo.getDomain())
+		{
+			return 0;
+		}
+		if (getSpecialCargo() != NO_SPECIALUNIT && getSpecialCargo() != eCargoSpecial)
+		{
+			return 0;
+		}
+		if (GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS)
+		&& eCargoSpecial != NO_SPECIALUNIT && getSMNotSpecialCargo() == eCargoSpecial)
+		{
+			return 0;
+		}
+	}
+	if (GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS))
+	{
 		return std::max(0, cargoSpace() - SMgetCargo());
 	}
 	return std::max(0, cargoSpace() - getCargo());
@@ -16029,7 +16047,7 @@ void CvUnit::setTransportUnit(CvUnit* pTransportUnit)
 		if (pTransportUnit != NULL)
 		{
 			//Can Happen without it being a bug if the unit was forced reloaded by means of an adjustment when already loaded that allowed the unit to overload the transport.
-			FAssertMsg(pTransportUnit->cargoSpaceAvailable(getSpecialUnitType(), getDomainType()) > 0, "Cargo space is expected to be available");
+			FAssertMsg(pTransportUnit->cargoSpaceAvailable(getUnitType()) > 0, "Cargo space is expected to be available");
 
 			joinGroup(NULL, true); // Because what if a group of 3 tries to get in a transport which can hold 2...
 
@@ -24055,13 +24073,18 @@ int CvUnit::SMcargoSpaceFilter() const
 	return getSMCargoCapacity();
 }
 
+//	⚖ CAPACITY HAS ONE HOME AND SIZE MATTERS DERIVES FROM IT ([cascade/20-unit-plane.md]) -- smSpace follows from
+//	how many units the carrier holds, so it is never a second authored number. The authored hold is read in whole
+//	units and re-expressed as VOLUME (one nominal unit at its own type profile occupies 100), which is what makes
+//	the same authored 3 mean three hunters whether or not the option is on.
 int CvUnit::SMcargoCapacityPreCheck() const
 {
-	if (isCarrier())
+	if (!isCarrier())
 	{
-		return std::max(1, 100 + getCargoCapacitybyType(100));
+		return 0;
 	}
-	return 0;
+	const int iHold = m_pUnitInfo->getCargoSpaceTotal() / 100 + m_iCargoCapacity;
+	return std::max(1, getCargoCapacitybyType(std::max(1, iHold) * 100));
 }
 
 int CvUnit::getSMCargoCapacity() const
@@ -24270,9 +24293,17 @@ int CvUnit::getSizeMattersOffsetValue() const
 	return qualityRank() + groupRank() + sizeRank() - iTypePivot;
 }
 
+//	The VOLUMETRIC axis of the same rule, and it is the same pivot: the unit type's OWN group+size sum, so a unit
+//	at its type's profile is offset 0 and gets exactly the volume, hold and work rate the data authored.
+//	⚠ The retired form subtracted a flat 10. Only 252 of 2044 units with an authored profile sum to 10, so the
+//	other 88% had every value on this axis multiplied or divided by a power of the VOLUMETRIC multiplier -- 3 per
+//	rank, not the military plane's 1.5 -- reaching /2187 at the low end. It silently scaled cargo volume, cargo
+//	capacity AND setSMBaseWorkRate, which is why an authored work rate did not survive turning the option on.
 int CvUnit::getSizeMattersSpacialOffsetValue() const
 {
-	return groupRank() + sizeRank() - 10;
+	const int iTypePivot = m_pUnitInfo->getBaseGroupRank() + m_pUnitInfo->getBaseSizeRank();
+
+	return groupRank() + sizeRank() - iTypePivot;
 }
 
 int CvUnit::getCargoCapacitybyType(int iValue) const
@@ -24295,9 +24326,16 @@ int CvUnit::getCargoCapacitybyType(int iValue) const
 	return applySMRank(iValue, rankChange, GC.getSIZE_MATTERS_MOST_VOLUMETRIC_MULTIPLIER());
 }
 
+//	A carrier is a unit that HAS A HOLD, and the hold is the authored `cargo.space` plane -- its capacity, and on
+//	its `unit:` qualifier what it may take ([cascade/20-unit-plane.md]). The two legacy scalars survive only as the
+//	PROMOTION-set overrides (getDomainCargo), which just 6 promotions author, so neither can be the test.
+//	⛔ NEVER ask cargoSpace() here: the Size Matters branch resolves its capacity THROUGH this predicate
+//	(SMcargoSpaceFilter -> SMcargoCapacityPreCheck), so doing so recurses without end.
 bool CvUnit::isCarrier() const
 {
-	return getSpecialCargo() != NO_SPECIALUNIT || getDomainCargo() != NO_DOMAIN;
+	return m_pUnitInfo->getCargoSpaceTotal() + m_iCargoCapacity * 100 > 0
+		|| getSpecialCargo() != NO_SPECIALUNIT
+		|| getDomainCargo() != NO_DOMAIN;
 }
 
 bool CvUnit::isUnitAtBaseGroup() const

--- a/Sources/Engine/CvUnit.h
+++ b/Sources/Engine/CvUnit.h
@@ -884,7 +884,9 @@ public:
 	int cargoSpace() const;
 	void changeCargoSpace(int iChange);
 	bool isFull() const;
-	int cargoSpaceAvailable(SpecialUnitTypes eSpecialCargo = NO_SPECIALUNIT, DomainTypes eDomainCargo = NO_DOMAIN) const;
+	///<summary>Free room in this carrier's hold FOR THAT CANDIDATE -- 0 when the carrier's authored `cargo.space`
+	/// restriction does not admit it. NO_UNIT asks the unrestricted "how much room at all".</summary>
+	int cargoSpaceAvailable(UnitTypes eCargoUnit = NO_UNIT) const;
 	bool hasCargo() const;
 	bool canCargoAllMove() const;
 	bool canCargoEnterArea(TeamTypes eTeam, const CvArea* pArea, bool bIgnoreRightOfPassage) const;

--- a/Sources/Infos/CvModifiers.cpp
+++ b/Sources/Infos/CvModifiers.cpp
@@ -689,13 +689,32 @@ void CvModifiers::walk(std::vector<std::string>& segments, const picojson::value
 	// qualifiers, never address segments / count-by-type leaves. Shape-discriminated: an OBJECT-valued `max`
 	// stays a member segment (tradeRoutes.<scope>.max.{unit}); string-valued unit/religion/orderedBy* only.
 	ModNodeQuals nodeQuals;
+	//	⛔ `unit` IS BOTH A SCOPE SEGMENT AND A QUALIFIER KEY, so the shape alone cannot tell them apart: a
+	//	COMPOUND qualifier (`{unit: {all: [IS_LAND, !IS_VTOL]}, flat: 1}`) is object-valued exactly like the
+	//	`cargo.unit.{...}` scope hop. What separates them is the sentence above -- a qualifier is a SIBLING OF A
+	//	MAGNITUDE LEAF, and a scope hop never has one. (Census: of 10641 object-valued `unit` nodes in the data,
+	//	every scope hop has no magnitude sibling and every one of the 56 compound qualifiers has one.)
+	//	⚠ Accepting only STRING-valued qualifiers silently walked a compound one INTO the address, so the entry
+	//	compiled as the unkinded member `cargo.space.unit.all` and was DROPPED -- 56 of the 90 carriers, every
+	//	aircraft carrier among them, left with no hold at all.
+	bool bHasMagnitudeLeaf = false;
+	for (picojson::object::const_iterator magIt = o.begin(); magIt != o.end(); ++magIt)
+	{
+		if (cascadeUnitFromString(magIt->first) != CASC_UNIT_UNKNOWN)
+		{
+			bHasMagnitudeLeaf = true;
+			break;
+		}
+	}
 	for (picojson::object::const_iterator qualIt = o.begin(); qualIt != o.end(); ++qualIt)
 	{
-		if (qualIt->first == "unit" && qualIt->second.is<std::string>())
+		if (qualIt->first == "unit"
+		&& (qualIt->second.is<std::string>() || (bHasMagnitudeLeaf && qualIt->second.is<picojson::object>())))
 		{
 			nodeQuals.unitQual = &qualIt->second;
 		}
-		else if (qualIt->first == "religion" && qualIt->second.is<std::string>())
+		else if (qualIt->first == "religion"
+		&& (qualIt->second.is<std::string>() || (bHasMagnitudeLeaf && qualIt->second.is<picojson::object>())))
 		{
 			nodeQuals.religionQual = &qualIt->second;
 		}

--- a/Sources/Infos/CvUnitInfo.cpp
+++ b/Sources/Infos/CvUnitInfo.cpp
@@ -17,6 +17,7 @@
 #include "AI/CvGameAI.h"            // complete CvGameAI -- GC.getGame().getSorenRand() (zobrist draw, archive mirror)
 #include "CvUnitCombatInfo.h"       // the combat classes' sizeMatters bases + flat-combat sums (derived ranks)
 #include "CvModifiers.h"            // getModifiers() walk -> the unit's PROPERTY_* emission sources
+#include "CvCondition.h"            // the cargo.space `unit:` qualifier tree (admitsCargo evaluates it)
 #include "Property/CvPropertyBridge.h" // the JSON->manipulator translator (the ONE shared walk)
 
 namespace
@@ -664,4 +665,203 @@ void CvUnitInfo::mapFrom(const picojson::value& entity)
 			m_iAIWeight = jsonIdInt(*pBehaviour, "weight");
 		}
 	}
+}
+
+namespace
+{
+	//	One node of a carrier's `unit:` cargo qualifier, answered against the CANDIDATE'S OWN INFO. The
+	//	qualifier rides the compiled entry (CvModEntry::unitQual) and is evaluated HERE, at the consumer,
+	//	against each cargo candidate -- which is the contract getCargo() states and the reason the point sum
+	//	deliberately excludes qualified entries.
+	//	⚠ In a `unit:` qualifier IS_LAND/IS_AIR/IS_WATER are the candidate's DOMAIN, not a plot's substrate:
+	//	`cargo.space.{unit: IS_AIR}` is the aircraft carrier, and it is the direct heir of legacy DomainCargo
+	//	([cascade/20-unit-plane.md]). Everything else authored on this plane is an IS_<TAG> membership test.
+	bool un_cargoQualifierHolds(const CvCondition* pNode, const CvUnitInfo& kCandidate)
+	{
+		if (pNode == NULL)
+		{
+			return true;   // an unqualified hold admits everything
+		}
+		if (pNode->kind == CASC_COND_GROUP)
+		{
+			for (size_t iChild = 0; iChild < pNode->all.size(); ++iChild)
+			{
+				if (!un_cargoQualifierHolds(pNode->all[iChild], kCandidate))
+				{
+					return false;
+				}
+			}
+			//	A bare `!IS_X` parses to a GROUP carrying it in noneOf, so negation arrives here and nowhere else.
+			for (size_t iChild = 0; iChild < pNode->noneOf.size(); ++iChild)
+			{
+				if (un_cargoQualifierHolds(pNode->noneOf[iChild], kCandidate))
+				{
+					return false;
+				}
+			}
+			if (!pNode->anyOf.empty())
+			{
+				bool bAnyHolds = false;
+				for (size_t iChild = 0; iChild < pNode->anyOf.size() && !bAnyHolds; ++iChild)
+				{
+					bAnyHolds = un_cargoQualifierHolds(pNode->anyOf[iChild], kCandidate);
+				}
+				if (!bAnyHolds)
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+		if (pNode->kind != CASC_COND_PREDICATE)
+		{
+			//	A PRESENCE atom asks about world state a candidate-only read has none of. json par.3.5's rule for
+			//	anything this evaluator cannot answer is IGNORED (true) -- not second-guessed here.
+			return true;
+		}
+		switch (pNode->predKind)
+		{
+		case CASC_PRED_IS_LAND:
+			return kCandidate.getDomain() == DOMAIN_LAND;
+		case CASC_PRED_IS_AIR:
+			return kCandidate.getDomain() == DOMAIN_AIR;
+		case CASC_PRED_IS_WATER:
+			return kCandidate.getDomain() == DOMAIN_SEA;
+		case CASC_PRED_IS_TAG:
+			{
+				//	The tag id resolves LAZILY: the TAG_* infotypes mint AFTER condition parse, so the node's own
+				//	id is -1 and `param` carries the TAG_<SUFFIX> name.
+				const int iTagId = pNode->id >= 0
+					? pNode->id
+					: GC.getInfoTypeForString(pNode->param.c_str(), /*bHideAssert*/ true);
+				//	An UNMINTED tag is an unknown predicate and is IGNORED -- true, json par.3.5.
+				return iTagId < 0 || kCandidate.hasTag(iTagId);
+			}
+		default:
+			return true;   // json par.3.5: an unknown predicate is IGNORED
+		}
+	}
+
+	//	Is this entry the carrier's own authored hold? The cargo capacity plane is CARGO_SPACE at unit scope on
+	//	the flat side; anything else in the family (cargo.size, the SM members) is a different question.
+	bool un_isCargoSpaceEntry(const CvModEntry* pEntry)
+	{
+		return pEntry->kind == CARGO_SPACE
+			&& pEntry->scope == CASC_SCOPE_UNIT
+			&& pEntry->unit == CASC_UNIT_FLAT;
+	}
+
+	//	Collect the DOMAIN predicates a qualifier names, walking the AND/OR spine only.
+	//	⚖ `noneOf` is deliberately not walked: a negated atom on this plane is always a TAG exclusion
+	//	(`!IS_VTOL`, `!IS_MISSILE`), never a domain, and answering a tag for a domain question would invert the
+	//	whole clause -- `{all: [IS_AIR, IS_FIGHTER, !IS_MISSILE]}` would stop being an AIR hold.
+	void un_collectCargoDomains(const CvCondition* pNode, std::vector<DomainTypes>& kDomains)
+	{
+		if (pNode == NULL)
+		{
+			return;
+		}
+		if (pNode->kind == CASC_COND_GROUP)
+		{
+			for (size_t iChild = 0; iChild < pNode->all.size(); ++iChild)
+			{
+				un_collectCargoDomains(pNode->all[iChild], kDomains);
+			}
+			for (size_t iChild = 0; iChild < pNode->anyOf.size(); ++iChild)
+			{
+				un_collectCargoDomains(pNode->anyOf[iChild], kDomains);
+			}
+			return;
+		}
+		if (pNode->kind != CASC_COND_PREDICATE)
+		{
+			return;
+		}
+		switch (pNode->predKind)
+		{
+		case CASC_PRED_IS_LAND:  kDomains.push_back(DOMAIN_LAND); break;
+		case CASC_PRED_IS_AIR:   kDomains.push_back(DOMAIN_AIR);  break;
+		case CASC_PRED_IS_WATER: kDomains.push_back(DOMAIN_SEA);  break;
+		default: break;   // a tag says nothing about domain
+		}
+	}
+}
+
+int CvUnitInfo::getCargoSpaceTotal() const
+{
+	//	(1) the UNCONDITIONED half, through the ordinary point read -- what a promotion's unqualified
+	//	`cargo.space.flat` lands in, and the only half getCargo() has ever been able to see.
+	int iTotal = m_modifiers.sum(MODFAM_CARGO, CARGO_SPACE, CASC_SCOPE_UNIT, CASC_UNIT_FLAT);
+	//	(2) the QUALIFIED half the fold excludes -- which is where EVERY authored carrier's capacity lives,
+	//	because a restricted hold is the normal shape and an unrestricted one the exception.
+	size_t iBegin = 0;
+	size_t iEnd = 0;
+	m_modifiers.conditionedRange(MODFAM_CARGO, iBegin, iEnd);
+	const std::vector<const CvModEntry*>& conditioned = m_modifiers.conditioned();
+	for (size_t iEntry = iBegin; iEntry < iEnd; ++iEntry)
+	{
+		const CvModEntry* pEntry = conditioned[iEntry];
+		if (pEntry->unitQual == NULL || !un_isCargoSpaceEntry(pEntry))
+		{
+			continue;
+		}
+		iTotal += pEntry->value;
+	}
+	return iTotal;
+}
+
+bool CvUnitInfo::admitsCargo(const CvUnitInfo& kCandidate) const
+{
+	size_t iBegin = 0;
+	size_t iEnd = 0;
+	m_modifiers.conditionedRange(MODFAM_CARGO, iBegin, iEnd);
+	const std::vector<const CvModEntry*>& conditioned = m_modifiers.conditioned();
+	bool bHasRestriction = false;
+	for (size_t iEntry = iBegin; iEntry < iEnd; ++iEntry)
+	{
+		const CvModEntry* pEntry = conditioned[iEntry];
+		if (pEntry->unitQual == NULL || !un_isCargoSpaceEntry(pEntry))
+		{
+			continue;
+		}
+		bHasRestriction = true;
+		if (un_cargoQualifierHolds(pEntry->unitQual, kCandidate))
+		{
+			return true;
+		}
+	}
+	//	⚖ No qualified entry at all is an UNRESTRICTED hold (`cargo.space.flat` standing alone), and that admits
+	//	everything. It is NOT the same as a restriction that happens to reject: the first has nothing to say
+	//	about the candidate, the second has said no.
+	return !bHasRestriction;
+}
+
+bool CvUnitInfo::admitsCargoDomain(DomainTypes eDomain) const
+{
+	size_t iBegin = 0;
+	size_t iEnd = 0;
+	m_modifiers.conditionedRange(MODFAM_CARGO, iBegin, iEnd);
+	const std::vector<const CvModEntry*>& conditioned = m_modifiers.conditioned();
+	std::vector<DomainTypes> kDomains;
+	for (size_t iEntry = iBegin; iEntry < iEnd; ++iEntry)
+	{
+		const CvModEntry* pEntry = conditioned[iEntry];
+		if (pEntry->unitQual == NULL || !un_isCargoSpaceEntry(pEntry))
+		{
+			continue;
+		}
+		un_collectCargoDomains(pEntry->unitQual, kDomains);
+	}
+	if (kDomains.empty())
+	{
+		return true;   // the hold names no domain -- it is unrestricted on this axis
+	}
+	for (size_t iDomain = 0; iDomain < kDomains.size(); ++iDomain)
+	{
+		if (kDomains[iDomain] == eDomain)
+		{
+			return true;
+		}
+	}
+	return false;
 }

--- a/Sources/Infos/CvUnitInfo.h
+++ b/Sources/Infos/CvUnitInfo.h
@@ -108,6 +108,25 @@ public:
 	// against each cargo candidate -- the point sum here is the unqualified capacity plane.
 	int getCargo(CargoKind eKind, CvCascScope eScope) const
 	{ return m_modifiers.sum(MODFAM_CARGO, eKind, eScope, CASC_UNIT_FLAT); }
+	///<summary>The carrier's TOTAL authored `cargo.space` -- the QUALIFIED entries included. A restriction says
+	/// WHAT the hold takes, never how much, so every entry counts toward capacity whatever it is qualified on
+	/// ([cascade/20-unit-plane.md] THE RESTRICTION IS THE CARRIER'S).</summary>
+	//	⛔ getCargo(CARGO_SPACE) can NEVER answer this: sum() folds only UNCONDITIONED entries, and all 90
+	//	authored carriers qualify their hold -- so the point read is 0 for every transport in the game.
+	int getCargoSpaceTotal() const;
+	///<summary>Does this carrier's authored restriction admit that cargo candidate? A hold with no qualified
+	/// entry is unrestricted and admits everything.</summary>
+	//	⚑ The candidate answers off its OWN info -- domain for the IS_LAND/IS_AIR/IS_WATER predicates, tag bitset
+	//	for the IS_<TAG> ones -- so no live CvUnit and no eval ctx is involved, exactly as the sibling candidate
+	//	read (CvInfoValuation::candidateTaggedTargetSum) resolves its filter.
+	bool admitsCargo(const CvUnitInfo& kCandidate) const;
+	///<summary>Could a unit of that DOMAIN fit this hold at all -- the candidate-free half of admitsCargo, for
+	/// the callers classifying a carrier rather than testing one cargo unit (an assault transport takes LAND, an
+	/// aircraft carrier AIR).</summary>
+	//	⚠ It reads the DOMAIN predicates only and ignores the tag ones: a hold restricted to `IS_AIR + IS_FIGHTER`
+	//	is still an AIR hold, and which air units it takes is admitsCargo's question, not this one. A hold naming
+	//	no domain at all is domain-unrestricted and admits any.
+	bool admitsCargoDomain(DomainTypes eDomain) const;
 	int getCapture(CaptureKind eKind, CvCascScope eScope) const
 	{ return m_modifiers.sum(MODFAM_CAPTURE, eKind, eScope, CASC_UNIT_FLAT); }
 	int getFlatHeal(HealKind eKind, CvCascScope eScope) const

--- a/Sources/Python/CyUnitInfo.cpp
+++ b/Sources/Python/CyUnitInfo.cpp
@@ -185,7 +185,7 @@ int CyUnitInfo::getCargoSpace(int iUnit) const
 	if (pUnit == NULL) return 0;
 	//	Reduced to the whole count here, which is where the boundary reduces -- CvUnit::cargoSpace performs the
 	//	same division at its own point of use.
-	return pUnit->getCargo(CARGO_SPACE, CASC_SCOPE_UNIT) / 100;
+	return pUnit->getCargoSpaceTotal() / 100;
 }
 
 void CyUnitInfo::pythonPublish()

--- a/Sources/UI/CvUnitSort.cpp
+++ b/Sources/UI/CvUnitSort.cpp
@@ -90,7 +90,7 @@ int UnitSortCargo::getUnitValue(const CvPlayer *pPlayer, const CvCity *pCity, Un
 {
 	// cargo.unit.space.flat -- the unqualified capacity plane (a hold restricted to a cargo class carries a
 	// `unit:` predicate on its entries, which is a CONSUMER-side test against a candidate, not a capacity).
-	return GC.getUnitInfo(eUnit).getCargo(CARGO_SPACE, CASC_SCOPE_UNIT);
+	return GC.getUnitInfo(eUnit).getCargoSpaceTotal();
 }
 
 int UnitSortWithdrawal::getUnitValue(const CvPlayer *pPlayer, const CvCity *pCity, UnitTypes eUnit) const

--- a/docs/cascade/20-unit-plane.md
+++ b/docs/cascade/20-unit-plane.md
@@ -9,10 +9,15 @@ concatenation as each promotion is added — not a downward cascade.
 **Host-from-occupants** effects — what a city gets *per unit stationed in it* (military happiness/anger) — are
 **not** a bespoke host-family: they're an ordinary deposit on the source (the civic/trait), scaled by a
 predicate-filtered unit count and targeting `cities`: `happiness.empire.cities.{unit: IS_MILITARY, flat: N}`
-([json](../specs/json.md) §3.7). The **carrier↔cargo** behaviour splits across the two systems. The carry *ability* is a unit **skill** — whether
-the unit may use the **load/unload** action is `is_cargo_vessel`, and the attack restriction it brings is
-`defend_only` (both skills, [json](../specs/json.md) §8). The *amounts* live in the **`cargo`** modifier family (a unit
+([json](../specs/json.md) §3.7). The **carrier↔cargo** behaviour lives entirely in the **`cargo`** modifier family (a unit
 self-accumulator, set on the unit or a promotion), with two complementary members:
+
+> ⛔ **HAVING A HOLD *IS* THE CARRY ABILITY — there is no separate carrier flag, skill or info scalar.** A unit
+> is a carrier iff `cargo.space` gives it capacity, so `CvUnit::isCarrier` asks exactly that and nothing else.
+> ⚠ The legacy `SpecialCargo`/`DomainCargo` scalars survive ONLY as the promotion-set overrides
+> (`PROMOTION_TRANSPORT_PEOPLE` and its five siblings). **No unit authors them**, so a carrier test written on
+> either one answers false for every transport in the game — which is precisely how the whole transport system
+> came to be dead while reading as implemented.
 
 - **`cargo.space`** — how much the unit **carries** *and what*: `cargo.space.{unit: IS_<domain>, flat: N}` — a
   carrier is `cargo.space.{unit: IS_AIR, flat: N}` (*you can't transport a plane on a landing craft*); an
@@ -34,7 +39,16 @@ self-accumulator, set on the unit or a promotion), with two complementary member
   > ([validation.md](../specs/validation.md) intentional-model-change class; the spec leads, legacy behaviour is not
   > preserved for its own sake).
   > ⚠ Consequence: a carrier whose base capacity is 0 still has a restriction to state, and the §3.9 entry
-  > grammar has no payload-less form for it — an open item for the json spec.
+  > grammar has no payload-less form for it — an open item for the json spec. Until it exists such a hold is
+  > **unrestricted**: with no qualified entry there is no restriction to read, so the promotion-granted space
+  > takes anything (`CvUnitInfo::admitsCargo` answers true when the carrier authored no qualifier at all).
+  ⚖ **THE CAPACITY AND THE RESTRICTION ARE READ BY TWO DIFFERENT CALLS, AND NEITHER IS `getCargo(CARGO_SPACE)`.**
+  The point sum folds only UNCONDITIONED entries, so a qualified hold — which is every authored carrier — is
+  invisible to it. `CvUnitInfo::getCargoSpaceTotal()` is the capacity (qualified entries included, because a
+  restriction says what a hold takes and never how much); `CvUnitInfo::admitsCargo(candidate)` is the
+  restriction, evaluated against the candidate's own info — domain for `IS_LAND`/`IS_AIR`/`IS_WATER`, tag
+  bitset for the rest. ⛔ A new consumer asking "how much cargo does this unit type carry?" uses the former;
+  reaching for the point read reintroduces the silent zero.
   ⚖ **The "what" is ALWAYS a TAG predicate — that is what tags are for.** The legacy restriction by
   `SPECIALUNIT_*` group (`SpecialCargo` / `SMNotSpecialCargo`) brings no new qualifier form with it: it authors as
   the same `{unit: IS_<TAG>}` shape as the domain case. ⚠ It does require the tag to exist AND to be

--- a/docs/specs/json/03-the-shared-vocabulary/07-per-count-scaling.md
+++ b/docs/specs/json/03-the-shared-vocabulary/07-per-count-scaling.md
@@ -28,6 +28,17 @@ The qualifier generalizes by counted kind — the field NAMES what is counted an
 `happiness.empire.cities.{religion: "!IS_STATE_RELIGION", flat: N}` = "N happiness per city religion matching"
 (here: per non-state religion present in the city).
 
+> ⛔ **THE QUALIFIER MAY BE A CONDITION OBJECT, NOT ONLY A BARE STRING — `{unit: {all: [IS_LAND, !IS_VTOL]}}` is
+> the ordinary compound form, and it is the MAJORITY form in the cargo data.** ⚠ `unit` and `religion` are also
+> SCOPE / keyed-map segment names, so shape alone cannot say which one an object-valued key is. What settles it
+> is that **a qualifier is a SIBLING OF A MAGNITUDE LEAF** (`flat`/`percent`/…) and a scope hop never has one —
+> which is exactly how `CvModifiers::walk` discriminates them.
+> ⚑ Getting that wrong is SILENT and total: a compound qualifier read as an address segment turns the entry into
+> the unkinded member `cargo.space.unit.all` and **drops it**, so the deposit simply does not exist. It cost 56
+> of the 90 authored carriers their entire hold — every aircraft carrier among them — while the data read as
+> perfectly well authored. The `[READJSON] unkinded-member` census names it on every load
+> ([validation](../../validation.md)); a non-zero count is dropped authored data, never cosmetic.
+
 > **Predicates vs tags.** `IS_*` predicates are **independent queries**, *not* tag-membership: `IS_LAND`
 > (used by cargo above) matches an intrinsic *domain*, not a `tag`. But a predicate **may be defined to encompass
 > tags** (e.g. `IS_MILITARY` set up to match the `military` tag + similar) — predicates have **definitions**.


### PR DESCRIPTION
Closes #524.

The reporter blamed Size Matters. SM is incidental — **no unit could load onto any transport, in any configuration.** Four independent breaks, each sufficient alone.

## The four breaks

| # | what | evidence |
|---|---|---|
| 1 | `isCarrier()` asked two legacy info scalars | `identity.cargo` authored by **0 of 2044** units; `getDomainCargo()` is a promotion override only (6 promotions). False for all **90** carriers, refusing every load before any arithmetic. |
| 2 | `cargoSpace()` read the unqualified plane | `CvModifiers::sum()` folds only unconditioned entries. **90 of 90** authored `cargo.space` entries carry a `unit:` qualifier → capacity invisible by construction. The galley's `flat: 3` read as **0**. |
| 3 | nobody evaluated the qualifier | `getCargo`'s own comment says it is "evaluated at the CONSUMER against each cargo candidate". That consumer was never written — so fixing 1+2 alone would let a hunter board an aircraft carrier. |
| 4 | compound qualifiers were **dropped at parse** | The node-form shorthand accepted only *string*-valued `unit:`, so `{unit: {all: [IS_LAND, !IS_VTOL]}}` was walked into the address as unkinded member `cargo.space.unit.all`. **56 of 90** carriers, every aircraft carrier among them. |

Break 4's discriminator is the one the code's own comment already stated — a qualifier is a **sibling of a magnitude leaf**. Census over all `Assets/Data`: **10641** object-valued `unit` scope hops have no magnitude sibling; all **56** qualifiers have one. Zero overlap.

## Same root cause, found on the way

- **`getSizeMattersSpacialOffsetValue()` pivoted on a flat `10`.** The comment 30 lines above already rules that shape wrong for the strength axis. The volumetric axis kept it, where the multiplier is **3×** per rank instead of 1.5×:

  | group+size | units | factor on the authored value |
  |---:|---:|---|
  | 3–9 | 1777 | **÷3 … ÷2187** |
  | 10 | 252 | exact |
  | 11–14 | 15 | ×3 … ×81 |

  Only **12.3%** sat at the pivot. This scaled cargo volume, cargo capacity **and `setSMBaseWorkRate`** — an authored work rate did not survive turning the option on.
- **`SMcargoCapacityPreCheck()`** ignored the authored hold and returned a hardcoded `100 + 100`. Capacity has one home and SM derives from it; an authored 3 now means three hunters either way.
- **17 more `getCargo(CARGO_SPACE)` readers on a unit info** — AI naval assault and carrier planning, unit valuation, the pedia, the unit sort — all reading 0 for every transport.
- **`AI_unitValue` scored 0 for the whole `CARRIER_SEA`/`MISSILE_CARRIER_SEA`/`MISSIONARY_SEA`/`SPY_SEA` role** (gated on the same dead scalar), so the AI could never value a carrier. Second dead gate on that line — the first read `CvSpecialUnitInfo` data that never loaded (#194).
- **The upgrade check** could not tell whether an upgraded hull still carries what is aboard; a previous agent left a comment naming exactly the missing read.

## Verification

Ran on **the reporter's own save** (`SIZE_MATTERS = true`, turn 1609), Release, deployed artifact hash-checked against the build.

- Loads clean: `PythonErr` 0, `Exceptions` never created, `Xml_MissingTypes` 0, `unknownKeys=0 missingKeys=0`.
- Break 4 is **directly observable** in the load census:

```
BEFORE:  unkindedMembers=4   ... unkinded-member cargo.space.unit.all
AFTER:   unkindedMembers=3   ... (gone)
```

**Not observed:** a hunter physically boarding a galley — that needs a human at the UI. Worth a tester confirming, and the load census above is the surface to check if it still misbehaves.

**No save break.** `CvUnit::read` ends in `setSMValues(true)`, so the SM cache is recomputed from the info on every load; existing saves pick this up.

## Docs

`cascade/20-unit-plane.md` claimed the carry ability is a skill `is_cargo_vessel` with a `defend_only` sibling. Neither exists anywhere in the tree — corrected to what is true: having a hold *is* the carry ability. The parse trap is recorded in the entry-grammar spec where the qualifier is defined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)