### PR TITLE
fix(ui): tooltips spell out yields where the icon belongs

### DIFF
--- a/Assets/XML/GameText/BUG_CIV4GameText.xml
+++ b/Assets/XML/GameText/BUG_CIV4GameText.xml
@@ -137,7 +137,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUG_FINANCIAL_ADVISOR_COMMERCE</Tag>
-		<English>Total Commerce</English>
+		<English>Total [ICON_COMMERCE]</English>
 		<French>Commerce total</French>
 		<German>Handel insgesamt</German>
 		<Italian>Commercio totale</Italian>
@@ -147,7 +147,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUG_FINANCIAL_ADVISOR_DOMESTIC_TRADE</Tag>
-		<English>The Total Commerce from Domestic Trade Routes</English>
+		<English>The Total [ICON_COMMERCE] from Domestic Trade Routes</English>
 		<French>Commerce Total provenant des Routes d'échange</French>
 		<German>Gesamteinkommen durch inländische Handelsverbindungen</German>
 		<Italian>Commercio totale dalle rotte commerciali interne</Italian>
@@ -157,7 +157,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUG_FINANCIAL_ADVISOR_FOREIGN_TRADE</Tag>
-		<English>The Total Commerce from Foreign Trade Routes</English>
+		<English>The Total [ICON_COMMERCE] from Foreign Trade Routes</English>
 		<French>Commerce Total provenant des Routes d'échange étrangères</French>
 		<German>Gesamteinkommen durch ausländische Handelsverbindungen</German>
 		<Italian>Commercio totale dalle rotte commerciali estere</Italian>
@@ -167,7 +167,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUG_FINANCIAL_ADVISOR_SPECIALISTS</Tag>
-		<English>The Total Gold from Specialists</English>
+		<English>The Total [ICON_GOLD] from Specialists</English>
 		<French>Revenus Totaux provenant des Spécialistes</French>
 		<German>Gesamteinkommen durch Spezialisten</German>
 		<Italian>Oro totale ottenuto dagli specialisti</Italian>

--- a/Assets/XML/GameText/BuildingHelp_CIV4GameText.xml
+++ b/Assets/XML/GameText/BuildingHelp_CIV4GameText.xml
@@ -374,7 +374,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDINGHELP_ESPIONAGE_DEFENSE_MOD</Tag>
-		<English>[ICON_BULLET]%D1_Mod%% Defense against Espionage</English>
+		<English>[ICON_BULLET]%D1_Mod%% Defense against [ICON_ESPIONAGE]</English>
 		<French>[ICON_BULLET]Protection contre l'espionnage %D1_Mod%%</French>
 		<German>[ICON_BULLET]%D1_Mod%% Verteidigung gegen Spionage</German>
 		<Italian>[ICON_BULLET]%D1_Mod%% in difesa contro lo spionaggio</Italian>
@@ -774,7 +774,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDINGHELP_HURRY_MOD</Tag>
-		<English>[ICON_BULLET]%D1_Mod%% Hurry Production Cost</English>
+		<English>[ICON_BULLET]%D1_Mod%% Hurry [ICON_PRODUCTION] Cost</English>
 		<French>[ICON_BULLET]Coût de l'accélération de la production %D1_Mod%%</French>
 		<German>[ICON_BULLET]%D1_Mod%% Kosten für beschleunigte Produktion</German>
 		<Italian>[ICON_BULLET]%D1_Mod%% costo per accelerare la produzione</Italian>
@@ -894,7 +894,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDINGHELP_MILITARY_MOD</Tag>
-		<English>[ICON_BULLET]%D1_Mod%% Military Unit Production</English>
+		<English>[ICON_BULLET]%D1_Mod%% Military Unit [ICON_PRODUCTION]</English>
 		<French>[ICON_BULLET]Production d'unités militaires %D1_Mod%%</French>
 		<German>[ICON_BULLET]%D1_Mod%% Produktion von Militäreinheiten</German>
 		<Italian>[ICON_BULLET]%D1_Mod%% di produzione nelle unità militari</Italian>
@@ -1110,7 +1110,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDINGHELP_PROTECTS_CULTURE</Tag>
-		<English>[ICON_BULLET]Nearby Battles will not affect Culture</English>
+		<English>[ICON_BULLET]Nearby Battles will not affect [ICON_CULTURE]</English>
 		<French>[ICON_BULLET]Les Batailles aux alentours n'affecteront pas la culture</French>
 		<German>[ICON_BULLET]Nahe Schlachten beeinflussen die Kultur nicht</German>
 		<Italian>[ICON_BULLET]Le battaglie vicine non influenzeranno la cultura</Italian>
@@ -1404,7 +1404,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDINGHELP_SPACESHIP_MOD</Tag>
-		<English>[ICON_BULLET]%D1_Mod%% Spaceship Production</English>
+		<English>[ICON_BULLET]%D1_Mod%% Spaceship [ICON_PRODUCTION]</English>
 		<French>[ICON_BULLET]Production de vaisseau spatial %D1_Mod%%</French>
 		<German>[ICON_BULLET]%D1_Mod%% Raumschiffproduktion</German>
 		<Italian>[ICON_BULLET]%D1_Mod%% sulla produzione dell'astronave</Italian>
@@ -1413,7 +1413,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDINGHELP_SPACESHIP_MOD_ALL_CITIES</Tag>
-		<English>[ICON_BULLET]%D1_Mod%% Spaceship Production in All Cities</English>
+		<English>[ICON_BULLET]%D1_Mod%% Spaceship [ICON_PRODUCTION] in All Cities</English>
 		<French>[ICON_BULLET]Production de vaisseau spatial dans toutes les villes %D1_Mod%%</French>
 		<German>[ICON_BULLET]%D1_Mod%% Raumschiffproduktion in allen Städten</German>
 		<Italian>[ICON_BULLET]%D1_Mod%% sulla produzione dell'astronave in tutte le città</Italian>

--- a/Assets/XML/GameText/Events_CIV4GameText.xml
+++ b/Assets/XML/GameText/Events_CIV4GameText.xml
@@ -10866,7 +10866,7 @@
     </TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_EVENT_SPACE_PRODUCTION_CITY</Tag>
-		<English>[ICON_BULLET][ICON_BULLET]%D1_Mod%% Spaceship Production in %s2_city</English>
+		<English>[ICON_BULLET][ICON_BULLET]%D1_Mod%% Spaceship [ICON_PRODUCTION] in %s2_city</English>
 		<French>[ICON_BULLET][ICON_BULLET]Production du vaisseau spatial à %s2_city %D1_Mod%%</French>
 		<German>[ICON_BULLET][ICON_BULLET]%D1_Mod%% Raumschiffproduktion in %s2_city</German>
 		<Italian>[ICON_BULLET][ICON_BULLET]%D1_Mod%% sulla produzione dell'astronave a %s2_city</Italian>

--- a/Assets/XML/GameText/Global_CIV4GameText.xml
+++ b/Assets/XML/GameText/Global_CIV4GameText.xml
@@ -3950,7 +3950,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_CIVICHELP_MILITARY_PRODUCTION</Tag>
-		<English>[ICON_BULLET]%D1_Mod%% Military Unit Production</English>
+		<English>[ICON_BULLET]%D1_Mod%% Military Unit [ICON_PRODUCTION]</English>
 		<French>[ICON_BULLET]%D1_Mod%% de production d'unités militaires</French>
 		<German>[ICON_BULLET]%D1_Mod%% Produktion von Militäreinheiten</German>
 		<Italian>[ICON_BULLET]%D1_Mod%% di produzione nelle unità militari</Italian>
@@ -6705,7 +6705,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_ESPIONAGE_CULTURE_MOD</Tag>
-		<English>%D1%%: for City Culture</English>
+		<English>%D1%%: for City [ICON_CULTURE]</English>
 		<French>%D1%% : pour la culture de la ville</French>
 		<German>%D1%%: für städtische Kultur</German>
 		<Italian>%D1%%: per la cultura della città</Italian>
@@ -6713,7 +6713,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_ESPIONAGE_DEFENSE_MOD</Tag>
-		<English>%D1%%: for City Espionage Defense</English>
+		<English>%D1%%: for City [ICON_ESPIONAGE] Defense</English>
 		<French>%D1%% : pour la défense de la ville contre l'espionnage</French>
 		<German>%D1%%: für städtische Spionageabwehr</German>
 		<Italian>%D1%%: per la difesa cittadina dallo spionaggio</Italian>
@@ -6737,7 +6737,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_ESPIONAGE_EP_RATIO_MOD</Tag>
-		<English>%D1%%: for Espionage Point Spending</English>
+		<English>%D1%%: for [ICON_ESPIONAGE] Point Spending</English>
 		<French>%D1%% : pour les points d'espionnage dépensés</French>
 		<German>%D1%%: für Spionagepunkt-Aufwendung</German>
 		<Italian>%D1%%: per la spesa dei punti spionaggio</Italian>
@@ -8367,7 +8367,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_FOREIGN_ADVISOR_GOLD_PER_TURN_FOR_TRADE</Tag>
-		<English>%d1 Gold Per Turn Available For Trade</English>
+		<English>%d1[ICON_GOLD] Per Turn Available For Trade</English>
 		<French>%d1 or par tour disponible pour le commerce</French>
 		<German>%d1 Gold pro Runde zum Handel verfübar</German>
 		<Italian>%d1 Oro a turno disponibile per il commercio</Italian>


### PR DESCRIPTION
Reported: a lot of tooltips still say "Production" instead of the production icon, and the same for the commerce yields, commerce and food.

## There is one mechanism, not two — which is what decides the fix

The info owns its own symbol (`CvYieldInfo` / `CvCommerceInfo::getChar`), and text reaches it two ways that **both end at that getter**:

- the DLL composes `%c` from it directly — the canonical `setResumableYieldChangeHelp` path already does this correctly;
- static text writes `[ICON_PRODUCTION]`, which `CvDllTranslator`'s icon map resolves to *the very same* `getChar`:

```cpp
aIconMap[L"[ICON_PRODUCTION]"] = std::wstring(1, (wchar_t)GC.getYieldInfo(YIELD_PRODUCTION).getChar());
```

So a tag in a string is **not** a second mechanism — it is that mechanism's static spelling, and it stays correct if a yield's symbol ever moves.

The stray is the **third** thing: text that spells the word out, bypassing the map entirely and hard-coding what the info already knows. That is what this fixes.

## What changed

Sixteen entries across the building/civic help, the espionage mission list, and the financial + foreign advisors now carry the tag instead of the noun:

| before | after |
|---|---|
| `%D1_Mod%% Hurry Production Cost` | `%D1_Mod%% Hurry [ICON_PRODUCTION] Cost` |
| `%D1_Mod%% Military Unit Production` | `%D1_Mod%% Military Unit [ICON_PRODUCTION]` |
| `%D1_Mod%% Defense against Espionage` | `%D1_Mod%% Defense against [ICON_ESPIONAGE]` |
| `The Total Commerce from Domestic Trade Routes` | `The Total [ICON_COMMERCE] from Domestic Trade Routes` |
| `%d1 Gold Per Turn Available For Trade` | `%d1[ICON_GOLD] Per Turn Available For Trade` |

…and the rest in the same shape.

## Scoped to report shapes, not every occurrence

The word is **correct** where it names something other than the quantity, and swapping those would make the text worse: building and bonus names (`Gold Ore`, `Canned Food`, `Deep Space Antimatter Research Center`), concept names (`Culture Level`, `GP Research`), BUG option labels, and pedia prose explaining a rule.

A census of short English entries using one of the seven words without its icon returns **1216 hits**, and the overwhelming majority are those. So this was a per-entry judgement rather than a sweep, and the table of exact replacements is the reviewable artifact.

⚠ **English only.** The other languages carry their own wording for the same entries, and the icon is language-neutral so they could take the tag too — but identifying the noun in Russian or Italian is not something to do blind.

## Verification

XmlValidator run from `Assets/`: **404 files, no errors.**

If you can point at a specific screen where you are still seeing words, I can go at that one directly — the census above says most remaining hits are legitimate, so the ones bothering you may be in a family I scored as prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)