### PR TITLE
fix(data): a dig gate needs BOTH resources, and the mapinguari needs a heritage (#526)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1167,12 +1167,27 @@ the total-observability bar below.)
   edit the working tree only — no commits, branch switches, pushes, or PRs unless explicitly asked. The owner builds
   the DLL from the current working tree; committing to a new branch or checking out away silently removes the
   changes from their build. **Never switch branches while the owner may be mid-build.** (Read-only git is always fine.)
-- **The info JSONs (`Assets/Data/**`) are a DERIVED artifact — regenerate and commit them FREELY, never ask.** They
-  are curator OUTPUT, never hand-edited; right-or-wrong lives in the CURATOR. Regeneration is idempotent and cheap:
-  fix curator → `--sample` verify → `--write` → commit the regenerated data alongside the curator, so the two never
-  dangle apart. This does NOT loosen commit-on-explicit-ask for gameplay CODE.
-- **ALWAYS RECURATE WHEN A DECISION LANDS** —
-  any ruling that changes what the data model carries triggers the curator update + regen in the SAME work item.
+- **⛔ THE INFO JSONs (`Assets/Data/**`) ARE THE AUTHORED SOURCE — EDIT THEM DIRECTLY, and do NOT route a data fix
+  through the curator.** The data is SET and the game is LIVE on it, so the JSON is what the game is: a data change
+  lands there, only. It takes a **VERY** special case to be a curator problem at this stage — reach for the curator
+  only where the defect is genuinely a whole-corpus CONVERSION RULE, never to correct what one entry says.
+  ⛔ **AND THE LEGACY XML IS OBSOLETE AS A SOURCE OF TRUTH — it CANNOT be relied on unless specifically stated.**
+  It is a pre-migration snapshot that the authored JSON has since moved away from, so *"the XML says X"* settles
+  NOTHING about what the game does; where the two disagree the JSON is simply right. ⚠ Do not read it to
+  reconstruct intent, and do not "restore" the JSON toward it.
+  ⛔ **So a REGEN is no longer free, and the retired rule said the exact opposite** — it read *"regenerate and commit
+  FREELY, never ask; right-or-wrong lives in the CURATOR"*, which is now backwards and destructive: a blanket regen
+  OVERWRITES the authored data with conversion output and silently discards every fix made since. Do not run one as
+  a matter of course, and never to "tidy" a hand edit.
+  ⚑ **A MIGRATION-ERA SHAPE THEREFORE CARRIES NO AUTHORITY.** What the curator produced is an artifact of the
+  conversion, not authored intent — so *"the curator did this deliberately"* is never on its own a reason to keep a
+  gate, a fold or a value that is wrong in the game. ⚠ The curator's own comments read as rulings and are the trap
+  here: they record why a CONVERSION chose a shape, which is not the same claim as that shape being right.
+  ⚖ **And the data is now GAMEPLAY, so it follows the ordinary review rule** (the owner sees the diff / an active
+  issue) — the old free-to-commit exemption existed only because the JSON was derived, and that premise is gone.
+- **⛔ THE RUNTIME BAN ON THE LEGACY XML IS UNCHANGED AND IS NOT WEAKENED BY ANY OF THE ABOVE** — "obsolete as a
+  data source" is not "gone", and a replaced info's XML must still never be read INTO THE GAME
+  ([the hard rule](#build-and-test)).
 - **Docs-only changes go to `main` ONLY when the owner explicitly authorizes it**; default is the working branch. A
   branch-coupled doc (e.g. cascade specs on `json-data-migration`) belongs with that work and commits on the branch.
   The canonical straight-to-`main` docs are the INDEXES (`indexes/DESPAIR_INDEX.*`, `REALISM_INDEX.*`, the

--- a/Assets/Data/buildings/ancient/building_mine_borax.json
+++ b/Assets/Data/buildings/ancient/building_mine_borax.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_SALT",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_STONE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_SALT",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_STONE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/ancient/building_mine_cinnabar.json
+++ b/Assets/Data/buildings/ancient/building_mine_cinnabar.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_LEAD_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_SILVER_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_LEAD_ORE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_SILVER_ORE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/ancient/building_mine_fluorite.json
+++ b/Assets/Data/buildings/ancient/building_mine_fluorite.json
@@ -27,18 +27,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_SAPPHIRES",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_STONE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_SAPPHIRES",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_STONE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/ancient/building_mine_onyx.json
+++ b/Assets/Data/buildings/ancient/building_mine_onyx.json
@@ -27,18 +27,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_JADE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_MARBLE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_JADE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_MARBLE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/ancient/building_mine_potash.json
+++ b/Assets/Data/buildings/ancient/building_mine_potash.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_FINE_CLAY",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_SALT",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_FINE_CLAY",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_SALT",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/ancient/building_mine_quartz.json
+++ b/Assets/Data/buildings/ancient/building_mine_quartz.json
@@ -27,18 +27,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_DIAMOND",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_STONE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_DIAMOND",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_STONE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/ancient/building_mine_topaz.json
+++ b/Assets/Data/buildings/ancient/building_mine_topaz.json
@@ -27,18 +27,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_AMBER",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_GOLD_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_AMBER",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_GOLD_ORE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/ancient/building_mine_zinc.json
+++ b/Assets/Data/buildings/ancient/building_mine_zinc.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_COPPER_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_SILVER_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_COPPER_ORE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_SILVER_ORE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/atomic/building_mine_berlinite.json
+++ b/Assets/Data/buildings/atomic/building_mine_berlinite.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_BAUXITE_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_DIAMOND",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_BAUXITE_ORE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_DIAMOND",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/atomic/building_mine_caesium.json
+++ b/Assets/Data/buildings/atomic/building_mine_caesium.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_BAUXITE_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_SILVER_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_BAUXITE_ORE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_SILVER_ORE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/atomic/building_mine_chromite.json
+++ b/Assets/Data/buildings/atomic/building_mine_chromite.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_BAUXITE_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_IRON_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_BAUXITE_ORE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_IRON_ORE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/atomic/building_mine_lazulite.json
+++ b/Assets/Data/buildings/atomic/building_mine_lazulite.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_BAUXITE_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_SAPPHIRES",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_BAUXITE_ORE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_SAPPHIRES",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/atomic/building_mine_nickel.json
+++ b/Assets/Data/buildings/atomic/building_mine_nickel.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_BAUXITE_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_SULPHUR",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_BAUXITE_ORE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_SULPHUR",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/classical/building_mine_magnetite.json
+++ b/Assets/Data/buildings/classical/building_mine_magnetite.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_IRON_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_OBSIDIAN",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_IRON_ORE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_OBSIDIAN",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/industrial/building_mine_graphite.json
+++ b/Assets/Data/buildings/industrial/building_mine_graphite.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_COAL",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_STONE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_COAL",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_STONE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/industrial/building_mine_jet.json
+++ b/Assets/Data/buildings/industrial/building_mine_jet.json
@@ -27,18 +27,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_COAL",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_OBSIDIAN",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_COAL",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_OBSIDIAN",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/industrial/building_mine_mascagnite.json
+++ b/Assets/Data/buildings/industrial/building_mine_mascagnite.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_SULPHUR",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_COAL",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_SULPHUR",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_COAL",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/prehistoric/building_mapinguari_compound.json
+++ b/Assets/Data/buildings/prehistoric/building_mapinguari_compound.json
@@ -16,6 +16,7 @@
    ],
    "all": [
     "TECH_SIMPLE_WOOD_WORKING",
+    "HERITAGE_FOLKLORE_ANTEATER",
     {
      "type": "MAPCATEGORY_EARTH",
      "scope": "plot"

--- a/Assets/Data/buildings/renaissance/building_dig_site_ammonite_fossils.json
+++ b/Assets/Data/buildings/renaissance/building_dig_site_ammonite_fossils.json
@@ -26,18 +26,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_CLAM",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_FOSSIL_BEDS",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_CLAM",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_FOSSIL_BEDS",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_dig_site_archaeopteryx_fossils.json
+++ b/Assets/Data/buildings/renaissance/building_dig_site_archaeopteryx_fossils.json
@@ -26,18 +26,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_POULTRY",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_FOSSIL_BEDS",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_POULTRY",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_FOSSIL_BEDS",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_dig_site_dimetrodon_fossils.json
+++ b/Assets/Data/buildings/renaissance/building_dig_site_dimetrodon_fossils.json
@@ -26,18 +26,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_PIG",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_FOSSIL_BEDS",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_PIG",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_FOSSIL_BEDS",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_dig_site_ichthyostega_fossils.json
+++ b/Assets/Data/buildings/renaissance/building_dig_site_ichthyostega_fossils.json
@@ -26,18 +26,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_COAL",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_FOSSIL_BEDS",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_COAL",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_FOSSIL_BEDS",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_dig_site_mammoth_fossils.json
+++ b/Assets/Data/buildings/renaissance/building_dig_site_mammoth_fossils.json
@@ -26,18 +26,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_MAMMOTH",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_FOSSIL_BEDS",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_MAMMOTH",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_FOSSIL_BEDS",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_dig_site_neanderthal_fossils.json
+++ b/Assets/Data/buildings/renaissance/building_dig_site_neanderthal_fossils.json
@@ -26,18 +26,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_STONE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_FOSSIL_BEDS",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_STONE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_FOSSIL_BEDS",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_dig_site_petrified_wood.json
+++ b/Assets/Data/buildings/renaissance/building_dig_site_petrified_wood.json
@@ -26,18 +26,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_PRIME_TIMBER",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_FOSSIL_BEDS",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_PRIME_TIMBER",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_FOSSIL_BEDS",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_dig_site_plesiosaur_fossils.json
+++ b/Assets/Data/buildings/renaissance/building_dig_site_plesiosaur_fossils.json
@@ -26,18 +26,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_WHALE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_FOSSIL_BEDS",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_WHALE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_FOSSIL_BEDS",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_dig_site_shark_teeth.json
+++ b/Assets/Data/buildings/renaissance/building_dig_site_shark_teeth.json
@@ -26,18 +26,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_FISH",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_FOSSIL_BEDS",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_FISH",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_FOSSIL_BEDS",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_dig_site_smilodon_fossils.json
+++ b/Assets/Data/buildings/renaissance/building_dig_site_smilodon_fossils.json
@@ -26,18 +26,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_WHEAT",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_FOSSIL_BEDS",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_WHEAT",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_FOSSIL_BEDS",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_dig_site_triceratops_fossils.json
+++ b/Assets/Data/buildings/renaissance/building_dig_site_triceratops_fossils.json
@@ -26,18 +26,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_COW",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_FOSSIL_BEDS",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_COW",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_FOSSIL_BEDS",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_dig_site_trilobite_fossils.json
+++ b/Assets/Data/buildings/renaissance/building_dig_site_trilobite_fossils.json
@@ -26,18 +26,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_CRAB",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_FOSSIL_BEDS",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_CRAB",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_FOSSIL_BEDS",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_dig_site_velociraptor_fossils.json
+++ b/Assets/Data/buildings/renaissance/building_dig_site_velociraptor_fossils.json
@@ -26,18 +26,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_HORSE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_FOSSIL_BEDS",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_HORSE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_FOSSIL_BEDS",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_mapinguari_changing_of_the_guard_ceremony.json
+++ b/Assets/Data/buildings/renaissance/building_mapinguari_changing_of_the_guard_ceremony.json
@@ -13,6 +13,7 @@
   "operate": {
    "all": [
     "TECH_GUNPOWDER",
+    "HERITAGE_FOLKLORE_ANTEATER",
     {
      "type": "MAPCATEGORY_EARTH",
      "scope": "plot"

--- a/Assets/Data/buildings/renaissance/building_mine_citrine.json
+++ b/Assets/Data/buildings/renaissance/building_mine_citrine.json
@@ -27,18 +27,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_AMBER",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_SULPHUR",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_AMBER",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_SULPHUR",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_mine_cobalt.json
+++ b/Assets/Data/buildings/renaissance/building_mine_cobalt.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_SULPHUR",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_STONE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_SULPHUR",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_STONE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_mine_lithium.json
+++ b/Assets/Data/buildings/renaissance/building_mine_lithium.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_LEAD_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_SALT",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_LEAD_ORE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_SALT",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_mine_magnesium.json
+++ b/Assets/Data/buildings/renaissance/building_mine_magnesium.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_SALT",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_IRON_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_SALT",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_IRON_ORE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_mine_manganese.json
+++ b/Assets/Data/buildings/renaissance/building_mine_manganese.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_LEAD_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_IRON_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_LEAD_ORE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_IRON_ORE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_mine_pyrite.json
+++ b/Assets/Data/buildings/renaissance/building_mine_pyrite.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_IRON_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_SULPHUR",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_IRON_ORE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_SULPHUR",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [

--- a/Assets/Data/buildings/renaissance/building_mine_tungsten.json
+++ b/Assets/Data/buildings/renaissance/building_mine_tungsten.json
@@ -22,18 +22,14 @@
   "operate": {
    "all": [
     {
-     "any": [
-      {
-       "type": "BONUS_TIN_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      },
-      {
-       "type": "BONUS_IRON_ORE",
-       "scope": "city",
-       "connection": "onSite"
-      }
-     ]
+     "type": "BONUS_TIN_ORE",
+     "scope": "city",
+     "connection": "onSite"
+    },
+    {
+     "type": "BONUS_IRON_ORE",
+     "scope": "city",
+     "connection": "onSite"
     }
    ],
    "dormant": [


### PR DESCRIPTION
Content gates from #526, plus the ruling that makes the JSON the place to fix them.

## Dig families — OR becomes AND (36 records)

The migration folded the legacy `<VicinityBonus>` singular and its `<PrereqVicinityBonuses>` list into one OR. On dig families that is wrong: **a mine is only a mine if you dig**, and a salt *evaporation pond* supplies `BONUS_SALT` (an active building is a bonus source like any deposit), so under an OR a coastal city with no salt in the ground unlocked salt-gated mines.

The `DIG_SITE_*` set makes it unmistakable — every one is `<theme resource> + FOSSIL_BEDS`:

| as OR (before) | as AND (now) |
|---|---|
| a city with a **clam and no fossil beds** gets the ammonite dig site | ammonite fossils where there are clams **and** fossil beds |
| any city with fossil beds gets **all thirteen** dig sites | each needs its own theme resource too |

All 36 gates are exactly **two** resources, so the AND asks for a co-located pair — the geology the pairings already describe (tungsten with tin and iron, graphite with coal and stone, potash with fine clay and salt).

Scoped to dig families deliberately: a list with **no** singular was always a real OR and is untouched (the pest buildings want grains OR cheese OR vegetables).

## Mapinguari — behind a heritage

Buildable by anyone, and the route was **not** the compound: `BUILDING_MAPINGUARI_CHANGING_OF_THE_GUARD_CEREMONY` is `autoBuild` gated on nothing but Gunpowder, so it placed itself in every city of every player who researched it and satisfied the units' `any: [compound, ceremony]` gate.

Both buildings now require `HERITAGE_FOLKLORE_ANTEATER`. A heritage is granted by a unit mission (subduing the animal), so it is geographically gated and never default. Anteaters and sloths are both Pilosa; the mapinguari is classically a surviving giant ground sloth.

## The ruling

`Assets/Data` is the **authored** source now. A data fix lands in the JSON, not the curator; a regen is no longer free (it would overwrite authored data with conversion output); and the legacy XML is not a source of truth unless specifically stated. AGENTS.md said the opposite, which is now destructive advice, so it is replaced. **The runtime ban on reading legacy XML into the game is untouched.**

## Verification

- All 13,134 JSON files parse; the rewriter round-trips byte-identically, so the diffs carry only the gate change.
- **Not** verified in game. The thing to look at: a coastal city with a salt pond and no salt deposit should no longer offer the salt-gated mines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)