### PR TITLE
fix(great people): no great person could ever be born (#539)

### DIFF
--- a/Assets/savemigration.txt
+++ b/Assets/savemigration.txt
@@ -2339,3 +2339,18 @@ CvPlayer::m_iNumMilitaryUnits             (int)
 | rather than a correction of it. Maintained incrementally in play by CvPlot::setPlotType, whose delta now
 | keys off LAND-ness instead of the water-transition guard.
 CvMap::m_iLandPlots                       (int)
+| The city's per-great-person-type RATE, and the player's national twin of it. Both were DEAD ACCUMULATORS in
+| the exact shape AGENTS.md names -- a mutator with no remaining call site, a member still serialized, and a
+| getter still read -- and the consequence was total: getGreatPeopleUnitRate summed only these two, so it
+| answered 0 for every unit forever, the per-type PROGRESS never grew, and CvCity::doGreatPeople could never
+| select a type. The threshold deduction sits inside that selection, so progress also never spent: a city sat
+| at "882 of 880" climbing forever and NO GREAT PERSON WAS EVER BORN (#539).
+| REPLACEMENT: CvCity::greatPeopleUnitRates derives the weights in one pass from what the city HOLDS -- each
+| active building and assigned specialist contributing its own greatPeopleRate under the great person its
+| `identity.greatPeopleUnitType` names. Nothing is stored, so there is no accumulator left to go dead again.
+| ⚠ The per-type PROGRESS (CvCity::m_paiGreatPeopleUnitProgress) is NOT cut -- it is genuine accumulated
+| history and stays serialized.
+CvCity::m_paiGreatPeopleUnitRate          (int array, GC.getNumUnitInfos())
+CvPlayer::iGreatPeopleRateforUnitSize     (short)
+CvPlayer::iGreatPeopleRateforUnitType     (short, variable-length)
+CvPlayer::iGreatPeopleRateforUnitCount    (int, variable-length)

--- a/Sources/Engine/CvCity.cpp
+++ b/Sources/Engine/CvCity.cpp
@@ -659,7 +659,6 @@ CvCity::CvCity()
 
 	m_paiProjectProduction = NULL;
 	m_paiUnitProduction = NULL;
-	m_paiGreatPeopleUnitRate = NULL;
 	m_paiGreatPeopleUnitProgress = NULL;
 	m_paiSpecialistCount = NULL;
 	m_paiForceSpecialistCount = NULL;
@@ -917,7 +916,6 @@ void CvCity::uninit()
 {
 	SAFE_DELETE_ARRAY(m_paiProjectProduction);
 	SAFE_DELETE_ARRAY(m_paiUnitProduction);
-	SAFE_DELETE_ARRAY(m_paiGreatPeopleUnitRate);
 	SAFE_DELETE_ARRAY(m_paiGreatPeopleUnitProgress);
 	SAFE_DELETE_ARRAY(m_paiSpecialistCount);
 	SAFE_DELETE_ARRAY(m_paiForceSpecialistCount);
@@ -1158,12 +1156,10 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 		}
 
 		m_paiUnitProduction = new int[GC.getNumUnitInfos()];
-		m_paiGreatPeopleUnitRate = new int[GC.getNumUnitInfos()];
 		m_paiGreatPeopleUnitProgress = new int[GC.getNumUnitInfos()];
 		for (int iI = 0; iI < GC.getNumUnitInfos(); iI++)
 		{
 			m_paiUnitProduction[iI] = 0;
-			m_paiGreatPeopleUnitRate[iI] = 0;
 			m_paiGreatPeopleUnitProgress[iI] = 0;
 		}
 
@@ -9537,25 +9533,76 @@ int CvCity::getUnitProductionDecayTurns(UnitTypes eIndex) const
 }
 
 
-int CvCity::getGreatPeopleUnitRate(UnitTypes eIndex) const
+//	WHICH GREAT PERSON this city is generating, and how fast -- the per-type weights the spawn draws against.
+//	A source contributes its greatPeopleRate to the city TOTAL through the ordinary channel, and separately
+//	NAMES the great person its contribution weights toward (`identity.greatPeopleUnitType`, authored by 488
+//	buildings and by the specialists). The type is never a target on the channel, so the split cannot come out
+//	of the package: it is the source's own rate read against its own designation, which is what this does.
+//	⚠ ONE PASS over the city's sources, never a per-type answer. doGreatPeople asks about EVERY unit in the
+//	game, so a per-type scan of the building registry would be O(units × buildings) per city per turn.
+//	⚠ ×100 native like every authored amount -- the caller reduces at the warehouse edge, exactly as the city
+//	total does ([north-star.md] the warehouse carve-out).
+void CvCity::greatPeopleUnitRates(std::map<short, int>& greatPeopleUnitRates) const
 {
-	FASSERT_BOUNDS(0, GC.getNumUnitInfos(), eIndex);
-	int iTotalGreatPeopleUnitRate = 0;
-	iTotalGreatPeopleUnitRate += m_paiGreatPeopleUnitRate[eIndex];
-	iTotalGreatPeopleUnitRate += GET_PLAYER(getOwner()).getNationalGreatPeopleUnitRate(eIndex);
-	return std::max(0, iTotalGreatPeopleUnitRate);
-}
+	greatPeopleUnitRates.clear();
 
-void CvCity::setGreatPeopleUnitRate(UnitTypes eIndex, int iNewValue)
-{
-	FASSERT_BOUNDS(0, GC.getNumUnitInfos(), eIndex);
-	m_paiGreatPeopleUnitRate[eIndex] = iNewValue;
-}
+	if (isDisorder())
+	{
+		return;
+	}
+	const CityContext& cityContext = getCityContext();
+	const EmpireContext& empireContext = GET_PLAYER(getOwner()).getEmpireContext();
+	const CvPlotGroup* pPlotGroup = plotGroup(getOwner());
 
+	for (int iI = 0; iI < GC.getNumBuildingInfos(); iI++)
+	{
+		const BuildingTypes eBuilding = static_cast<BuildingTypes>(iI);
 
-void CvCity::changeGreatPeopleUnitRate(UnitTypes eIndex, int iChange)
-{
-	setGreatPeopleUnitRate(eIndex, (m_paiGreatPeopleUnitRate[eIndex] + iChange));
+		//	A dormant building generates nothing, exactly as it deposits nothing.
+		if (!isActiveBuilding(eBuilding))
+		{
+			continue;
+		}
+		const CvBuildingInfo& kBuilding = GC.getBuildingInfo(eBuilding);
+		const int iGreatPersonUnit = kBuilding.getGreatPeopleUnitType();
+
+		if (iGreatPersonUnit < 0)
+		{
+			continue;
+		}
+		const int iRate = kBuilding.expectedModifier(MODFAM_GREAT_PEOPLE_RATE, (int)CHANNEL_AMOUNT,
+			CASC_UNIT_FLAT, cityContext, empireContext, pPlotGroup);
+
+		if (iRate > 0)
+		{
+			greatPeopleUnitRates[static_cast<short>(iGreatPersonUnit)] += iRate;
+		}
+	}
+
+	for (int iI = 0; iI < GC.getNumSpecialistInfos(); iI++)
+	{
+		const SpecialistTypes eSpecialist = static_cast<SpecialistTypes>(iI);
+		const int iSpecialists = getSpecialistCount(eSpecialist) + getFreeSpecialistCount(eSpecialist);
+
+		if (iSpecialists < 1)
+		{
+			continue;
+		}
+		const CvSpecialistInfo& kSpecialist = GC.getSpecialistInfo(eSpecialist);
+		const int iGreatPersonUnit = kSpecialist.getGreatPeopleUnitType();
+
+		if (iGreatPersonUnit < 0)
+		{
+			continue;
+		}
+		const int iRate = kSpecialist.expectedModifier(MODFAM_GREAT_PEOPLE_RATE, (int)CHANNEL_AMOUNT,
+			CASC_UNIT_FLAT, cityContext, empireContext, pPlotGroup);
+
+		if (iRate > 0)
+		{
+			greatPeopleUnitRates[static_cast<short>(iGreatPersonUnit)] += iSpecialists * iRate;
+		}
+	}
 }
 
 
@@ -12368,9 +12415,14 @@ void CvCity::doGreatPeople()
 	// serialized progress (and its threshold) keep their meaning ([north-star.md] warehouse carve-out).
 	changeGreatPeopleProgress(getGreatPeopleRate() / 100);
 
-	for (int iI = 0; iI < GC.getNumUnitInfos(); iI++)
+	//	The per-type weights advance from what the city is actually generating. Same warehouse edge as the total
+	//	above, so the two ledgers stay in one scale.
+	std::map<short, int> greatPeopleRatesByUnit;
+	greatPeopleUnitRates(greatPeopleRatesByUnit);
+
+	for (std::map<short, int>::const_iterator it = greatPeopleRatesByUnit.begin(); it != greatPeopleRatesByUnit.end(); ++it)
 	{
-		changeGreatPeopleUnitProgress(((UnitTypes)iI), getGreatPeopleUnitRate((UnitTypes)iI));
+		changeGreatPeopleUnitProgress(static_cast<UnitTypes>(it->first), it->second / 100);
 	}
 
 	if (getGreatPeopleProgress() >= GET_PLAYER(getOwner()).greatPeopleThresholdNonMilitary())
@@ -12535,7 +12587,6 @@ void CvCity::readBody(FDataStreamBase* pStream)
 
 	WRAPPER_READ_CLASS_ARRAY_ALLOW_MISSING(wrapper, "CvCity", REMAPPED_CLASS_TYPE_PROJECTS, GC.getNumProjectInfos(), m_paiProjectProduction);
 	WRAPPER_READ_CLASS_ARRAY_ALLOW_MISSING(wrapper, "CvCity", REMAPPED_CLASS_TYPE_UNITS, GC.getNumUnitInfos(), m_paiUnitProduction);
-	WRAPPER_READ_CLASS_ARRAY_ALLOW_MISSING(wrapper, "CvCity", REMAPPED_CLASS_TYPE_UNITS, GC.getNumUnitInfos(), m_paiGreatPeopleUnitRate);
 	WRAPPER_READ_CLASS_ARRAY_ALLOW_MISSING(wrapper, "CvCity", REMAPPED_CLASS_TYPE_UNITS, GC.getNumUnitInfos(), m_paiGreatPeopleUnitProgress);
 	WRAPPER_READ_CLASS_ARRAY_ALLOW_MISSING(wrapper, "CvCity", REMAPPED_CLASS_TYPE_SPECIALISTS, GC.getNumSpecialistInfos(), m_paiSpecialistCount);
 	WRAPPER_READ_CLASS_ARRAY_ALLOW_MISSING(wrapper, "CvCity", REMAPPED_CLASS_TYPE_SPECIALISTS, GC.getNumSpecialistInfos(), m_paiForceSpecialistCount);
@@ -13158,7 +13209,6 @@ void CvCity::write(FDataStreamBase* pStream)
 
 	WRAPPER_WRITE_CLASS_ARRAY(wrapper, "CvCity", REMAPPED_CLASS_TYPE_PROJECTS, GC.getNumProjectInfos(), m_paiProjectProduction);
 	WRAPPER_WRITE_CLASS_ARRAY(wrapper, "CvCity", REMAPPED_CLASS_TYPE_UNITS, GC.getNumUnitInfos(), m_paiUnitProduction);
-	WRAPPER_WRITE_CLASS_ARRAY(wrapper, "CvCity", REMAPPED_CLASS_TYPE_UNITS, GC.getNumUnitInfos(), m_paiGreatPeopleUnitRate);
 	WRAPPER_WRITE_CLASS_ARRAY(wrapper, "CvCity", REMAPPED_CLASS_TYPE_UNITS, GC.getNumUnitInfos(), m_paiGreatPeopleUnitProgress);
 	WRAPPER_WRITE_CLASS_ARRAY(wrapper, "CvCity", REMAPPED_CLASS_TYPE_SPECIALISTS, GC.getNumSpecialistInfos(), m_paiSpecialistCount);
 	WRAPPER_WRITE_CLASS_ARRAY(wrapper, "CvCity", REMAPPED_CLASS_TYPE_SPECIALISTS, GC.getNumSpecialistInfos(), m_paiForceSpecialistCount);

--- a/Sources/Engine/CvCity.h
+++ b/Sources/Engine/CvCity.h
@@ -1122,9 +1122,10 @@ public:
 	void setProjectProduction(ProjectTypes eIndex, int iNewValue);
 	void changeProjectProduction(ProjectTypes eIndex, int iChange);
 
-	int getGreatPeopleUnitRate(UnitTypes eIndex) const;
-	void setGreatPeopleUnitRate(UnitTypes eIndex, int iNewValue);
-	void changeGreatPeopleUnitRate(UnitTypes eIndex, int iChange);
+	//	The per-GREAT-PERSON-TYPE rates this city generates, keyed by unit id -- the weights the spawn draws
+	//	against, derived in ONE pass from the sources the city holds. ×100 native; the caller reduces at the
+	//	warehouse edge.
+	void greatPeopleUnitRates(std::map<short, int>& greatPeopleUnitRates) const;
 
 	int getGreatPeopleUnitProgress(UnitTypes eIndex) const;
 	void setGreatPeopleUnitProgress(UnitTypes eIndex, int iNewValue);
@@ -1670,7 +1671,6 @@ protected:
 
 	int* m_paiProjectProduction;
 	int* m_paiUnitProduction;
-	int* m_paiGreatPeopleUnitRate;
 	int* m_paiGreatPeopleUnitProgress;
 	// Citizen-juggle bracket state -- purely transient run state: NEVER serialized, cleared by reset().
 	int m_iCitizenJugglingCount;

--- a/Sources/Engine/CvPlayer.cpp
+++ b/Sources/Engine/CvPlayer.cpp
@@ -628,7 +628,6 @@ void CvPlayer::uninit()
 	m_unitMaking.clear();
 	m_greatGeneralPointsType.clear();
 	m_goldenAgeOnBirthOfGreatPersonCount.clear();
-	m_greatPeopleRateforUnit.clear();
 	m_buildingMaking.clear();
 	m_extraBuildingHappiness.clear();
 	m_extraBuildingHealth.clear();
@@ -17511,20 +17510,6 @@ void CvPlayer::read(FDataStreamBase* pStream)
 				}
 			}
 
-			iSize = 0;
-			WRAPPER_READ_DECORATED(wrapper, "CvPlayer", &iSize, "iGreatPeopleRateforUnitSize");
-			while (iSize-- > 0)
-			{
-				WRAPPER_READ_DECORATED(wrapper, "CvPlayer", &iType, "iGreatPeopleRateforUnitType");
-				WRAPPER_READ_DECORATED(wrapper, "CvPlayer", &iCount, "iGreatPeopleRateforUnitCount");
-				iType = static_cast<short>(wrapper.getNewClassEnumValue(REMAPPED_CLASS_TYPE_UNITS, iType, true));
-
-				if (iType > -1)
-				{
-					m_greatPeopleRateforUnit.insert(std::make_pair(iType, iCount));
-				}
-			}
-
 			// Unit counters
 			iSize = 0;
 			WRAPPER_READ_DECORATED(wrapper, "CvPlayer", &iSize, "UnitCountSMSize");
@@ -18178,12 +18163,6 @@ void CvPlayer::write(FDataStreamBase* pStream)
 			{
 				WRAPPER_WRITE_DECORATED(wrapper, "CvPlayer", it->first, "iGoldenAgeOnBirthOfGreatPersonCountType");
 				WRAPPER_WRITE_DECORATED(wrapper, "CvPlayer", it->second, "iGoldenAgeOnBirthOfGreatPersonCountCount");
-			}
-			WRAPPER_WRITE_DECORATED(wrapper, "CvPlayer", (short)m_greatPeopleRateforUnit.size(), "iGreatPeopleRateforUnitSize");
-			for (std::map<short, int>::const_iterator it = m_greatPeopleRateforUnit.begin(), itEnd = m_greatPeopleRateforUnit.end(); it != itEnd; ++it)
-			{
-				WRAPPER_WRITE_DECORATED(wrapper, "CvPlayer", it->first, "iGreatPeopleRateforUnitType");
-				WRAPPER_WRITE_DECORATED(wrapper, "CvPlayer", it->second, "iGreatPeopleRateforUnitCount");
 			}
 			// Unit counters
 			WRAPPER_WRITE_DECORATED(wrapper, "CvPlayer", (short)m_unitCountSM.size(), "UnitCountSMSize");
@@ -25562,43 +25541,6 @@ void CvPlayer::clearLeaderTraits()
 		}
 	}
 	setLeaderHeadLevel(0);
-}
-
-
-void CvPlayer::changeNationalGreatPeopleUnitRate(const UnitTypes eUnit, const int iChange)
-{
-	FASSERT_BOUNDS(-1, GC.getNumUnitInfos(), eUnit);
-
-	if (iChange == 0)
-	{
-		FErrorMsg("This is not a change!");
-		return;
-	}
-	if (eUnit == NO_UNIT)
-	{
-		return;
-	}
-	std::map<short, int>::const_iterator itr = m_greatPeopleRateforUnit.find((short)eUnit);
-
-	if (itr == m_greatPeopleRateforUnit.end())
-	{
-		m_greatPeopleRateforUnit.insert(std::make_pair((short)eUnit, iChange));
-	}
-	else if (itr->second == -iChange)
-	{
-		m_greatPeopleRateforUnit.erase(itr->first);
-	}
-	else // change unit count
-	{
-		m_greatPeopleRateforUnit[itr->first] += iChange;
-	}
-}
-
-int CvPlayer::getNationalGreatPeopleUnitRate(const UnitTypes eUnit) const
-{
-	FASSERT_BOUNDS(0, GC.getNumUnitInfos(), eUnit);
-	std::map<short, int>::const_iterator itr = m_greatPeopleRateforUnit.find((short)eUnit);
-	return itr != m_greatPeopleRateforUnit.end() ? itr->second : 0;
 }
 
 

--- a/Sources/Engine/CvPlayer.h
+++ b/Sources/Engine/CvPlayer.h
@@ -1870,8 +1870,6 @@ public:
 	void clearLeaderTraits();
 
 
-	int getNationalGreatPeopleUnitRate(const UnitTypes eIndex) const;
-	void changeNationalGreatPeopleUnitRate(const UnitTypes eIndex, const int iChange);
 
 
 
@@ -1992,7 +1990,6 @@ private:
 	std::map<short, int> m_bonusMintedPercent;
 	std::map<short, int> m_extraBuildingHappiness;
 	std::map<short, int> m_extraBuildingHealth;
-	std::map<short, int> m_greatPeopleRateforUnit;
 	std::map<short, char> m_goldenAgeOnBirthOfGreatPersonCount;
 
 	int m_iNumAnarchyTurns;


### PR DESCRIPTION
Fixes #539 — reported as "great persons do not get created when enough progress is reached", tooltip reading **"Progress: 882 of 880"**.

## Cause

`CvCity::doGreatPeople` picks *which* great person to spawn by drawing against per-type weights, and only spawns if that draw selects something:

```cpp
iTotal += getGreatPeopleUnitProgress(i);            // every one zero
iRand = getSorenRandNum(iTotal, "Great Person");    // 0
if (iRand < getGreatPeopleUnitProgress(i)) ...      // 0 < 0, never true
if (eGreatPeopleUnit != NO_UNIT) { deduct; create; }  // never entered
```

Those weights advance by `getGreatPeopleUnitRate`, which summed exactly two terms and **both were dead**:

| term | state |
|---|---|
| `CvCity::m_paiGreatPeopleUnitRate` | setter and changer had **no callers anywhere** |
| `CvPlayer::getNationalGreatPeopleUnitRate` | its changer had **none either** |

So the rate answered 0 for every unit forever and the draw could never select. The threshold deduction sits **inside** the selection branch, so progress was never spent either — hence "882 of 880", climbing forever.

That is the dead-accumulator shape AGENTS.md names exactly: *a mutator with no remaining call site + a member still serialized + a getter still read = a consumer served a frozen value.* Here the frozen value was zero and the feature was total.

## The data was never the problem

488 buildings author `identity.greatPeopleUnitType` (`UNIT_ARTIST`…), the specialists carry it too, and both infos expose `getGreatPeopleUnitType()` — but its only consumers were **three AI valuation sites**. The AI knew which great person a source generates; the game never applied it.

## The fix

`CvCity::greatPeopleUnitRates` derives the weights from what the city **holds** — each active building and assigned specialist contributing its own `greatPeopleRate` under the great person its identity names.

The rate is a plain channel and the type is a separate identity FK, never a target on the channel, so the split cannot come out of the package: it is the source's own rate read against its own designation, through the same `expectedModifier` what-if the other per-source reads already use.

- **One pass**, not a per-type answer — `doGreatPeople` asks about every unit in the game, so a per-type registry scan would be O(units × buildings) per city per turn.
- **Derived at the turn boundary**, which is where great people have always been calculated; GPP cannot burst one mid-turn. (Generals/hunters come from combat, prophets from grants — neither goes through this path.)
- **Reduced ÷100 at the same warehouse edge** as the city total, so the two ledgers stay in one scale.

Both dead accumulators are cut with their serialization and named in `savemigration.txt`. Nothing is stored in their place, so there is no accumulator left to go dead again. The per-type **progress** stays — it is genuine accumulated history.

## Verification

- `Assert rebuild` clean; `verify-savemigration` clean with the new entries (751).
- **Not** verified in game. The check: a city at or past its threshold finally produces a great person, of a type its buildings and specialists actually point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)