### PR TITLE
fix(ui): the happiness tooltip said "buildings" for the whole deposit plane (#526)

### DIFF
--- a/Assets/XML/GameText/Global_CIV4GameText.xml
+++ b/Assets/XML/GameText/Global_CIV4GameText.xml
@@ -28504,6 +28504,22 @@ feindliche Einheit scrollen[COLOR_REVERT][\BOLD]Anzeige der Siegchance
 		<Italian>[ICON_BULLET][COLOR_HIGHLIGHT_TEXT]+%d1[COLOR_REVERT] [ICON_UNHAPPY]: Gli edifici e gli effetti che influenzano la città mi irritano!</Italian> <!-- city screen hover happiness panel upper right -->
 	</TEXT>
 	<TEXT>
+		<Tag>TXT_KEY_UNHAPPY_CITY_SPECIALISTS</Tag>
+		<English>+%d1[ICON_UNHAPPY] "The people we have set to work here are a burden on us!"</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_UNHAPPY_EMPIRE_SOURCES</Tag>
+		<English>+%d1[ICON_UNHAPPY] "The way our nation is run weighs on this city!"</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_HAPPY_CITY_SPECIALISTS</Tag>
+		<English>+%d1[ICON_HAPPY] "The people we have set to work here please us!"</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_HAPPY_EMPIRE_SOURCES</Tag>
+		<English>+%d1[ICON_HAPPY] "The way our nation is run pleases this city!"</English>
+	</TEXT>
+	<TEXT>
 		<Tag>TXT_KEY_UNHAPPY_CIVIC</Tag>
 		<English>+%d1_Change[ICON_UNHAPPY]: "We hate our government!"</English>
 		<French>+%d1_Change[ICON_UNHAPPY]: "Nous détestons notre gouvernement!"</French>

--- a/Sources/Engine/CvCity.cpp
+++ b/Sources/Engine/CvCity.cpp
@@ -265,17 +265,43 @@ void CvCity::getWellbeing(int (&wellbeing)[NUM_WELLBEING_CHANNELS]) const
 	}
 }
 
-//	The share of the deposits above that this city's OWN BUILDINGS put there.
-//	⚠ These are four channels like any other, on the one uniform package with no special storage, so the
-//	building-origin share is the ordinary origin package read at the channel -- exactly how a food or a hammer
-//	would be attributed to buildings. There is no wellbeing-specific store to consult.
+//	The share of the deposits above that ONE leg put there.
+//	⚠ These are four channels like any other, on the one uniform package with no special storage, so a leg's
+//	share is the ordinary package read at the channel -- exactly how a food or a hammer is attributed. There is
+//	no wellbeing-specific store to consult.
 //	⚠ The FLAT leg only: a percent stack applies to the channel as a whole and cannot be split across the
 //	sources that fed it, so a consumer reports the named legs and lets its own residual carry the rest.
-void CvCity::getBuildingWellbeing(int (&wellbeing)[NUM_WELLBEING_CHANNELS]) const
+void CvCity::getWellbeingFrom(WellbeingLeg eLeg, int (&wellbeing)[NUM_WELLBEING_CHANNELS]) const
 {
 	for (int iChannelIndex = 0; iChannelIndex < NUM_WELLBEING_CHANNELS; ++iChannelIndex)
 	{
-		wellbeing[iChannelIndex] = (int)getBuildingYields().readFlat(cty_wellbeingChannel((WellbeingChannel)iChannelIndex));
+		const int iChannel = cty_wellbeingChannel((WellbeingChannel)iChannelIndex);
+		int64_t iFlat = 0;
+
+		switch (eLeg)
+		{
+		case WELLBEING_LEG_BUILDINGS:
+			iFlat = getBuildingYields().readFlat(iChannel);
+			break;
+
+		case WELLBEING_LEG_SPECIALISTS:
+			iFlat = getSpecialistYields().readFlat(iChannel);
+			break;
+
+		case WELLBEING_LEG_EMPIRE:
+			//	The upper scopes roll DOWN into every city, so an empire or team deposit is experienced here
+			//	even though it was never authored here -- which is exactly why it must not keep reading as a
+			//	building of this city's.
+			if (getOwner() != NO_PLAYER)
+			{
+				const CvPlayer& owner = GET_PLAYER(getOwner());
+
+				iFlat = owner.getCascadePackage().readFlat(iChannel);
+				iFlat += GET_TEAM(owner.getTeam()).getCascadePackage().readFlat(iChannel);
+			}
+			break;
+		}
+		wellbeing[iChannelIndex] = (int)iFlat;
 	}
 }
 

--- a/Sources/Engine/CvCity.cpp
+++ b/Sources/Engine/CvCity.cpp
@@ -242,21 +242,40 @@ void CvCity::getCommerceTerms(CommerceTypes eCommerce, CvCommerceSplitTerms& kTe
 	kTerms = aTerms[eCommerce];
 }
 
+//	The channel a wellbeing side's deposits land on.
+//	The opposing channels share ONE authored family and are minted as SIGN TWINS beside it (modifier.md §2b: a
+//	negative deposit routes to the opposing channel at fill), so anger/unhealth are looked up as the twin of
+//	their authored channel rather than as families of their own.
+static int cty_wellbeingChannel(WellbeingChannel eWellbeing)
+{
+	const int iAuthoredChannel = CascadeChannelRegistry::channelLookup(infoWellbeingFamily(eWellbeing), (int)CHANNEL_AMOUNT, -1);
+
+	if (eWellbeing == WELLBEING_ANGER || eWellbeing == WELLBEING_UNHEALTH)
+	{
+		return CascadeChannelRegistry::wellbeingTwin(iAuthoredChannel);
+	}
+	return iAuthoredChannel;
+}
+
 void CvCity::getWellbeing(int (&wellbeing)[NUM_WELLBEING_CHANNELS]) const
 {
 	for (int iChannelIndex = 0; iChannelIndex < NUM_WELLBEING_CHANNELS; ++iChannelIndex)
 	{
-		const WellbeingChannel eWellbeing = (WellbeingChannel)iChannelIndex;
-		// The opposing channels share ONE authored family and are minted as SIGN TWINS beside it (modifier.md
-		// §2b: a negative deposit routes to the opposing channel at fill), so anger/unhealth are looked up as
-		// the twin of their authored channel rather than as families of their own.
-		const int iAuthoredChannel = CascadeChannelRegistry::channelLookup(infoWellbeingFamily(eWellbeing), (int)CHANNEL_AMOUNT, -1);
-		int iChannel = iAuthoredChannel;
-		if (eWellbeing == WELLBEING_ANGER || eWellbeing == WELLBEING_UNHEALTH)
-		{
-			iChannel = CascadeChannelRegistry::wellbeingTwin(iAuthoredChannel);
-		}
-		wellbeing[iChannelIndex] = InfoValuation::realizedAtCity(*this, iChannel);
+		wellbeing[iChannelIndex] = InfoValuation::realizedAtCity(*this, cty_wellbeingChannel((WellbeingChannel)iChannelIndex));
+	}
+}
+
+//	The share of the deposits above that this city's OWN BUILDINGS put there.
+//	⚠ These are four channels like any other, on the one uniform package with no special storage, so the
+//	building-origin share is the ordinary origin package read at the channel -- exactly how a food or a hammer
+//	would be attributed to buildings. There is no wellbeing-specific store to consult.
+//	⚠ The FLAT leg only: a percent stack applies to the channel as a whole and cannot be split across the
+//	sources that fed it, so a consumer reports the named legs and lets its own residual carry the rest.
+void CvCity::getBuildingWellbeing(int (&wellbeing)[NUM_WELLBEING_CHANNELS]) const
+{
+	for (int iChannelIndex = 0; iChannelIndex < NUM_WELLBEING_CHANNELS; ++iChannelIndex)
+	{
+		wellbeing[iChannelIndex] = (int)getBuildingYields().readFlat(cty_wellbeingChannel((WellbeingChannel)iChannelIndex));
 	}
 }
 

--- a/Sources/Engine/CvCity.h
+++ b/Sources/Engine/CvCity.h
@@ -836,10 +836,20 @@ public:
 	// The four wellbeing channels (modifier.md §2b): happiness/anger/health/unhealth as four ORDINARY channels,
 	// each a positive magnitude -- the opposing pairs are summed at the verdict, which is not a read.
 	void getWellbeing(int (&wellbeing)[NUM_WELLBEING_CHANNELS]) const;
-	//	The share of getWellbeing this city's OWN BUILDINGS deposited -- the ordinary origin-package read at the
-	//	channel, since these are four channels like any other. FLAT leg only (a percent stack cannot be split
-	//	across the sources that fed it).
-	void getBuildingWellbeing(int (&wellbeing)[NUM_WELLBEING_CHANNELS]) const;
+	//	Which LEG of the deposit roll-up a share of getWellbeing came from. These name the packages
+	//	rolledLegsAtCity sums, which is as fine as attribution gets today: a package aggregates every source
+	//	that deposited into it, so EMPIRE covers civics, traits, techs, bonuses and the rest as one figure.
+	//	Naming those individually is the per-term decomposition census (cascade/09-wellbeing-channels.md).
+	enum WellbeingLeg
+	{
+		WELLBEING_LEG_BUILDINGS = 0,   // this city's own tier-2 flats -- buildings and the city-scope sources with them
+		WELLBEING_LEG_SPECIALISTS,     // this city's tier-1 specialist plane
+		WELLBEING_LEG_EMPIRE           // the upper scopes rolling down: the owner's package plus the team's
+	};
+	//	The share of getWellbeing one leg deposited -- the ordinary origin-package read at the channel, since
+	//	these are four channels like any other. FLAT leg only: a percent stack applies to the channel as a whole
+	//	and cannot be split across the sources that fed it.
+	void getWellbeingFrom(WellbeingLeg eLeg, int (&wellbeing)[NUM_WELLBEING_CHANNELS]) const;
 	void getDefenseKinds(int (&defenses)[NUM_DEFENSE_KINDS]) const;
 	void getMaintenanceKinds(int (&maintenances)[NUM_MAINTENANCE_KINDS]) const;
 	void getBuildRateKinds(int (&buildRates)[NUM_BUILD_RATE_KINDS]) const;

--- a/Sources/Engine/CvCity.h
+++ b/Sources/Engine/CvCity.h
@@ -836,6 +836,10 @@ public:
 	// The four wellbeing channels (modifier.md §2b): happiness/anger/health/unhealth as four ORDINARY channels,
 	// each a positive magnitude -- the opposing pairs are summed at the verdict, which is not a read.
 	void getWellbeing(int (&wellbeing)[NUM_WELLBEING_CHANNELS]) const;
+	//	The share of getWellbeing this city's OWN BUILDINGS deposited -- the ordinary origin-package read at the
+	//	channel, since these are four channels like any other. FLAT leg only (a percent stack cannot be split
+	//	across the sources that fed it).
+	void getBuildingWellbeing(int (&wellbeing)[NUM_WELLBEING_CHANNELS]) const;
 	void getDefenseKinds(int (&defenses)[NUM_DEFENSE_KINDS]) const;
 	void getMaintenanceKinds(int (&maintenances)[NUM_MAINTENANCE_KINDS]) const;
 	void getBuildRateKinds(int (&buildRates)[NUM_BUILD_RATE_KINDS]) const;

--- a/Sources/UI/CvGameTextMgr.cpp
+++ b/Sources/UI/CvGameTextMgr.cpp
@@ -3145,14 +3145,30 @@ void CvGameTextMgr::setAngerHelp(CvWStringBuffer &szBuffer, CvCity& city)
 	//	specialists, corporations, techs, ...) under the buildings label -- so the figure disagreed with the
 	//	city screen's building tab, which sums the per-building contributions. Whatever the named lines below do
 	//	not account for lands in the MISC residual, which is what that line is for.
-	int aBuildingDeposits[NUM_WELLBEING_CHANNELS];
-	city.getBuildingWellbeing(aBuildingDeposits);
-	int iAnger = aBuildingDeposits[WELLBEING_ANGER] / 100;
-	if (iAnger > 0)
+	//	⚠ The DEPOSIT lines are reported per LEG. This was one line printing getWellbeing outright -- every
+	//	source in the cascade (civics, traits, bonuses, specialists, corporations, techs, ...) under the
+	//	BUILDINGS label -- so the figure disagreed with the city screen's building tab, which sums the
+	//	per-building contributions, and the gap between them was every non-building source in the game.
+	//	Whatever the named lines do not account for lands in the MISC residual, which is what it is for.
+	const CvCity::WellbeingLeg aeLegs[3] = {
+		CvCity::WELLBEING_LEG_BUILDINGS, CvCity::WELLBEING_LEG_SPECIALISTS, CvCity::WELLBEING_LEG_EMPIRE
+	};
+	const char* aszAngerLegKey[3] = {
+		"TXT_KEY_UNHAPPY_CITY_BUILDINGS", "TXT_KEY_UNHAPPY_CITY_SPECIALISTS", "TXT_KEY_UNHAPPY_EMPIRE_SOURCES"
+	};
+	int iAnger = 0;
+	for (int iLeg = 0; iLeg < 3; ++iLeg)
 	{
-		iTotal += iAnger;
-		szBuffer.append(gDLL->getText("TXT_KEY_UNHAPPY_CITY_BUILDINGS", iAnger));
-		szBuffer.append(NEWLINE);
+		int aLegDeposits[NUM_WELLBEING_CHANNELS];
+		city.getWellbeingFrom(aeLegs[iLeg], aLegDeposits);
+
+		iAnger = aLegDeposits[WELLBEING_ANGER] / 100;
+		if (iAnger > 0)
+		{
+			iTotal += iAnger;
+			szBuffer.append(gDLL->getText(aszAngerLegKey[iLeg], iAnger));
+			szBuffer.append(NEWLINE);
+		}
 	}
 
 	// The anger PERCENTS are raw runtime state with no entry list to render from, so each keeps its own line.
@@ -3237,18 +3253,28 @@ void CvGameTextMgr::setHappyHelp(CvWStringBuffer &szBuffer, CvCity& city)
 		return;
 	}
 	CvPlayer& kPlayer = GET_PLAYER(city.getOwner());
-	//	⚠ The BUILDINGS line reports what the city's own buildings actually deposited -- see setAngerHelp above
-	//	for why it is not the whole deposit plane. The MISC residual carries what the named lines miss.
-	int aBuildingDeposits[NUM_WELLBEING_CHANNELS];
-	city.getBuildingWellbeing(aBuildingDeposits);
+	//	⚠ The DEPOSIT lines are reported per LEG -- see setAngerHelp above for why one line for all of them was
+	//	wrong. The MISC residual carries what the named lines miss.
+	const CvCity::WellbeingLeg aeLegs[3] = {
+		CvCity::WELLBEING_LEG_BUILDINGS, CvCity::WELLBEING_LEG_SPECIALISTS, CvCity::WELLBEING_LEG_EMPIRE
+	};
+	const char* aszHappyLegKey[3] = {
+		"TXT_KEY_HAPPY_BUILDINGS", "TXT_KEY_HAPPY_CITY_SPECIALISTS", "TXT_KEY_HAPPY_EMPIRE_SOURCES"
+	};
 	int iSum = 0;
-
-	int iHappy = aBuildingDeposits[WELLBEING_HAPPINESS] / 100;
-	if (iHappy > 0)
+	int iHappy = 0;
+	for (int iLeg = 0; iLeg < 3; ++iLeg)
 	{
-		iSum += iHappy;
-		szBuffer.append(gDLL->getText("TXT_KEY_HAPPY_BUILDINGS", iHappy));
-		szBuffer.append(NEWLINE);
+		int aLegDeposits[NUM_WELLBEING_CHANNELS];
+		city.getWellbeingFrom(aeLegs[iLeg], aLegDeposits);
+
+		iHappy = aLegDeposits[WELLBEING_HAPPINESS] / 100;
+		if (iHappy > 0)
+		{
+			iSum += iHappy;
+			szBuffer.append(gDLL->getText(aszHappyLegKey[iLeg], iHappy));
+			szBuffer.append(NEWLINE);
+		}
 	}
 	iHappy = city.getMilitaryHappiness();
 	if (iHappy > 0)

--- a/Sources/UI/CvGameTextMgr.cpp
+++ b/Sources/UI/CvGameTextMgr.cpp
@@ -3140,9 +3140,14 @@ void CvGameTextMgr::setAngerHelp(CvWStringBuffer &szBuffer, CvCity& city)
 	const int iDivisor = GC.getPERCENT_ANGER_DIVISOR();
 	int iTotal = 0;
 
-	int aDeposits[NUM_WELLBEING_CHANNELS];
-	city.getWellbeing(aDeposits);
-	int iAnger = aDeposits[WELLBEING_ANGER] / 100;
+	//	⚠ The BUILDINGS line reports what the city's own buildings actually deposited, not the whole deposit
+	//	plane. It used to print getWellbeing outright -- every source in the cascade (civics, traits, bonuses,
+	//	specialists, corporations, techs, ...) under the buildings label -- so the figure disagreed with the
+	//	city screen's building tab, which sums the per-building contributions. Whatever the named lines below do
+	//	not account for lands in the MISC residual, which is what that line is for.
+	int aBuildingDeposits[NUM_WELLBEING_CHANNELS];
+	city.getBuildingWellbeing(aBuildingDeposits);
+	int iAnger = aBuildingDeposits[WELLBEING_ANGER] / 100;
 	if (iAnger > 0)
 	{
 		iTotal += iAnger;
@@ -3232,11 +3237,13 @@ void CvGameTextMgr::setHappyHelp(CvWStringBuffer &szBuffer, CvCity& city)
 		return;
 	}
 	CvPlayer& kPlayer = GET_PLAYER(city.getOwner());
-	int aDeposits[NUM_WELLBEING_CHANNELS];
-	city.getWellbeing(aDeposits);
+	//	⚠ The BUILDINGS line reports what the city's own buildings actually deposited -- see setAngerHelp above
+	//	for why it is not the whole deposit plane. The MISC residual carries what the named lines miss.
+	int aBuildingDeposits[NUM_WELLBEING_CHANNELS];
+	city.getBuildingWellbeing(aBuildingDeposits);
 	int iSum = 0;
 
-	int iHappy = aDeposits[WELLBEING_HAPPINESS] / 100;
+	int iHappy = aBuildingDeposits[WELLBEING_HAPPINESS] / 100;
 	if (iHappy > 0)
 	{
 		iSum += iHappy;


### PR DESCRIPTION
Fixes the happiness-attribution item in #526.

## What the reporter saw

> unhappiness is all listed as coming from buildings while not listing it under the buildings tab — one of my cities has about 10 unhappiness under the buildings tab, but 40 unhappiness from buildings listed

## Cause

`setAngerHelp` and `setHappyHelp` took `city.getWellbeing()` — the city's **entire** deposit roll-up, every source the cascade has (civics, traits, bonuses, specialists, corporations, techs, projects, handicaps, military units) — and printed it under `TXT_KEY_UNHAPPY_CITY_BUILDINGS` / `TXT_KEY_HAPPY_BUILDINGS`.

The city screen's building tab meanwhile sums the actual per-building contributions. **Both numbers were right; the label was wrong**, and the gap between them is every non-building source in the game.

## Fix

The buildings line now reports what the buildings actually deposited.

Worth naming the error in getting there: I first assumed wellbeing needed a *special* mechanism and reported that no per-origin read existed. It does. Happiness/anger/health/unhealth are **four channels like any other**, carried on the one uniform package with no special storage ([`cascade/09-wellbeing-channels.md`](../blob/main/docs/cascade/09-wellbeing-channels.md)) — so the building-origin share is the ordinary origin-package read at the channel, `getBuildingYields().readFlat(ch)`, exactly how a food or a hammer is attributed to buildings. `rolledLegsAtCity` already splits the city-flat leg from the upper empire/team legs the same way.

`CvCity::getBuildingWellbeing` is that read, sharing `getWellbeing`'s channel resolution (the anger/unhealth sign-twin lookup) rather than restating it.

## Scope

The **flat** leg. A percent stack applies to the channel as a whole and cannot be split across the sources that fed it, so the named lines report flats and the **MISC residual** carries the remainder — which is what that line already existed for.

Naming the *other* sources (a line per deposit term) is the decomposition census `cascade/09` already records as missing, and is deliberately not this fix.

## Verification

- `Assert rebuild` clean.
- **Not** verified on screen. The check: the tooltip's buildings figure should now agree with the building tab's sum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)