### PR TITLE
fix(capture): city capture blocked by a blending animal; outlaws never capture NPC cities; city death no longer strips empire holdings (#541)

### DIFF
--- a/Sources/Enabler/CvBuildingEnabler.cpp
+++ b/Sources/Enabler/CvBuildingEnabler.cpp
@@ -13,6 +13,7 @@
 #include "CvInfo.h"
 #include "CvBuildingInfo.h"       // notConstructible (the enabler's own never-buildable flag; self-containment)
 #include "Repos/InfoRepo.h"
+#include "AI/BetterBTSAI.h"           // PerfAccumTimer / logPerf -- the [PERF] instrument
 #include "AI/CvPlayerAI.h"            // GET_PLAYER
 #include "AI/CvTeamAI.h"             // GET_TEAM
 #include "Defines/CvGlobals.h"
@@ -577,6 +578,33 @@ void BuildingEnabler::onCityTechChanged(TeamTypes eTeam, TechTypes eTech, bool b
 	}
 }
 
+namespace
+{
+	// [PERF] accumulators for the three re-gate legs of one building flip, summed over a sweep and logged once
+	// by the sweep's owner (CvCity::kill) -- per-flip lines would be spam; the sweep is what is slow.
+	double s_dBuildingChangedSelfGateMs = 0.0;
+	double s_dBuildingChangedCapFanMs = 0.0;
+	double s_dBuildingChangedCategoryMs = 0.0;
+
+	bool bd_capAuthored(const CvAllowed* pAllowed, EnAllowedCap eKind)
+	{
+		return pAllowed != NULL && pAllowed->cap(eKind) != -1;
+	}
+}
+
+void BuildingEnabler::perfAccumReset()
+{
+	s_dBuildingChangedSelfGateMs = 0.0;
+	s_dBuildingChangedCapFanMs = 0.0;
+	s_dBuildingChangedCategoryMs = 0.0;
+}
+
+void BuildingEnabler::perfAccumLog(const char* szPhase, int iOwner)
+{
+	logPerf(1, "[PERF/phase] turn=%d owner=%d phase=%s selfGate=%.3f capFan=%.3f category=%.3f",
+		GC.getGame().getGameTurn(), iOwner, szPhase, s_dBuildingChangedSelfGateMs, s_dBuildingChangedCapFanMs, s_dBuildingChangedCategoryMs);
+}
+
 void BuildingEnabler::onCityBuildingChanged(const CvCity& kCity, int iBuilding, bool bPresent)
 {
 	EnablerDomain& d = kCity.m_enabler.buildings;
@@ -592,34 +620,52 @@ void BuildingEnabler::onCityBuildingChanged(const CvCity& kCity, int iBuilding, 
 		// gate-on-entry + the step-2 re-gates in THIS city (building prereq atoms reference iBuilding)
 		std::set<int> touched;
 		bd_touched(jb, touched);
-		bd_gateSet(kCity, touched);
+		{
+			PerfAccumTimer timer(s_dBuildingChangedSelfGateMs);
+			bd_gateSet(kCity, touched);
+		}
 		// the CAP CROSSING (par.7.1 step 3): a capped building's count changed -- re-gate IT on every seeded
 		// city its cap scope reaches (a completed world wonder vanishes from every rival's list; the tally's
 		// buildings domain carries the counts). A GROUP-capped member's crossing re-gates ALL its group
-		// siblings (the grouped wonders: one member built consumes the shared slot). world/team caps reach ALL
-		// players; empire reaches the owner's -- the widest reach is used (idempotent gate evals).
+		// siblings (the grouped wonders: one member built consumes the shared slot). The reach IS the cap's
+		// scope (json.md par.4.4): world -> every player, team -> the owner's team, empire -> the owner alone.
 		const SpecialBuildingTypes eSb = (SpecialBuildingTypes)GC.getBuildingInfo((BuildingTypes)iBuilding).getSpecialBuildingType();
 		const CvInfo* jg = (eSb != NO_SPECIALBUILDING) ? InfoRepo<CvSpecialBuildingInfo>::get().get((int)eSb) : NULL;
-		const bool bGroupCapped = (jg != NULL && jg->getAllowed() != NULL);
-		if ((jb != NULL && jb->getAllowed() != NULL) || bGroupCapped)
+		const CvAllowed* pOwnCap = (jb != NULL) ? jb->getAllowed() : NULL;
+		const CvAllowed* pGroupCap = (jg != NULL) ? jg->getAllowed() : NULL;
+		if (pOwnCap != NULL || pGroupCap != NULL)
 		{
 			std::set<int> capSet;
 			capSet.insert(iBuilding);
-			if (bGroupCapped)
+			if (pGroupCap != NULL)
 			{
 				const std::vector<int>& mem = bd_sbMembers((int)eSb);
 				capSet.insert(mem.begin(), mem.end());
 			}
-			for (int iP = 0; iP < MAX_PLAYERS; iP++)
+			const bool bWorldReach = bd_capAuthored(pOwnCap, ALLOWEDCAP_WORLD) || bd_capAuthored(pGroupCap, ALLOWEDCAP_WORLD);
+			const bool bTeamReach = bWorldReach || bd_capAuthored(pOwnCap, ALLOWEDCAP_TEAM) || bd_capAuthored(pGroupCap, ALLOWEDCAP_TEAM);
 			{
-				CvPlayer& kP = GET_PLAYER((PlayerTypes)iP);
-				foreach_(const CvCity* pCity, kP.cities())
-					bd_gateSet(*pCity, capSet);
+				PerfAccumTimer timer(s_dBuildingChangedCapFanMs);
+				for (int iP = 0; iP < MAX_PLAYERS; iP++)
+				{
+					CvPlayer& kP = GET_PLAYER((PlayerTypes)iP);
+					if (!bWorldReach)
+					{
+						const bool bInReach = bTeamReach ? (kP.getTeam() == kPlayer.getTeam()) : (iP == (int)kCity.getOwner());
+						if (!bInReach)
+						{
+							continue;
+						}
+					}
+					foreach_(const CvCity* pCity, kP.cities())
+						bd_gateSet(*pCity, capSet);
+				}
 			}
 			// THIS CITY additionally re-gates every capped building: the per-city CATEGORY cap counts the city's
 			// wonders of a category, so one arriving can cap out every OTHER candidate of that category here --
 			// candidates the cap-scope fan above never names, because it re-gates the building whose own COUNT
 			// moved, not its category siblings.
+			PerfAccumTimer timer(s_dBuildingChangedCategoryMs);
 			const std::vector<int>& categoryCapped = bd_cappedBuildings();
 			std::set<int> categorySet(categoryCapped.begin(), categoryCapped.end());
 			bd_gateSet(kCity, categorySet);

--- a/Sources/Enabler/CvBuildingEnabler.h
+++ b/Sources/Enabler/CvBuildingEnabler.h
@@ -52,6 +52,11 @@ public:
 	// The city's own facts arrive as events.
 	static void onCityCreated(const CvCity& kCity);
 
+	// [PERF] the three re-gate legs of onCityBuildingChanged, accumulated across a sweep; the sweep's owner
+	// resets before and logs once after.
+	static void perfAccumReset();
+	static void perfAccumLog(const char* szPhase, int iOwner);
+
 	// ==== THE REQUIRES GATE (enabler.md par.7.1 steps 2+3): requiresMet (build ∧ operate) + the allowed
 	// self-caps, through the ONE evaluator/cap check; a failed gate flips a tree member LISTED -> GREYED. ====
 	// LOAD follows the par.7.1 order rule's "gate once after the stream ends" option: NO gate evaluations

--- a/Sources/Engine/CvCity.cpp
+++ b/Sources/Engine/CvCity.cpp
@@ -1381,6 +1381,17 @@ void CvCity::changeReinforcementCounter(int iChange)
 }
 
 
+namespace
+{
+	// [PERF] accumulators for the steps of one building flip, summed over a whole removal sweep and logged
+	// once by CvCity::kill (per-flip lines would be spam; the sweep is the unit that is slow).
+	double s_dBuildingFlipInvalidateMs = 0.0;
+	double s_dBuildingFlipLedgerMs = 0.0;
+	double s_dBuildingFlipSetupMs = 0.0;
+	double s_dBuildingFlipProcessMs = 0.0;
+	double s_dBuildingFlipEmitMs = 0.0;
+}
+
 void CvCity::kill(bool bUpdatePlotGroups, bool bUpdateCulture)
 {
 	PROFILE_FUNC();
@@ -1418,11 +1429,28 @@ void CvCity::kill(bool bUpdatePlotGroups, bool bUpdateCulture)
 	setCultureLevel(NO_CULTURELEVEL, false);
 	clearCultureDistanceCache();
 
-	for (int iI = 0, iNum = GC.getNumBuildingInfos(); iI < iNum; iI++)
 	{
-		changeHasBuilding((BuildingTypes)iI, false);
+		PERF_SCOPE("city.kill.removeBuildings", eOwner);
+		s_dBuildingFlipInvalidateMs = 0.0;
+		s_dBuildingFlipLedgerMs = 0.0;
+		s_dBuildingFlipSetupMs = 0.0;
+		s_dBuildingFlipProcessMs = 0.0;
+		s_dBuildingFlipEmitMs = 0.0;
+		const int iRemoved = (int)getHasBuildings().size();
+		spinePerfConsumerAccumReset();
+		BuildingEnabler::perfAccumReset();
+		foreach_(const BuildingTypes eType, getHasBuildings())
+		{
+			changeHasBuilding(eType, false);
+		}
+		BuildingEnabler::perfAccumLog("city.kill.removeBuildings.enablerLegs", (int)eOwner);
+		logPerf(1, "[PERF/phase] turn=%d owner=%d phase=city.kill.removeBuildings.split count=%d invalidate=%.3f ledger=%.3f setup=%.3f process=%.3f emit=%.3f",
+			GC.getGame().getGameTurn(), (int)eOwner, iRemoved, s_dBuildingFlipInvalidateMs, s_dBuildingFlipLedgerMs,
+			s_dBuildingFlipSetupMs, s_dBuildingFlipProcessMs, s_dBuildingFlipEmitMs);
+		spinePerfConsumerAccumLog("city.kill.removeBuildings.consumers", (int)eOwner);
 	}
 
+	PERF_SCOPE("city.kill.afterBuildings", eOwner);
 	for (int iI = 0; iI < GC.getNumReligionInfos(); iI++)
 	{
 		setHasReligion((ReligionTypes)iI, false, false, true);
@@ -1443,7 +1471,10 @@ void CvCity::kill(bool bUpdatePlotGroups, bool bUpdateCulture)
 		}
 	}
 
-	setPopulation(0);
+	{
+		PERF_SCOPE("city.kill.setPopulationZero", eOwner);
+		setPopulation(0);
+	}
 	//AI_assignWorkingPlots();
 	clearOrderQueue();
 
@@ -1474,16 +1505,22 @@ void CvCity::kill(bool bUpdatePlotGroups, bool bUpdateCulture)
 
 	// The city is going: withdraw its membership from every plot of its work area, so no store keeps folding a
 	// city that no longer exists.
-	changeWorkableArea(getNumCityPlots(), 0);
+	{
+		PERF_SCOPE("city.kill.detachPlot", eOwner);
+		changeWorkableArea(getNumCityPlots(), 0);
+		pPlot->setPlotCity(NULL);
+		pPlot->setImprovementType(GC.getIMPROVEMENT_CITY_RUINS());
+	}
 
-	pPlot->setPlotCity(NULL);
+	{
+		PERF_SCOPE("city.kill.python.cityLost", eOwner);
+		CvEventReporter::getInstance().cityLost(this);
+	}
 
-	pPlot->setImprovementType(GC.getIMPROVEMENT_CITY_RUINS());
-
-
-	CvEventReporter::getInstance().cityLost(this);
-
-	kOwner.deleteCity(getID());
+	{
+		PERF_SCOPE("city.kill.deleteCity", eOwner);
+		kOwner.deleteCity(getID());
+	}
 
 	if (bUpdateCulture)
 	{
@@ -1509,7 +1546,10 @@ void CvCity::kill(bool bUpdatePlotGroups, bool bUpdateCulture)
 	}
 
 
-	GC.getMap().updateWorkingCity();
+	{
+		PERF_SCOPE("city.kill.updateWorkingCity", eOwner);
+		GC.getMap().updateWorkingCity();
+	}
 
 	kOwner.AI_makeAssignWorkDirty();
 
@@ -10222,7 +10262,11 @@ void CvCity::setHasBuilding(const BuildingTypes eType, const bool bNewValue, con
 	// placing systems never learn the tag exists. The city stores nothing.
 	if (GC.getBuildingInfo(eType).isEmpireLevel())
 	{
-		GET_PLAYER(getOwner()).setHasEmpireBuilding(eType, bNewValue, bFirst);
+		// Only PLACEMENT routes to the holder; a city change never removes what the empire holds.
+		if (bNewValue)
+		{
+			GET_PLAYER(getOwner()).setHasEmpireBuilding(eType, true, bFirst);
+		}
 		return;
 	}
 
@@ -10233,24 +10277,34 @@ void CvCity::setHasBuilding(const BuildingTypes eType, const bool bNewValue, con
 #ifdef YIELD_VALUE_CACHING
 		ClearYieldValueCache(); // A new building can change yield rates
 #endif
-		invalidateCachedCanTrainForUnit(NO_UNIT);
-
-		alterBuildingLedger(eType, bNewValue, eOriginalOwner, iOriginalTime);
-
-		setupBuilding(kBuilding, eType, bNewValue, bFirst);
-
-		if (bNewValue) // Building addition
 		{
-			processBuilding(eType, 1, false, true);
+			PerfAccumTimer timer(s_dBuildingFlipInvalidateMs);
+			invalidateCachedCanTrainForUnit(NO_UNIT);
 		}
-		else // Building removal
 		{
-			// A DORMANT building contributed nothing, so there is nothing to un-process -- only an ACTIVE one
-			// needs its contribution removed. The verdict is the ENABLER's operating set (enabler.md §3.2), never
-			// a legacy disabled-flag (docs/specs/validation.md §pollution guardrail (zero legacy ride-in)).
-			if (m_operatingBuildings.active.count((int)eType) != 0)
+			PerfAccumTimer timer(s_dBuildingFlipLedgerMs);
+			alterBuildingLedger(eType, bNewValue, eOriginalOwner, iOriginalTime);
+		}
+		{
+			PerfAccumTimer timer(s_dBuildingFlipSetupMs);
+			setupBuilding(kBuilding, eType, bNewValue, bFirst);
+		}
+
+		{
+			PerfAccumTimer timer(s_dBuildingFlipProcessMs);
+			if (bNewValue) // Building addition
 			{
-				processBuilding(eType, -1, false, true);
+				processBuilding(eType, 1, false, true);
+			}
+			else // Building removal
+			{
+				// A DORMANT building contributed nothing, so there is nothing to un-process -- only an ACTIVE one
+				// needs its contribution removed. The verdict is the ENABLER's operating set (enabler.md §3.2), never
+				// a legacy disabled-flag (docs/specs/validation.md §pollution guardrail (zero legacy ride-in)).
+				if (m_operatingBuildings.active.count((int)eType) != 0)
+				{
+					processBuilding(eType, -1, false, true);
+				}
 			}
 		}
 
@@ -10259,13 +10313,16 @@ void CvCity::setHasBuilding(const BuildingTypes eType, const bool bNewValue, con
 		// (operating) crossing is the enabler's separate SEVT_BUILDING_ACTIVATED / _DORMANTED.
 		// The two directions are two FACTS, so the branch is here ONCE rather than in every consumer's body
 		// (docs/spine.md §A FACT NAMES THE HAPPENING).
-		if (bNewValue)
 		{
-			emitCityBuildingAdded(getID(), getOwner(), (int)eType, bFirst);
-		}
-		else
-		{
-			emitCityBuildingRemoved(getID(), getOwner(), (int)eType);
+			PerfAccumTimer timer(s_dBuildingFlipEmitMs);
+			if (bNewValue)
+			{
+				emitCityBuildingAdded(getID(), getOwner(), (int)eType, bFirst);
+			}
+			else
+			{
+				emitCityBuildingRemoved(getID(), getOwner(), (int)eType);
+			}
 		}
 
 		// (Buildings REPLACED by this one are not disabled here: a predecessor standing under its successor is
@@ -12621,7 +12678,7 @@ void CvCity::readBody(FDataStreamBase* pStream)
 		// carries its loaded value is reset to unset and handed straight back to its setter. That keeps the
 		// setter the sole author of both the committed value and the fact, which a "commit here, announce
 		// there" split cannot: the two drift, and that is exactly what this pass is removing.
-		emitCityOwnerAdded(iCityId, iCityOwner);
+		emitCityOwnerAdded(iCityId, iCityOwner, GC.getMap().plotNum(m_iX, m_iY));
 		setPopulationInternal(iLoadedPopulation);
 		for (iI = 0; iI < GC.getNumReligionInfos(); ++iI)
 		{

--- a/Sources/Engine/CvPlayer.cpp
+++ b/Sources/Engine/CvPlayer.cpp
@@ -2346,6 +2346,7 @@ CvCity* CvPlayer::initCity(int iX, int iY, bool bBumpUnits, bool bUpdatePlotGrou
 void CvPlayer::acquireCity(CvCity* pOldCity, bool bConquest, bool bTrade, bool bUpdatePlotGroups)
 {
 	PROFILE_FUNC();
+	PERF_SCOPE("player.acquireCity", getID());
 	if (pOldCity->isMarkedForDestruction()) return;
 	pOldCity->markForDestruction();
 
@@ -2381,7 +2382,10 @@ void CvPlayer::acquireCity(CvCity* pOldCity, bool bConquest, bool bTrade, bool b
 	// We can skip a lot if city is just to be razed right away.
 	const bool bAutoRaze = GC.getGame().isAutoRaze(const_cast<CvCity*>(pOldCity), eNewOwner, bConquest, bTrade, bRecapture);
 
-	CvEventReporter::getInstance().cityAcquired(eOldOwner, eNewOwner, pOldCity, bConquest, bTrade, bAutoRaze);
+	{
+		PERF_SCOPE("player.acquireCity.python.cityAcquired", getID());
+		CvEventReporter::getInstance().cityAcquired(eOldOwner, eNewOwner, pOldCity, bConquest, bTrade, bAutoRaze);
+	}
 
 	if (bAutoRaze)
 	{
@@ -2474,6 +2478,7 @@ void CvPlayer::acquireCity(CvCity* pOldCity, bool bConquest, bool bTrade, bool b
 			// If civ has fixed borders, they'll retain more due to the lower threshold for maintaining ownership.
 			pOldCity->clearCultureDistanceCache();
 			const int iCultureLevel = pOldCity->getCultureLevel();
+			PERF_SCOPE("player.acquireCity.flipPlots", getID());
 			foreach_(CvPlot* pLoopPlot, pOldCity->plots(true))
 			{
 				const int iCultureDist = pOldCity->cultureDistance(*pLoopPlot);
@@ -2621,13 +2626,19 @@ void CvPlayer::acquireCity(CvCity* pOldCity, bool bConquest, bool bTrade, bool b
 				aBuildingHealthChange.push_back(std::make_pair((BuildingTypes)iI, iChange));
 			}
 		}
-		pOldCity->kill(false, false); // Invalidates pOldCity pointer.
+		{
+			PERF_SCOPE("player.acquireCity.killOldCity", getID());
+			pOldCity->kill(false, false); // Invalidates pOldCity pointer.
+		}
 
 		if (bTrade)
 		{
 			algo::for_each(pCityPlot->rect(1, 1), bind(&CvPlot::setCulture, _1, eOldOwner, 0, false, false, false));
 		}
-		pNewCity = initCity(pCityPlot->getX(), pCityPlot->getY(), !bConquest, false);
+		{
+			PERF_SCOPE("player.acquireCity.initCity", getID());
+			pNewCity = initCity(pCityPlot->getX(), pCityPlot->getY(), !bConquest, false);
+		}
 
 		FAssertMsg(pNewCity, "NewCity is not assigned a valid value");
 
@@ -2661,17 +2672,20 @@ void CvPlayer::acquireCity(CvCity* pOldCity, bool bConquest, bool bTrade, bool b
 		// [enabler.md §3.2]). ⛔ No successor is placed either way -- what the legacy culture-shell chain used to
 		// put here is what the curator now reads to emit that tree on the building itself.
 		const CvTeam& newTeam = GET_TEAM(getTeam());
-		for (std::map<BuildingTypes, BuiltBuildingData>::const_iterator itr = buildingLedger.begin(); itr != buildingLedger.end(); ++itr)
 		{
-			if (newTeam.isObsoleteBuilding(itr->first))
+			PERF_SCOPE("player.acquireCity.setHasBuilding.all", getID());
+			for (std::map<BuildingTypes, BuiltBuildingData>::const_iterator itr = buildingLedger.begin(); itr != buildingLedger.end(); ++itr)
 			{
-				const CvModifiers* pWhenObsolete = GC.getBuildingInfo(itr->first).getWhenObsolete();
-				if (pWhenObsolete == NULL || pWhenObsolete->empty())
+				if (newTeam.isObsoleteBuilding(itr->first))
 				{
-					continue;
+					const CvModifiers* pWhenObsolete = GC.getBuildingInfo(itr->first).getWhenObsolete();
+					if (pWhenObsolete == NULL || pWhenObsolete->empty())
+					{
+						continue;
+					}
 				}
+				pNewCity->setHasBuilding(itr->first, true, itr->second.eBuiltBy, itr->second.iTimeBuilt, false);
 			}
-			pNewCity->setHasBuilding(itr->first, true, itr->second.eBuiltBy, itr->second.iTimeBuilt, false);
 		}
 
 		for (BuildingChangeArray::iterator it = aBuildingHappyChange.begin(); it != aBuildingHappyChange.end(); ++it)
@@ -2776,7 +2790,7 @@ void CvPlayer::acquireCity(CvCity* pOldCity, bool bConquest, bool bTrade, bool b
 	{
 		emitCityOwnerRemoved(pNewCity->getID(), (int)eOldOwner);
 	}
-	emitCityOwnerAdded(pNewCity->getID(), (int)eNewOwner);
+	emitCityOwnerAdded(pNewCity->getID(), (int)eNewOwner, GC.getMap().plotNum(pNewCity->getX(), pNewCity->getY()));
 
 		// Don't bother with plot group calculations if they are immediately to be superseded by an auto raze
 		if (bUpdatePlotGroups)
@@ -2826,7 +2840,11 @@ void CvPlayer::acquireCity(CvCity* pOldCity, bool bConquest, bool bTrade, bool b
 					pInfo->setData1(pNewCity->getID());
 					gDLL->getInterfaceIFace()->addPopup(pInfo, eNewOwner);
 				}
-				else CvEventReporter::getInstance().cityAcquiredAndKept(eOldOwner, eNewOwner, pNewCity, bConquest, bTrade);
+				else
+				{
+					PERF_SCOPE("player.acquireCity.python.cityAcquiredAndKept", getID());
+					CvEventReporter::getInstance().cityAcquiredAndKept(eOldOwner, eNewOwner, pNewCity, bConquest, bTrade);
+				}
 			}
 		}
 		else if (bHuman)
@@ -2856,6 +2874,7 @@ void CvPlayer::acquireCity(CvCity* pOldCity, bool bConquest, bool bTrade, bool b
 			}
 			else
 			{
+				PERF_SCOPE("player.acquireCity.python.cityAcquiredAndKept", getID());
 				CvEventReporter::getInstance().cityAcquiredAndKept(eOldOwner, eNewOwner, pNewCity, bConquest, bTrade);
 			}
 		}
@@ -6248,7 +6267,7 @@ void CvPlayer::found(int iX, int iY, CvUnit *pUnit)
 		// reseed uses at CvCity::read, which establishes that the city belongs to its owner before its contents.
 		// Without this a FOUNDED city never announces ownership in live play at all: the only other owner emits are
 		// dispose and acquire, so the load path and the play path would disagree about the same fact.
-		emitCityOwnerAdded(pCity->getID(), (int)getID());
+		emitCityOwnerAdded(pCity->getID(), (int)getID(), GC.getMap().plotNum(pCity->getX(), pCity->getY()));
 		emitCityFounded((int)getID(), pCity->getID(),
 			(pUnit != NULL) ? (int)pUnit->getUnitType() : -1, (pUnit != NULL) ? pUnit->getID() : -1);
 	}

--- a/Sources/Engine/CvPlot.cpp
+++ b/Sources/Engine/CvPlot.cpp
@@ -12376,7 +12376,7 @@ bool CvPlot::hasDefender(
 				&&
 				pAttacker->isEnemy(GET_PLAYER(unitX->getOwner()).getTeam(), this, unitX)
 			)
-		&& (!pAttacker || !unitX->canUnitCoexistWithArrivingUnit(*pAttacker))
+		&& (!pAttacker || !unitX->canCoexistWithAttacker(*pAttacker, false, false))
 		&& (
 				!bTestPotentialEnemy
 				||

--- a/Sources/Engine/CvUnit.cpp
+++ b/Sources/Engine/CvUnit.cpp
@@ -480,7 +480,8 @@ void CvUnit::init(int iID, UnitTypes eUnit, UnitAITypes eUnitAI, PlayerTypes eOw
 		//   BEFORE doSetDefaultStatuses -- that calls statusUpdate(), establishing the unit's status/animation
 		//     state. Emitting after it left promotions landing on an already-computed visual state (units drawn
 		//     only after re-selection; a fortified unit stuck in its run animation).
-		emitUnitCreated((int)getUnitType(), getID(), (int)getOwner());
+		emitUnitCreated((int)getUnitType(), getID(), (int)getOwner(),
+			(plot() != NULL) ? GC.getMap().plotNum(getX(), getY()) : -1);
 		doSetDefaultStatuses();
 
 		// Cache initial healer values
@@ -13874,6 +13875,7 @@ void CvUnit::setXY(int iX, int iY, bool bGroup, bool bUpdate, bool bShow, bool b
 			&& isEnemy(pNewCity->getTeam())
 			&& (!isBarbCoExist() || !pNewPlot->isHominid())
 			&& (!isHiddenNationality() || !pNewCity->isNPC())
+			&& (!getUnitInfo().hasTag(CLS_TAG_OUTLAW) || !pNewCity->isNPC())
 			&& !canCoexistAlwaysOnPlot(*pNewPlot)
 			&& !pNewPlot->hasDefender(false, NO_PLAYER, getOwner(), this, true, false, false, true))
 			{
@@ -18336,7 +18338,8 @@ void CvUnit::read(FDataStreamBase* pStream)
 	// the stream shows an empire whose units all predate the save. Emitted HERE, the first point m_iID / m_eOwner /
 	// m_eUnitType have all deserialized. Result-producers suppress inside the load bracket, so this restores the
 	// instance without re-granting anything -- the emitCityBuildingAdded(bFirst = false) contract.
-	emitUnitCreated((int)m_eUnitType, m_iID, (int)m_eOwner);
+	emitUnitCreated((int)m_eUnitType, m_iID, (int)m_eOwner,
+		GC.getMap().isPlot(m_iX, m_iY) ? GC.getMap().plotNum(m_iX, m_iY) : -1);
 	// The death SCHEDULE lands through its setter: a save can be taken with a kill already deferred. It
 	// deserialized earlier, so it is taken off the member, cleared, and handed back -- a cleared schedule is
 	// the reset() default and correctly announces nothing. The unit's coordinates arrive later, so the setter

--- a/Sources/Spine/CvEventSpine.cpp
+++ b/Sources/Spine/CvEventSpine.cpp
@@ -18,6 +18,7 @@
 #include "Spine/CvEventSpine.h"
 #include "Tools/CvHttpServer.h"   // the /events STREAM consumer (isEnabled + publishEvent)
 #include "Infrastructure/CvLogWriter.h"   // the off-thread log file writer (the FILE consumer's sink)
+#include <typeinfo>
 #include "AI/BetterBTSAI.h"   // gPlayerLogLevel (reused as the slice-1 gate; dedicated gate/BUG option + the live
                            // CvHttpServer feed come next)
 #include "Defines/CvGlobals.h"        // GC -- resolve raw Type indices to readable names in the (gated) consumer
@@ -60,6 +61,12 @@ void CvEventSpine::registerConsumer(IEventConsumer* pConsumer)
 	m_iInterestMask |= pConsumer->wantedKinds();
 }
 
+namespace
+{
+	const int SPINE_PERF_MAX_CONSUMERS = 32;
+	double s_adConsumerAccumMs[SPINE_PERF_MAX_CONSUMERS] = { 0.0 };
+}
+
 void CvEventSpine::emit(const CvSpineEvent& kEvent)
 {
 	const int iBit = 1 << kEvent.eKind;
@@ -67,10 +74,12 @@ void CvEventSpine::emit(const CvSpineEvent& kEvent)
 	{
 		return; // interest-guard: no registered consumer wants this kind -> skip entirely (the cheap path)
 	}
-	for (std::vector<IEventConsumer*>::const_iterator it = m_consumers.begin(); it != m_consumers.end(); ++it)
+	int iConsumerIndex = 0;
+	for (std::vector<IEventConsumer*>::const_iterator it = m_consumers.begin(); it != m_consumers.end(); ++it, ++iConsumerIndex)
 	{
 		if (((*it)->wantedKinds() & iBit) != 0)
 		{
+			PerfAccumTimer timer(s_adConsumerAccumMs[iConsumerIndex < SPINE_PERF_MAX_CONSUMERS ? iConsumerIndex : SPINE_PERF_MAX_CONSUMERS - 1]);
 			(*it)->onEvent(kEvent);
 		}
 	}
@@ -80,6 +89,24 @@ CvEventSpine& eventSpine()
 {
 	static CvEventSpine s_spine;
 	return s_spine;
+}
+
+void spinePerfConsumerAccumReset()
+{
+	for (int iI = 0; iI < SPINE_PERF_MAX_CONSUMERS; iI++)
+	{
+		s_adConsumerAccumMs[iI] = 0.0;
+	}
+}
+
+void spinePerfConsumerAccumLog(const char* szPhase, int iOwner)
+{
+	const std::vector<IEventConsumer*>& consumers = eventSpine().consumers();
+	for (int iI = 0; iI < (int)consumers.size() && iI < SPINE_PERF_MAX_CONSUMERS; iI++)
+	{
+		logPerf(1, "[PERF/phase] turn=%d owner=%d phase=%s consumer=%s ms=%.3f",
+			GC.getGame().getGameTurn(), iOwner, szPhase, typeid(*consumers[iI]).name(), s_adConsumerAccumMs[iI]);
+	}
 }
 
 // ===================== slice-1 first consumer: the BROAD logging consumer =====================
@@ -1093,11 +1120,11 @@ void emitCityCultureLevelRemoved(int iCity, int iOwner, int iLevel)
 	eventSpine().emit(e);
 }
 
-void emitCityOwnerAdded(int iCity, int iOwner)
+void emitCityOwnerAdded(int iCity, int iOwner, int iPlot)
 {
 	CvSpineEvent e(EVENTKIND_DOMAIN, SEVT_CITY_OWNER_ADDED, -1, 0, 0, iOwner, iCity);
 	e.iDomainTag = SD_SPINE;
-	e.addI(SPF_OWNER, iOwner).addI(SPF_CITY, iCity);
+	e.addI(SPF_OWNER, iOwner).addI(SPF_CITY, iCity).addI(SPF_PLOT, iPlot);
 	eventSpine().emit(e);
 }
 
@@ -2034,11 +2061,11 @@ void emitUnitEnteredCity(int iUnitType, int iUnitId, int iOwner, int iCity)
 	eventSpine().emit(e);   // synchronous render -> szTags still in scope
 }
 
-void emitUnitCreated(int iUnitType, int iUnitId, int iOwner)
+void emitUnitCreated(int iUnitType, int iUnitId, int iOwner, int iPlot)
 {
-	CvSpineEvent e(EVENTKIND_DOMAIN, SEVT_UNIT_CREATED, iUnitType, iUnitId, 0, iOwner, -1);
+	CvSpineEvent e(EVENTKIND_DOMAIN, SEVT_UNIT_CREATED, iUnitType, iUnitId, 0, iOwner, iPlot);
 	e.iDomainTag = SD_SPINE;
-	e.addI(SPF_UNIT, iUnitType).addI(SPF_OWNER, iOwner);
+	e.addI(SPF_UNIT, iUnitType).addI(SPF_OWNER, iOwner).addI(SPF_PLOT, iPlot);
 	eventSpine().emit(e);
 }
 

--- a/Sources/Spine/CvEventSpine.h
+++ b/Sources/Spine/CvEventSpine.h
@@ -914,7 +914,7 @@ void emitCityHeadquartersRemoved(int iCity, int iOwner, int iCorporation);
 void emitCityCultureLevelAdded(int iCity, int iOwner, int iLevel);
 void emitCityCultureLevelRemoved(int iCity, int iOwner, int iLevel);
 // The city's owner slot moved. REMOVED names the losing owner, ADDED the gaining one.
-void emitCityOwnerAdded(int iCity, int iOwner);
+void emitCityOwnerAdded(int iCity, int iOwner, int iPlot);
 void emitCityOwnerRemoved(int iCity, int iOwner);
 // Network MEMBERSHIP: the city's centre plot left one plot-group and joined another.
 void emitCityNetworkAdded(int iOwner, int iCity, int iPlotGroup);
@@ -1014,7 +1014,7 @@ void emitTeamMemberRemoved(int iTeam, int iCount);
 // ===== UNIT =====
 // A unit INSTANCE was created / died. Call KILLED from CvUnit::die and nowhere else: that function is the only
 // unconditional end of a unit's life. iPlot = -1 where the unit held none.
-void emitUnitCreated(int iUnitType, int iUnitId, int iOwner);
+void emitUnitCreated(int iUnitType, int iUnitId, int iOwner, int iPlot);
 void emitUnitKilled(int iUnitType, int iUnitId, int iOwner, int iPlot);
 // A resolved combat. Called from CvEventReporter::combatResult, BESIDE its Python callback -- the reporter's
 // arguments verbatim, so the spine sees exactly what Python sees and a later migration is a swap.
@@ -1132,6 +1132,7 @@ public:
 	void emit(const CvSpineEvent& kEvent);
 
 	bool anyInterest(EventKind eKind) const { return (m_iInterestMask & (1 << eKind)) != 0; }
+	const std::vector<IEventConsumer*>& consumers() const { return m_consumers; }
 
 private:
 	std::vector<IEventConsumer*> m_consumers;
@@ -1145,5 +1146,11 @@ CvEventSpine& eventSpine();
 //	is NOT a consumer (it reads the object-owned counts on demand, tally.md). Idempotent; call once
 //	(CvGame::doTurn guards it).
 void spineRegisterConsumers();
+
+// [PERF] per-consumer dispatch time, accumulated across every emit between a reset and a log. The log line names
+// each consumer by its type and its summed milliseconds, so a slow sweep is attributed to the consumer that
+// spent it rather than to the emit as a whole.
+void spinePerfConsumerAccumReset();
+void spinePerfConsumerAccumLog(const char* szPhase, int iOwner);
 
 #endif // CV_EVENT_SPINE_H

--- a/docs/specs/enabler/02-pass-1-generate-the-frontier-the.md
+++ b/docs/specs/enabler/02-pass-1-generate-the-frontier-the.md
@@ -187,6 +187,11 @@ via `enables` (the space line), doctrine bans via `disables` + empire modifiers.
 >   gate; the per-city half lives on the per-city consumers' own gates).
 > - ⚠ **An old save's per-city copies NORMALIZE at load:** the city read routes an `empireLevel` id to the
 >   owner — idempotent, so N city copies fold to held-once — and the city keeps nothing.
+> - ⛔ **A CHANGE IN A CITY HAS ZERO EFFECT ON THE EMPIRE'S HOLDINGS.** The city-side placement choke point
+>   routes only a PLACEMENT to the holder; a city-side REMOVAL of an empire-level id is a no-op, never a
+>   withdrawal at the player. ⚑ The failure this closes: a city's death swept every building info through its
+>   own removal path, so one barbarian city dying stripped the barbarian empire of its 268 empire-level holdings
+>   (and paid seven seconds of enabler fan doing it). A city tears down what IT holds, and it holds none of these.
 >
 > ⛔ **The per-city GRANT stays the model for everything else.** A wonder granting an ordinary constructible
 > building to every city (a Granary, Irrigation Canals) grants real per-city copies whose presence genuinely

--- a/docs/specs/tags.md
+++ b/docs/specs/tags.md
@@ -155,23 +155,23 @@ existed would have silently WIDENED every people-only transport into a troop car
 
 ### Criminal-type — `outlaw`
 
-Derived from the **criminal combat CLASS**, not a `DefaultUnitAI` role. A unit is criminal-type →
-tag **`outlaw`** iff its **primary `<Combat>` is `UNITCOMBAT_CRIMINAL`** *or* `UNITCOMBAT_CRIMINAL` appears in its
-**`<SubCombatTypes>`**. ⚑ That rule needs no special case: it is exactly "primary ∪ subs", which IS the union
-above, so `outlaw` is simply `UNITCOMBAT_CRIMINAL`'s authored tag like any other.
-
-This combat-class signal is **broader** than the old `UNITAI_INFILTRATOR` gate (which caught only **13**): it now
-covers **22** units, adding the ones INFILTRATOR missed — `OUTLAW` (primary `RUFFIAN` + subcombat `CRIMINAL`),
-`ASSASSIN`/`HASHISHIN` (primary `STRIKE_TEAM` + subcombat `CRIMINAL`), `CUTTHROAT`, `BEGGAR`, `BOSNEGERS`, `HAJDUK`,
-`HEZBOLLAH`, `KARAI_PYHARE` — alongside the original INFILTRATOR set (`biker_gang` · `burglar` · `exile` ·
-`gunfighter` · `hacker` · `mobster_car` · `robber` · `rogue` · `scoundrel` · `street_gang` · `technarchist` ·
-`thief` · `thug`). The full current set (22): `assassin` · `beggar` · `biker_gang` · `bosnegers` · `burglar` ·
-`cutthroat` · `exile` · `gunfighter` · `hacker` · `hajduk` · `hashishin` · `hezbollah` · `karai_pyhare` ·
-`mobster_car` · `outlaw` · `robber` · `rogue` · `scoundrel` · `street_gang` · `technarchist` · `thief` · `thug`.
+Derived from the **criminal combat CLASSES**, not a `DefaultUnitAI` role. The tag is authored on
+`UNITCOMBAT_CRIMINAL`, `UNITCOMBAT_EXILE`, `UNITCOMBAT_PIRATE` and `UNITCOMBAT_RUFFIAN`, and a unit is
+criminal-type iff one of those is its **primary `<Combat>`** or appears in its **`<SubCombatTypes>`**. ⚑ That
+rule needs no special case: it is exactly "primary ∪ subs", which IS the union above, so `outlaw` is simply
+those classes' authored tag like any other — the criminals proper, the exiles, the pirates and the ruffians
+(bandits, highwaymen, partisans, rebels) all read as one identity.
 
 > `hiddenNationality` is **not** the gate — it is a **skill** (mutable, promotion-grantable; e.g.
 > `PROMOTION_PROUD_PIRATE` grants it), see [skills.md](skills.md) §1. The criminal-type `outlaw` tag and the
 > hidden-nationality skill are independent: most outlaws carry the skill, but the tag is defined by the combat class.
+
+> **⛔ A CRIMINAL NEVER CAPTURES AN NPC CITY.** The capture gate in `CvUnit::setXY` refuses an `outlaw`-tagged
+> unit against a city owned by an NPC player, beside the hidden-nationality refusal that already stood there.
+> ⚑ The two tests are kept SEPARATE because they answer different questions: a hidden-nationality unit
+> captures FOR the barbarians, so taking a barbarian city for them is a no-op; an outlaw is refused on its
+> IDENTITY, whether or not it hides its nationality. An undefended barbarian city is therefore simply entered,
+> never taken.
 
 ## Open
 


### PR DESCRIPTION
Fixes #541.

## What was wrong
Units walked into an undefended barbarian city instead of taking it. Mapped on the reporter's save (turn 2190): a prey **Galapagos Penguin** with `blendIntoCity` stood in the city. The entry test (`canCoexistWithAttacker`) treats a blending unit as coexisting, so the units entered without a fight; the capture gate's `CvPlot::hasDefender` used the narrower `canUnitCoexistWithArrivingUnit`, counted the penguin as a defender, and skipped the capture. The city was uncapturable while the penguin sat there.

## Changes
- **Capture:** `hasDefender` uses the same coexistence predicate as entry. Capture verified live on the save.
- **Ruling: a criminal never captures an NPC city.** The `outlaw` tag gates capture beside the hidden-nationality refusal; `tags.md` records it and now lists the four criminal classes the tree actually authors (44 units, one without hidden nationality).
- **Ruling: a change in a city has zero effect on empire-level buildings.** `CvCity::kill` swept every building info through the city-side placement choke point, which routed each empire-level id to the owner's empire store with `false` — one barbarian city dying stripped the barbarian empire of its 268 empire-level holdings. `kill` walks the city's own held set; a city-side removal of an empire-level id is a no-op (`enabler.md` pass 1).
- **The 17-second capture.** Measured with new `[PERF/phase]` timers: 7 s was the empire-level strip; the rest was `BuildingEnabler::onCityBuildingChanged` fanning every capped building's count crossing to every city of every player regardless of the cap's scope. The fan is scoped to the cap kind (world → all, team → owner's team, empire → owner), per json.md §4.4.

| phase | before | after |
|---|--:|--:|
| old city kill, 498 building removals | 13,983 ms | 925 ms |
| re-applying 202 buildings to the new city | 3,024 ms | 476 ms |
| whole `acquireCity` | 17,184 ms | 1,466 ms |

- **Observability kept:** `unitCreated` / `cityOwnerAdded` facts carry the plot (creation and load reseed); `[PERF/phase]` timers on the acquire path, the kill blocks, the per-step and per-consumer split of a building flip (spine dispatch accounting), and the enabler's three re-gate legs.

## Observed / not observed
- Observed live: the capture landing, and every timing above, on the attached save.
- Not observed: `getWorstDefender` still carries the narrow coexistence predicate (same shape, untouched). Of the remaining 925 ms, 349 ms is the dying city re-gating its own capped category — spec-sanctioned for a live city, wasted on one being destroyed; skipping it on death needs an enabler bracket and is left open.
- For a tester: `Performance.log` lines `phase=player.acquireCity*` and `phase=city.kill.*` name every leg of a capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViP65jwg5DdEkHRrcJoCVR
