### PR TITLE
fix(map): the land-plot count went negative, killing barbarian spawns (#526)

### DIFF
--- a/Assets/savemigration.txt
+++ b/Assets/savemigration.txt
@@ -2326,3 +2326,16 @@ CvCity::m_aiProductionToCommerceModifier  (int array, NUM_COMMERCE_TYPES)
 | REPLACEMENT: rebuilt in CvPlayer::read from the unit list, after the units have streamed -- the definition
 | of the count rather than a correction of it. Maintained incrementally in play by CvUnit init/kill as before.
 CvPlayer::m_iNumMilitaryUnits             (int)
+
+| The map's land-plot count -- a COUNT OVER THE MAP'S OWN PLOTS, so it is derived and derived data serializes
+| nothing (save.md par.5). Being serialized is what let a SEEDING hole outlive the game that generated the map:
+| the counter is seeded exclusively by CvPlot::setPlotType, whose delta was guarded on the water TRANSITION
+| (bWasWater || bIsWater) while reset leaves a plot NO_PLOT -- so at generation NO_PLOT -> land was no
+| transition at all and counted nothing, while NO_PLOT -> ocean counted -1 apiece, and every generated map
+| stored MINUS its water-plot count. Negative land then reached Python through CyMap::getLandPlots and
+| CvGame::m_iMaxLand, where a fractional power over it raised ValueError and killed BarbarianCiv's
+| onBeginGameTurn (no barbarians spawn at all) and CvGameUtils.calculateScore.
+| REPLACEMENT: rebuilt in CvMap::read from the plots, after they have streamed -- the definition of the count
+| rather than a correction of it. Maintained incrementally in play by CvPlot::setPlotType, whose delta now
+| keys off LAND-ness instead of the water-transition guard.
+CvMap::m_iLandPlots                       (int)

--- a/Sources/Engine/CvMap.cpp
+++ b/Sources/Engine/CvMap.cpp
@@ -1320,7 +1320,8 @@ void CvMap::read(FDataStreamBase* pStream)
 
 	getCurrentViewport()->resizeForMap();
 
-	WRAPPER_READ(wrapper, "CvMap", &m_iLandPlots);
+	//	⛔ m_iLandPlots is NOT read: it is a COUNT OVER THIS MAP'S OWN PLOTS, so it is derived, and derived data
+	//	serializes nothing ([save.md] par.5). It is rebuilt from the plots further down.
 	WRAPPER_READ(wrapper, "CvMap", &m_iOwnedPlots);
 	WRAPPER_READ(wrapper, "CvMap", &m_iTopLatitude);
 	WRAPPER_READ(wrapper, "CvMap", &m_iBottomLatitude);
@@ -1360,6 +1361,25 @@ void CvMap::read(FDataStreamBase* pStream)
 	// Derived, not serialized: recompute the Earth band now that plot terrain is loaded.
 	updateLatitudeGridHeight();
 
+	//	The land-plot count REBUILT from the plots, which are the thing it counts -- not compared against a
+	//	stored copy, because none is stored ([save.md] par.5). ⚠ It runs AFTER the plots have streamed, which is
+	//	what makes it the DEFINITION of the count rather than a correction of it.
+	//	In play it is maintained incrementally by CvPlot::setPlotType, which is what the value is.
+	{
+		int iLandPlots = 0;
+
+		for (int iI = 0; iI < numPlots(); iI++)
+		{
+			const PlotTypes ePlotType = m_pMapPlots[iI].getPlotType();
+
+			if (ePlotType != NO_PLOT && ePlotType != PLOT_OCEAN)
+			{
+				iLandPlots++;
+			}
+		}
+		m_iLandPlots = iLandPlots;
+	}
+
 	WRAPPER_READ_OBJECT_END(wrapper);
 
 	OutputDebugString("Reading Map: End\n");
@@ -1384,7 +1404,6 @@ void CvMap::write(FDataStreamBase* pStream)
 
 	WRAPPER_WRITE(wrapper, "CvMap", m_iGridWidth);
 	WRAPPER_WRITE(wrapper, "CvMap", m_iGridHeight);
-	WRAPPER_WRITE(wrapper, "CvMap", m_iLandPlots);
 	WRAPPER_WRITE(wrapper, "CvMap", m_iOwnedPlots);
 	WRAPPER_WRITE(wrapper, "CvMap", m_iTopLatitude);
 	WRAPPER_WRITE(wrapper, "CvMap", m_iBottomLatitude);

--- a/Sources/Engine/CvPlot.cpp
+++ b/Sources/Engine/CvPlot.cpp
@@ -6761,6 +6761,22 @@ void CvPlot::setPlotType(PlotTypes eNewValue, bool bRecalculate, bool bRebuildGr
 	// The commit, the hash and the facts; then this setter's own EFFECTS below.
 	setPlotTypeInternal(eNewValue);
 
+	//	The map's land-plot count is a FACT of the type, so it settles here with the commit rather than among the
+	//	water-transition EFFECTS below -- and it keys off LAND-ness, never the bWasWater/bIsWater pair.
+	//	⚠ reset() leaves a plot NO_PLOT and generation announces every plot through this setter exactly once,
+	//	which is the ONLY seeding this counter ever gets (setOwner and setBonusType seed their own siblings).
+	//	Under the effects guard, NO_PLOT -> land is not a water transition and so counted NOTHING, while
+	//	NO_PLOT -> ocean counted -1 apiece: a generated map held MINUS its water-plot count.
+	{
+		const bool bWasLand = eOldPlotType != NO_PLOT && eOldPlotType != PLOT_OCEAN;
+		const bool bIsLand = eNewValue != NO_PLOT && eNewValue != PLOT_OCEAN;
+
+		if (bWasLand != bIsLand)
+		{
+			GC.getMap().changeLandPlots(bIsLand ? 1 : -1);
+		}
+	}
+
 	updateSeeFromSight(true, true);
 
 
@@ -6885,8 +6901,6 @@ void CvPlot::setPlotType(PlotTypes eNewValue, bool bRecalculate, bool bRebuildGr
 				plotX->updatePotentialCityWork();
 			}
 		}
-
-		GC.getMap().changeLandPlots(bIsWater ? -1 : 1);
 
 		if (getBonusType() != NO_BONUS)
 		{


### PR DESCRIPTION
Fixes the barbarian half of #526.

## What the reporter saw

```
TRACE: Error in BeginGameTurn event handler <bound method BarbarianCiv.onBeginGameTurn ...>
TRACE: negative number cannot be raised to a fractional power
```
…and no barbarian spawns. `PythonErr.log` carries a second, separate traceback with the same message from `CvGameUtils.calculateScore`.

Both are one root cause, and it is in the engine rather than in either Python file that reported it.

## Root cause

`CvMap::m_iLandPlots` is seeded exclusively by `CvPlot::setPlotType`, whose delta sat inside the water-transition guard:

```cpp
if (bWasWater || bIsWater) { … GC.getMap().changeLandPlots(bIsWater ? -1 : 1); }
```

That was correct while `CvPlot::reset` defaulted a plot to `PLOT_OCEAN`. It no longer does — `reset` leaves `NO_PLOT` deliberately, so a water plot's `IS_WATER`/`HAS_COAST` verdict bits actually derive. Map generation announces **every** plot through `setPlotType` from that `NO_PLOT` state (`CvMapGenerator::setPlotTypes`), and it is the only seeding this counter ever gets:

| transition | water guard | counted |
|---|---|---|
| `NO_PLOT → land` | not a water transition | **nothing** |
| `NO_PLOT → ocean` | is one | **−1** apiece |

So every generated map held **minus its water-plot count**, baked into the save. In-play land↔water flips were always accounted correctly, which is why this only ever looked like a data problem.

## Blast radius beyond barbarians

The negative value reaches Python via `CyMap::getLandPlots` (`BarbarianCiv.getScenario:365` — the `ValueError` takes the whole `onBeginGameTurn` handler down, so no barbarian city ever becomes a minor civ) and via `CvGame::m_iMaxLand` (`CvGameUtils.calculateScore:137`). The engine-side consumers were wrong in silence:

- starting-position spacing (`CvPlayer.cpp:2077`)
- the AI's land-share reads (`CvPlayerAI.cpp:21903`, clamped to 1 → wildly inflated percentages)
- `CvGame.cpp:6999` divides by it
- **Domination Victory's land requirement is bypassed entirely** (`CvGame.cpp:7562`): `100*totalLand < landPlots*pct` can never fire once the right-hand side is negative

## The change

1. **The hole at its source** — the delta keys off land-ness instead of the water-transition pair, and settles at the commit point beside `setPlotTypeInternal` rather than among the setter's water-transition *effects*, because it is a fact of the type and not one of them.
2. **The count stops being serialized** — it is a count over the map's own plots, so it is derived, and derived data serializes nothing ([save.md §5](../blob/main/docs/specs/save.md)). The old tag drains by name through `savemigration.txt` (no `WRAPPER_SKIP_ELEMENT`); `CvMap::read` rebuilds it from the plots after they have streamed, beside the Earth-band recompute already there.

Same shape as the `m_iNumMilitaryUnits` cut in 94c0da47e.

**The second half is what repairs saves already carrying the negative value, including the reporter's** — no new game needed. The load build is the *definition* of the count, not a correction of one, precisely because nothing stale is read back for it to disagree with. In play the value stays incrementally maintained by `setPlotType`.

## Verification

- `Assert rebuild` clean (49s).
- `verify-savemigration` clean with the new entry (747) — which is what confirms the member is genuinely no longer serialized rather than merely unread.
- **Not** verified in a running game. The reporter's attached save is the place to look: barbarians should resume forming minor civs, and `PythonErr.log` should stop collecting both tracebacks.

## Not in this PR

The other items in #526 (borax `or`/`and`, salt ponds unlocking salt mines, mapinguari availability, the GUI reports) are separate and are being triaged on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
