### PR TITLE
fix(cascade): specialists deposited onto a plane nothing read (#532)

### DIFF
--- a/Sources/Data/CvInfoValuation.cpp
+++ b/Sources/Data/CvInfoValuation.cpp
@@ -850,6 +850,18 @@ void InfoValuation::rolledLegsAtCity(const CvCity& city, int iChannel, int64_t& 
 		percentSum += owner.getCascadePackage().readPercent(iChannel);
 	}
 	flatSum += city.getBuildingYields().readFlat(iChannel);
+	//	⛔ THE SPECIALIST PLANE IS PART OF THIS SUM, AND OMITTING IT DROPPED EVERY DEPOSIT ON IT.
+	//	§2 is ONE formula with ONE Σflat -- `(base + Σflat) × (100 + Σpercent)/100` -- so every flat on the
+	//	channel sums here, whichever plane holds it. A specialist's flats live on their own plane only because
+	//	their COMBINE POSITION differs in the two-tier RATE (§2a: BASE × modifier + EXTRA), which is the
+	//	yield/commerce rate cityReceiverRate computes and which takes the planes as separate arguments.
+	//	⚠ THIS leg serves the channels that have no such rate, where §2 applies unreduced and there is one flat
+	//	sum with no tier to keep apart -- so leaving the plane out preserved no distinction, it simply discarded
+	//	the deposits. A yield is one channel and they combine where needed; a specialist is not excluded from
+	//	the combine.
+	//	⚑ Measured: 26 specialists author a wellbeing channel alone (SPECIALIST_CELEBRITY +2 happiness,
+	//	SPECIALIST_DOCTOR +1.5 health, the settled citizen/slave penalties), and not one reached a city.
+	flatSum += city.getSpecialistYields().readFlat(iChannel);
 	percentSum += city.getCityPercents().readPercent(iChannel);
 }
 


### PR DESCRIPTION
Fixes #532.

## What was happening

A specialist's flats are booked onto their own plane, and **only `cityReceiverRate` ever read it**. `realizedAtCity` routes a channel there only when it is a *receiver*, and the city receivers are `FOOD, PRODUCTION, COMMERCE, CULTURE`. Every other channel fell through to `rolledLegsAtCity`, which summed team + owner + **building** flats and never opened the specialist plane. `realizedWellbeing` adds only raw-state inputs on top, so nothing picked them up later either.

**Written and never read.** On the wellbeing channels alone that is 26 specialists:

| specialist | authored | reached the city |
|---|---|---|
| `SPECIALIST_CELEBRITY` | +2 happiness | no |
| `SPECIALIST_DOCTOR` | +1.5 health | no |
| `SPECIALIST_GREAT_DOCTOR` | +3 health | no |
| `SPECIALIST_SETTLED_CITIZEN` | −1 happiness, −1 health | no |
| every settled-slave variant | −0.4 happiness, −0.4 health | no |

Settled slaves cost nothing. It never surfaced as "specialists do nothing" precisely because their food, production and commerce **are** the four that get read — the visible half worked.

Beyond wellbeing the same omission dropped specialist `experience` (26 authoring), `PROPERTY_CRIME` (14), `PROPERTY_DISEASE` (13), `greatPeopleRate` (12), `espionage` (6), `underworld` (2) and the pollution/education properties.

## The spec settles which side was wrong — it is the read

§2 is **one** formula with **one** `Σflat`:

> `effective = (base + Σflat) × (100 + Σpercent)/100 × Π(multiplier/100)`

So every flat on the channel sums, whichever plane holds it. The plane split exists because the **combine position** differs in the two-tier RATE (§2a: `BASE × modifier + EXTRA`) — which is the yield/commerce rate `cityReceiverRate` computes, and which takes the planes as separate arguments precisely so it can honour the tiers.

Channels with no such rate take §2 unreduced: one flat sum, no tier to keep apart. Leaving the plane out preserved no distinction — it discarded the deposits. A yield is one channel and they combine where needed; a specialist is not excluded from the combine.

## No double count

The two-tier path uses the **5-arg** overload and reads the specialist plane separately — that overload is untouched. The 2-arg legs are the non-receiver reads (defense, the modifier/percent reads, the deposit terms) and none adds specialists of its own.

## This changes balance, deliberately

In several systems at once, which is what it means for authored data to start applying: cities gain the health their doctors were authored to give and the unhappiness their settled population was authored to cost, and specialist crime / disease / experience / great-people contributions begin arriving. The data was always there; only the read was missing.

## Verification

`Assert rebuild` clean. **Not** verified in game — the check is a city with settled slaves now showing their unhappiness (#531's tooltip names the specialists leg directly), and the property channels moving where specialists sit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)