### PR TITLE
fix(ui): hovering an enemy city listed its whole garrison through the fog (#526)

### DIFF
--- a/Sources/UI/CvGameTextMgr.cpp
+++ b/Sources/UI/CvGameTextMgr.cpp
@@ -831,6 +831,18 @@ void CvGameTextMgr::setPlotListHelp(CvWStringBuffer &szString, CvPlot* pPlot, bo
 	{
 		return;
 	}
+	//	⛔ THE PLOT'S OWN VISIBILITY GATES THE WHOLE LIST, AND IT IS THE FIRST QUESTION -- the per-unit check
+	//	below answers a DIFFERENT one and cannot stand in for it. `isInvisible` asks whether THIS UNIT conceals
+	//	itself from the viewer (a submarine, a hidden hunter); it says nothing about whether the viewer can see
+	//	the TILE. Without this gate the plot's live unit list renders through the fog, so hovering an enemy CITY
+	//	listed its whole garrison -- handing the player exactly the information the fog exists to withhold, on
+	//	the one tile where it matters most.
+	//	⚠ bDebug so debug mode still sees everything, the same convention CvPlot::updateCenterUnit's own
+	//	isActiveVisible(true) uses -- the two answer the same fog question and must not disagree.
+	if (!pPlot->isActiveVisible(true))
+	{
+		return;
+	}
 	const TeamTypes eActiveTeam = GC.getGame().getActiveTeam();
 	bool bFirst = true;
 	//	The plot's OWN unit list -- what it holds, never a sweep of anything.


### PR DESCRIPTION
Reported in #526 as "you can see units that should be hidden in the fog of war". The concrete case: **hover an enemy city and the tooltip names the units inside it.**

## Cause

`setPlotListHelp` filtered the plot's unit list on `isInvisible(activeTeam)` alone:

```cpp
foreach_(const CvUnit* pLoopUnit, pPlot->units())
{
    if (pLoopUnit == NULL || pLoopUnit->isInvisible(eActiveTeam, false))
        continue;                       // per-UNIT concealment only
    setUnitHelp(szString, pLoopUnit, bOneLine, bShort);
}
```

That answers a **different question** and cannot stand in for the one that was missing. `isInvisible` asks whether *this unit* conceals itself from the viewer — a submarine, a hidden hunter. It says nothing about whether the viewer can see the **tile**.

The plot's unit list is live game state, so with no fog gate every unit on a fogged tile rendered — on the one tile where it matters most, since a city is exactly where a player wants to know the garrison before committing.

## Fix

The plot's own visibility gates the whole list, asked first:

```cpp
if (!pPlot->isActiveVisible(true))
{
    return;
}
```

`bDebug` is passed so debug mode still sees everything — the same convention `CvPlot::updateCenterUnit` already uses for this question (`isActiveVisible(true)`). The two answer one fog question and must not disagree.

## Scope

⚠ This is **the leak, not the whole reported item**. Whether the concealment *contest* itself behaves is separate and stays with the hide-and-seek rework (#530, parked against #403) — as does the fact that nothing in the UI renders concealment or detection at all, so a player is never told why something is or is not visible.

## Verification

`Assert rebuild` clean. **Not** verified on screen — the check is hovering an enemy city outside your vision and seeing no unit list, while still seeing one on a tile you do have vision of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)